### PR TITLE
[feat] homepage UI 구현

### DIFF
--- a/src/layout/AppLayout.css.ts
+++ b/src/layout/AppLayout.css.ts
@@ -4,7 +4,7 @@ import { vars } from '@styles/global.css';
 
 export const container = style({
   display: 'flex',
-  backgroundColor: vars.color.gray100,
+  backgroundColor: vars.color.gray50,
   height: '100%',
 });
 

--- a/src/pages/home/HomePage.css.ts
+++ b/src/pages/home/HomePage.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
-export const page = style({
+export const container = style({
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s6,

--- a/src/pages/home/HomePage.css.ts
+++ b/src/pages/home/HomePage.css.ts
@@ -10,9 +10,16 @@ export const page = style({
   minHeight: '100%',
 });
 
+export const sectionCardBase = style({
+  border: `1px solid ${vars.color.gray100}`,
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+});
+
 export const contentGrid = style({
   display: 'grid',
   gridTemplateColumns: 'minmax(0, 1fr) 35rem',
+  alignItems: 'start',
   gap: vars.space.s4,
 });
 
@@ -20,4 +27,5 @@ export const sideColumn = style({
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s4,
+  minWidth: 0,
 });

--- a/src/pages/home/HomePage.css.ts
+++ b/src/pages/home/HomePage.css.ts
@@ -1,0 +1,23 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const page = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s6,
+  padding: '2.4rem',
+  minHeight: '100%',
+});
+
+export const contentGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) 35rem',
+  gap: vars.space.s4,
+});
+
+export const sideColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s4,
+});

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -80,7 +80,6 @@ const HomePage = () => {
               ...item,
               icon: item.iconKey === 'success' ? sectionIcons.success : undefined,
             }))}
-            sectionIcon={sectionIcons.status}
           />
         </div>
       </div>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,5 +1,91 @@
+import { useState } from 'react';
+
+import ActivityIcon from '@assets/icons/ic-activity.svg?react';
+import ArrowRightIcon from '@assets/icons/ic-arrow-right.svg?react';
+import CalendarIcon from '@assets/icons/ic-calendar.svg?react';
+import CheckCircleIcon from '@assets/icons/ic-check-circle.svg?react';
+import ClockIcon from '@assets/icons/ic-clock.svg?react';
+import UsersIcon from '@assets/icons/ic-multi-user.svg?react';
+import PlayIcon from '@assets/icons/ic-play.svg?react';
+import TrendDownIcon from '@assets/icons/ic-trenddown.svg?react';
+import TrendUpIcon from '@assets/icons/ic-trendup.svg?react';
+
+import HomeSummarySection from './components/HomeSummarySection/HomeSummarySection';
+import RecentTrainingSection from './components/RecentTrainingSection/RecentTrainingSection';
+import ScheduledTrainingSection from './components/ScheduledTrainingSection/ScheduledTrainingSection';
+import SystemStatusSection from './components/SystemStatusSection/SystemStatusSection';
+import { HOME_TRAINING_STATUS } from './constants/home';
+import * as styles from './HomePage.css';
+import {
+  homeMetrics,
+  initialTraining,
+  recentTrainingRecords,
+  systemStatusItems,
+} from './mocks/homeData';
+
+import type { HomeMetric } from './types/home';
+
+const metricIcons: Record<HomeMetric['iconKey'], JSX.Element> = {
+  activity: <ActivityIcon />,
+  clock: <ClockIcon />,
+  trend: <TrendUpIcon />,
+  user: <UsersIcon />,
+};
+
+const trendIcons: Record<HomeMetric['trendDirection'], JSX.Element> = {
+  up: <TrendUpIcon />,
+  down: <TrendDownIcon />,
+};
+
+const sectionIcons = {
+  calendar: <CalendarIcon />,
+  action: <ArrowRightIcon />,
+  play: <PlayIcon />,
+  success: <CheckCircleIcon />,
+};
+
 const HomePage = () => {
-  return <>홈페이지</>;
+  const [training, setTraining] = useState(initialTraining);
+
+  const handleTrainingStart = () => {
+    setTraining((current) =>
+      current.status === HOME_TRAINING_STATUS.IN_PROGRESS
+        ? current
+        : { ...current, status: HOME_TRAINING_STATUS.IN_PROGRESS },
+    );
+  };
+
+  return (
+    <div className={styles.page}>
+      <HomeSummarySection
+        metrics={homeMetrics.map((metric) => ({
+          ...metric,
+          icon: metricIcons[metric.iconKey],
+          trendIcon: trendIcons[metric.trendDirection],
+        }))}
+      />
+
+      <div className={styles.contentGrid}>
+        <RecentTrainingSection records={recentTrainingRecords} actionIcon={sectionIcons.action} />
+
+        <div className={styles.sideColumn}>
+          <ScheduledTrainingSection
+            training={training}
+            onStart={handleTrainingStart}
+            sectionIcon={sectionIcons.calendar}
+            actionIcon={sectionIcons.play}
+          />
+          <SystemStatusSection
+            items={systemStatusItems.map((item) => ({
+              ...item,
+              icon: item.iconKey === 'success' ? sectionIcons.success : undefined,
+            }))}
+            sectionIcon={sectionIcons.status}
+          />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default HomePage;

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -56,7 +56,7 @@ const HomePage = () => {
   };
 
   return (
-    <div className={styles.page}>
+    <div className={styles.container}>
       <HomeSummarySection
         metrics={homeMetrics.map((metric) => ({
           ...metric,

--- a/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
+++ b/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
@@ -7,7 +7,7 @@ import { sectionCardBase } from '../../HomePage.css';
 const summaryCardBase = style([
   sectionCardBase,
   {
-    borderRadius: '1.2rem',
+    borderRadius: vars.radius.lg,
   },
 ]);
 
@@ -95,7 +95,7 @@ export const metricValueRow = style({
 
 export const metricValue = style({
   color: vars.color.gray900,
-  ...vars.typography.title_b_28,
+  ...vars.typography.titleBold28,
 });
 
 export const metricSuffix = style({

--- a/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
+++ b/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
@@ -2,12 +2,14 @@ import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
-const summaryCardBase = style({
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: '1.2rem',
-  boxShadow: vars.shadow.card,
-  backgroundColor: vars.color.white,
-});
+import { sectionCardBase } from '../../HomePage.css';
+
+const summaryCardBase = style([
+  sectionCardBase,
+  {
+    borderRadius: '1.2rem',
+  },
+]);
 
 export const summaryGrid = style({
   display: 'grid',

--- a/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
+++ b/src/pages/home/components/HomeSummarySection/HomeSummarySection.css.ts
@@ -1,0 +1,107 @@
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+const summaryCardBase = style({
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: '1.2rem',
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+});
+
+export const summaryGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+  gap: vars.space.s4,
+});
+
+export const metricCard = style([
+  summaryCardBase,
+  {
+    padding: '2.1rem',
+    minHeight: '15.9rem',
+  },
+]);
+
+export const metricHeader = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  marginBottom: '1.4rem',
+});
+
+export const metricIcon = styleVariants({
+  blue: {
+    backgroundColor: vars.color.primaryLight2,
+    color: vars.color.primary,
+  },
+  yellow: {
+    backgroundColor: vars.color.warningLight,
+    color: vars.color.warning,
+  },
+  green: {
+    backgroundColor: vars.color.successLight,
+    color: vars.color.success,
+  },
+  purple: {
+    backgroundColor: vars.color.purpleLight,
+    color: vars.color.purple,
+  },
+});
+
+export const metricIconBase = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '1rem',
+  width: '4rem',
+  height: '4rem',
+});
+
+globalStyle(`${metricIconBase} svg`, {
+  width: '2rem',
+  height: '2rem',
+});
+
+export const metricTrend = styleVariants({
+  positive: {
+    color: vars.color.success,
+  },
+  negative: {
+    color: vars.color.danger,
+  },
+});
+
+export const metricTrendBase = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s1,
+  ...vars.typography.captionBold,
+});
+
+globalStyle(`${metricTrendBase} svg`, {
+  width: '1.2rem',
+  height: '1.2rem',
+});
+
+export const metricValueRow = style({
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '0.2rem',
+  marginBottom: vars.space.s1,
+});
+
+export const metricValue = style({
+  color: vars.color.gray900,
+  ...vars.typography.title_b_28,
+});
+
+export const metricSuffix = style({
+  color: vars.color.gray700,
+  ...vars.typography.body14,
+});
+
+export const metricTitle = style({
+  color: vars.color.textMid,
+  ...vars.typography.body14,
+});

--- a/src/pages/home/components/HomeSummarySection/HomeSummarySection.tsx
+++ b/src/pages/home/components/HomeSummarySection/HomeSummarySection.tsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx';
+
+import * as styles from './HomeSummarySection.css';
+
+import type { HomeMetric } from '../../types/home';
+
+type HomeSummarySectionProps = {
+  metrics: HomeMetric[];
+};
+
+const HomeSummarySection = ({ metrics }: HomeSummarySectionProps) => (
+  <section className={styles.summaryGrid} aria-label="홈 요약 지표">
+    {metrics.map((metric) => (
+      <article key={metric.id} className={styles.metricCard}>
+        <div className={styles.metricHeader}>
+          <span className={clsx(styles.metricIconBase, styles.metricIcon[metric.iconTone])}>
+            {metric.icon}
+          </span>
+          <span className={clsx(styles.metricTrendBase, styles.metricTrend[metric.trendTone])}>
+            {metric.trendIcon}
+            {metric.trend}
+          </span>
+        </div>
+
+        <div className={styles.metricValueRow}>
+          <strong className={styles.metricValue}>{metric.value}</strong>
+          {metric.valueSuffix ? (
+            <span className={styles.metricSuffix}>{metric.valueSuffix}</span>
+          ) : null}
+        </div>
+        <p className={styles.metricTitle}>{metric.title}</p>
+      </article>
+    ))}
+  </section>
+);
+
+export default HomeSummarySection;

--- a/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.css.ts
+++ b/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.css.ts
@@ -1,0 +1,94 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '@styles/global.css';
+
+export const recordsSection = style({
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: '2rem',
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+  padding: 0,
+  minHeight: '69rem',
+  overflow: 'hidden',
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '2rem 2.4rem',
+});
+
+export const sectionTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.titleBold,
+});
+
+export const headerAction = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s1,
+  color: vars.color.primary,
+  ...vars.typography.body14Medium,
+});
+
+export const headerActionButton = style([
+  headerAction,
+  {
+    border: 'none',
+    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+    padding: 0,
+    height: 'auto',
+    minHeight: 'auto',
+    selectors: {
+      '&&:hover:not(:disabled)': {
+        border: 'none',
+        borderColor: 'transparent',
+        backgroundColor: 'transparent',
+        color: vars.color.primaryHover,
+      },
+    },
+  },
+]);
+
+export const recordsTable = style({
+  width: '100%',
+  tableLayout: 'fixed',
+  borderCollapse: 'collapse',
+});
+
+export const tableHeadCell = style({
+  borderTop: `1px solid ${vars.color.gray100}`,
+  borderBottom: `1px solid ${vars.color.gray100}`,
+  backgroundColor: vars.color.gray25,
+  padding: '1.2rem 2rem',
+  color: vars.color.textMid,
+  ...vars.typography.captionBold,
+});
+
+export const tableCell = recipe({
+  base: {
+    borderBottom: `1px solid ${vars.color.gray100}`,
+    padding: '1.7rem 2rem',
+    textAlign: 'center',
+    ...vars.typography.body14,
+    color: vars.color.textHigh,
+  },
+  variants: {
+    tone: {
+      default: {},
+      emphasis: {
+        color: vars.color.textHigh,
+        fontWeight: vars.fontWeight.bold,
+      },
+      date: {
+        color: vars.color.textMid,
+      },
+    },
+  },
+  defaultVariants: {
+    tone: 'default',
+  },
+});

--- a/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.css.ts
+++ b/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.css.ts
@@ -3,15 +3,18 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '@styles/global.css';
 
-export const recordsSection = style({
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: '2rem',
-  boxShadow: vars.shadow.card,
-  backgroundColor: vars.color.white,
-  padding: 0,
-  minHeight: '69rem',
-  overflow: 'hidden',
-});
+import { sectionCardBase } from '../../HomePage.css';
+
+export const recordsSection = style([
+  sectionCardBase,
+  {
+    borderRadius: '2rem',
+    padding: 0,
+    minWidth: 0,
+    minHeight: '69rem',
+    overflow: 'hidden',
+  },
+]);
 
 export const sectionHeader = style({
   display: 'flex',

--- a/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.tsx
+++ b/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+
+import { Button } from '@components/Button';
+import StatusBadge from '@components/chip/StatusBadge';
+
+import * as styles from './RecentTrainingSection.css';
+import { HOME_GRADE_BADGE_COLOR, HOME_RECENT_TRAINING_TABLE_HEADERS } from '../../constants/home';
+
+import type { TrainingRecord } from '../../types/home';
+
+type RecentTrainingSectionProps = {
+  records: TrainingRecord[];
+  actionIcon: ReactNode;
+};
+
+const RecentTrainingSection = ({ records, actionIcon }: RecentTrainingSectionProps) => (
+  <section className={styles.recordsSection}>
+    <div className={styles.sectionHeader}>
+      <h2 className={styles.sectionTitle}>최근 훈련 기록</h2>
+
+      <Button
+        type="button"
+        variant="outlined"
+        size="sm"
+        rightIcon={actionIcon}
+        className={styles.headerActionButton}
+      >
+        전체 보기
+      </Button>
+    </div>
+
+    <table className={styles.recordsTable}>
+      <thead>
+        <tr>
+          {HOME_RECENT_TRAINING_TABLE_HEADERS.map((header) => (
+            <th key={header} className={styles.tableHeadCell}>
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {records.map((record) => (
+          <tr key={record.id}>
+            <td className={styles.tableCell({ tone: 'emphasis' })}>{record.name}</td>
+            <td className={styles.tableCell({ tone: 'date' })}>{record.date}</td>
+            <td className={styles.tableCell()}>{record.participants}</td>
+            <td className={styles.tableCell({ tone: 'emphasis' })}>{record.evacuationTime}</td>
+            <td className={styles.tableCell()}>{record.survivalRate}</td>
+            <td className={styles.tableCell()}>
+              <StatusBadge
+                label={record.grade}
+                color={
+                  HOME_GRADE_BADGE_COLOR[record.grade as keyof typeof HOME_GRADE_BADGE_COLOR] ??
+                  'neutral'
+                }
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </section>
+);
+
+export default RecentTrainingSection;

--- a/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.tsx
+++ b/src/pages/home/components/RecentTrainingSection/RecentTrainingSection.tsx
@@ -50,10 +50,7 @@ const RecentTrainingSection = ({ records, actionIcon }: RecentTrainingSectionPro
             <td className={styles.tableCell()}>
               <StatusBadge
                 label={record.grade}
-                color={
-                  HOME_GRADE_BADGE_COLOR[record.grade as keyof typeof HOME_GRADE_BADGE_COLOR] ??
-                  'neutral'
-                }
+                color={HOME_GRADE_BADGE_COLOR[record.grade] ?? 'neutral'}
               />
             </td>
           </tr>

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -1,0 +1,84 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const scheduledCard = style({
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: '2rem',
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+  padding: '2rem',
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const sectionTitleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
+export const titleIcon = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  width: '2rem',
+  height: '2rem',
+  color: vars.color.primary,
+});
+
+export const sectionTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.titleBold,
+});
+
+export const scheduleInfoPanel = style({
+  marginTop: '1.8rem',
+  borderRadius: '1.8rem',
+  backgroundColor: vars.color.primaryLight2,
+  padding: '1.8rem',
+});
+
+export const subtleLabel = style({
+  color: vars.color.primary,
+  ...vars.typography.body14Medium,
+});
+
+export const schedulePlace = style({
+  marginTop: vars.space.s1,
+  color: vars.color.textHigh,
+  ...vars.typography.h4,
+});
+
+export const scheduleMetaGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  gap: '1.8rem',
+  marginTop: '1.2rem',
+});
+
+export const scheduleMetaItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.4rem',
+});
+
+export const metaLabel = style({
+  color: vars.color.textLow,
+  ...vars.typography.body14,
+});
+
+export const metaValue = style({
+  lineHeight: '1.4',
+  letterSpacing: '-0.03em',
+  color: vars.color.gray900,
+  fontSize: '1.6rem',
+  fontWeight: vars.fontWeight.bold,
+});
+
+export const scheduleButton = style({
+  marginTop: vars.space.s4,
+});

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
@@ -24,6 +24,7 @@ export const sectionTitleRow = style({
 
 export const titleIcon = style({
   display: 'inline-flex',
+  flexShrink: 0,
   alignItems: 'center',
   width: '2rem',
   height: '2rem',
@@ -32,7 +33,7 @@ export const titleIcon = style({
 
 export const sectionTitle = style({
   color: vars.color.textHigh,
-  ...vars.typography.titleBold,
+  ...vars.typography.body14_bold,
 });
 
 export const scheduleInfoPanel = style({

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -8,6 +8,7 @@ export const scheduledCard = style({
   boxShadow: vars.shadow.card,
   backgroundColor: vars.color.white,
   padding: '2rem',
+  minWidth: '36rem',
 });
 
 export const sectionHeader = style({

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -37,7 +37,7 @@ export const titleIcon = style({
 
 export const sectionTitle = style({
   color: vars.color.textHigh,
-  ...vars.typography.body14_bold,
+  ...vars.typography.body14Bold,
 });
 
 export const scheduleInfoPanel = style({

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -2,14 +2,17 @@ import { style } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
-export const scheduledCard = style({
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: '2rem',
-  boxShadow: vars.shadow.card,
-  backgroundColor: vars.color.white,
-  padding: '2rem',
-  minWidth: '36rem',
-});
+import { sectionCardBase } from '../../HomePage.css';
+
+export const scheduledCard = style([
+  sectionCardBase,
+  {
+    borderRadius: '2rem',
+    padding: '2rem',
+    width: '100%',
+    minWidth: 0,
+  },
+]);
 
 export const sectionHeader = style({
   display: 'flex',

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.css.ts
@@ -77,11 +77,8 @@ export const metaLabel = style({
 });
 
 export const metaValue = style({
-  lineHeight: '1.4',
-  letterSpacing: '-0.03em',
-  color: vars.color.gray900,
-  fontSize: '1.6rem',
-  fontWeight: vars.fontWeight.bold,
+  color: vars.color.textHigh,
+  ...vars.typography.caption13Bold,
 });
 
 export const scheduleButton = style({

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
@@ -10,7 +10,7 @@ import type { ScheduledTraining } from '../../types/home';
 type ScheduledTrainingSectionProps = {
   training: ScheduledTraining;
   onStart: () => void;
-  sectionIcon: ReactNode;
+  sectionIcon?: ReactNode;
   actionIcon: ReactNode;
 };
 
@@ -27,7 +27,7 @@ const ScheduledTrainingSection = ({
     <section className={styles.scheduledCard}>
       <div className={styles.sectionHeader}>
         <div className={styles.sectionTitleRow}>
-          <span className={styles.titleIcon}>{sectionIcon}</span>
+          {sectionIcon ? <span className={styles.titleIcon}>{sectionIcon}</span> : null}
           <h2 className={styles.sectionTitle}>{sectionTitle}</h2>
         </div>
       </div>

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from 'react';
+
+import { Button } from '@components/Button';
+
+import * as styles from './ScheduledTrainingSection.css';
+import { HOME_TRAINING_STATUS } from '../../constants/home';
+
+import type { ScheduledTraining } from '../../types/home';
+
+type ScheduledTrainingSectionProps = {
+  training: ScheduledTraining;
+  onStart: () => void;
+  sectionIcon: ReactNode;
+  actionIcon: ReactNode;
+};
+
+const ScheduledTrainingSection = ({
+  training,
+  onStart,
+  sectionIcon,
+  actionIcon,
+}: ScheduledTrainingSectionProps) => {
+  const isInProgress = training.status === HOME_TRAINING_STATUS.IN_PROGRESS;
+  const sectionTitle = isInProgress ? '훈련 진행 중' : '예정된 훈련';
+
+  return (
+    <section className={styles.scheduledCard}>
+      <div className={styles.sectionHeader}>
+        <div className={styles.sectionTitleRow}>
+          <span className={styles.titleIcon}>{sectionIcon}</span>
+          <h2 className={styles.sectionTitle}>{sectionTitle}</h2>
+        </div>
+      </div>
+
+      <div className={styles.scheduleInfoPanel}>
+        <p className={styles.subtleLabel}>건물 · 위치</p>
+        <p className={styles.schedulePlace}>
+          {training.building} · {training.floor}
+        </p>
+
+        <div className={styles.scheduleMetaGrid}>
+          <div className={styles.scheduleMetaItem}>
+            <span className={styles.metaLabel}>날짜</span>
+            <span className={styles.metaValue}>{training.date}</span>
+          </div>
+          <div className={styles.scheduleMetaItem}>
+            <span className={styles.metaLabel}>시간</span>
+            <span className={styles.metaValue}>{training.time}</span>
+          </div>
+          <div className={styles.scheduleMetaItem}>
+            <span className={styles.metaLabel}>참가</span>
+            <span className={styles.metaValue}>{training.participants}</span>
+          </div>
+        </div>
+      </div>
+
+      <Button
+        size="lg"
+        fullWidth
+        className={styles.scheduleButton}
+        leftIcon={actionIcon}
+        onClick={onStart}
+        disabled={isInProgress}
+      >
+        {isInProgress ? '훈련 중' : '훈련 시작'}
+      </Button>
+    </section>
+  );
+};
+
+export default ScheduledTrainingSection;

--- a/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
+++ b/src/pages/home/components/ScheduledTrainingSection/ScheduledTrainingSection.tsx
@@ -55,6 +55,7 @@ const ScheduledTrainingSection = ({
       </div>
 
       <Button
+        type="button"
         size="lg"
         fullWidth
         className={styles.scheduleButton}

--- a/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
+++ b/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
@@ -2,14 +2,17 @@ import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
-export const systemCard = style({
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: '2rem',
-  boxShadow: vars.shadow.card,
-  backgroundColor: vars.color.white,
-  padding: '2rem',
-  minWidth: '36rem',
-});
+import { sectionCardBase } from '../../HomePage.css';
+
+export const systemCard = style([
+  sectionCardBase,
+  {
+    borderRadius: '2rem',
+    padding: '2rem',
+    width: '100%',
+    minWidth: 0,
+  },
+]);
 
 export const sectionHeader = style({
   display: 'flex',

--- a/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
+++ b/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
@@ -1,0 +1,69 @@
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const systemCard = style({
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: '2rem',
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+  padding: '2rem',
+  minWidth: '36rem',
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const sectionTitleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
+export const sectionTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.body14_bold,
+});
+
+export const systemList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.6rem',
+  marginTop: '1.6rem',
+});
+
+export const systemRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s4,
+});
+
+export const systemLabel = style({
+  color: vars.color.textMid,
+  ...vars.typography.body14,
+});
+
+export const systemValue = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s1,
+  ...vars.typography.body14Medium,
+});
+
+export const systemValueTone = styleVariants({
+  neutral: { color: vars.color.textMid },
+  blue: { color: vars.color.infoText },
+  green: { color: vars.color.success },
+  yellow: { color: vars.color.warning },
+  red: { color: vars.color.danger },
+  purple: { color: vars.color.purpleText },
+});
+
+globalStyle(`${systemValue} svg`, {
+  width: '1.4rem',
+  height: '1.4rem',
+});

--- a/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
+++ b/src/pages/home/components/SystemStatusSection/SystemStatusSection.css.ts
@@ -28,7 +28,7 @@ export const sectionTitleRow = style({
 
 export const sectionTitle = style({
   color: vars.color.textHigh,
-  ...vars.typography.body14_bold,
+  ...vars.typography.body14Bold,
 });
 
 export const systemList = style({

--- a/src/pages/home/components/SystemStatusSection/SystemStatusSection.tsx
+++ b/src/pages/home/components/SystemStatusSection/SystemStatusSection.tsx
@@ -1,0 +1,41 @@
+import StatusBadge from '@components/chip/StatusBadge';
+
+import * as styles from './SystemStatusSection.css';
+
+import type { SystemStatusItem } from '../../types/home';
+
+type SystemStatusSectionProps = {
+  items: SystemStatusItem[];
+};
+
+const SystemStatusSection = ({ items }: SystemStatusSectionProps) => {
+  const [summary, ...details] = items;
+
+  return (
+    <section className={styles.systemCard}>
+      <div className={styles.sectionHeader}>
+        <div className={styles.sectionTitleRow}>
+          <h2 className={styles.sectionTitle}>시스템 상태</h2>
+        </div>
+
+        {summary ? (
+          <StatusBadge label={summary.label} color={summary.tone} dot={summary.dot} />
+        ) : null}
+      </div>
+
+      <div className={styles.systemList}>
+        {details.map((item) => (
+          <div key={item.id} className={styles.systemRow}>
+            <span className={styles.systemLabel}>{item.label}</span>
+            <span className={`${styles.systemValue} ${styles.systemValueTone[item.tone]}`}>
+              {item.icon}
+              {item.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default SystemStatusSection;

--- a/src/pages/home/constants/home.ts
+++ b/src/pages/home/constants/home.ts
@@ -1,0 +1,12 @@
+export const HOME_TRAINING_STATUS = {
+  SCHEDULED: 'scheduled',
+  IN_PROGRESS: 'inProgress',
+} as const;
+
+export const HOME_GRADE_BADGE_COLOR = {
+  'A+': 'green',
+  A: 'green',
+  'B+': 'blue',
+  B: 'blue',
+  C: 'yellow',
+} as const;

--- a/src/pages/home/constants/home.ts
+++ b/src/pages/home/constants/home.ts
@@ -10,3 +10,12 @@ export const HOME_GRADE_BADGE_COLOR = {
   B: 'blue',
   C: 'yellow',
 } as const;
+
+export const HOME_RECENT_TRAINING_TABLE_HEADERS = [
+  '훈련명',
+  '날짜',
+  '참가',
+  '대피시간',
+  '생존율',
+  '등급',
+] as const;

--- a/src/pages/home/mocks/homeData.ts
+++ b/src/pages/home/mocks/homeData.ts
@@ -1,0 +1,117 @@
+import { HOME_TRAINING_STATUS } from '../constants/home';
+
+import type {
+  HomeMetric,
+  ScheduledTraining,
+  SystemStatusItem,
+  TrainingRecord,
+} from '../types/home';
+
+export const homeMetrics: HomeMetric[] = [
+  {
+    id: 'sessions',
+    title: '총 훈련 세션',
+    value: '247',
+    trend: '+12%',
+    trendTone: 'positive',
+    iconTone: 'blue',
+    iconKey: 'activity',
+    trendDirection: 'up',
+  },
+  {
+    id: 'response-time',
+    title: '평균 대피 시간',
+    value: '3:42',
+    valueSuffix: '분',
+    trend: '-8s',
+    trendTone: 'negative',
+    iconTone: 'yellow',
+    iconKey: 'clock',
+    trendDirection: 'down',
+  },
+  {
+    id: 'survival-rate',
+    title: '평균 생존율',
+    value: '94.7',
+    valueSuffix: '%',
+    trend: '+2.1%',
+    trendTone: 'positive',
+    iconTone: 'green',
+    iconKey: 'trend',
+    trendDirection: 'up',
+  },
+  {
+    id: 'participants',
+    title: '총 참가 인원',
+    value: '1,842',
+    trend: '+208',
+    trendTone: 'positive',
+    iconTone: 'purple',
+    iconKey: 'user',
+    trendDirection: 'up',
+  },
+];
+
+export const recentTrainingRecords: TrainingRecord[] = [
+  {
+    id: 1,
+    name: 'A동 · 3층',
+    date: '2026-04-14',
+    participants: '45명',
+    evacuationTime: '3:15',
+    survivalRate: '96.2%',
+    grade: 'A',
+  },
+  {
+    id: 2,
+    name: 'B동 · 2층',
+    date: '2026-04-13',
+    participants: '32명',
+    evacuationTime: '4:02',
+    survivalRate: '91.5%',
+    grade: 'B+',
+  },
+  {
+    id: 3,
+    name: 'C동 · 1층',
+    date: '2026-04-12',
+    participants: '58명',
+    evacuationTime: '2:58',
+    survivalRate: '98.1%',
+    grade: 'A+',
+  },
+  {
+    id: 4,
+    name: 'A동 · 5층',
+    date: '2026-04-11',
+    participants: '41명',
+    evacuationTime: '3:44',
+    survivalRate: '89.7%',
+    grade: 'B',
+  },
+  {
+    id: 5,
+    name: 'D동 · 4층',
+    date: '2026-04-10',
+    participants: '37명',
+    evacuationTime: '3:21',
+    survivalRate: '93.4%',
+    grade: 'A',
+  },
+];
+
+export const initialTraining: ScheduledTraining = {
+  building: 'B동',
+  floor: '4층',
+  date: '2026.04.15',
+  time: '10:00',
+  participants: '52명',
+  status: HOME_TRAINING_STATUS.SCHEDULED,
+};
+
+export const systemStatusItems: SystemStatusItem[] = [
+  { id: 'overall', label: '정상', tone: 'green', dot: true },
+  { id: 'cctv', label: 'CCTV', value: '30/30', tone: 'green' },
+  { id: 'iot', label: 'IoT 유도등', value: '58/60', tone: 'yellow' },
+  { id: 'ai', label: 'AI 분석 엔진', value: '정상', tone: 'green', iconKey: 'success' },
+];

--- a/src/pages/home/mocks/homeData.ts
+++ b/src/pages/home/mocks/homeData.ts
@@ -103,7 +103,7 @@ export const recentTrainingRecords: TrainingRecord[] = [
 export const initialTraining: ScheduledTraining = {
   building: 'B동',
   floor: '4층',
-  date: '2026.04.15',
+  date: '2026-04-15',
   time: '10:00',
   participants: '52명',
   status: HOME_TRAINING_STATUS.SCHEDULED,

--- a/src/pages/home/types/home.ts
+++ b/src/pages/home/types/home.ts
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 
 import type { StatusBadgeColor } from '@components/chip/StatusBadge';
 
-import type { HOME_TRAINING_STATUS } from '../constants/home';
+import type { HOME_GRADE_BADGE_COLOR, HOME_TRAINING_STATUS } from '../constants/home';
 
 export type MetricIconTone = 'blue' | 'yellow' | 'green' | 'purple';
 export type TrendTone = 'positive' | 'negative';
@@ -30,7 +30,7 @@ export type TrainingRecord = {
   participants: string;
   evacuationTime: string;
   survivalRate: string;
-  grade: string;
+  grade: keyof typeof HOME_GRADE_BADGE_COLOR;
 };
 
 export type TrainingStatus = (typeof HOME_TRAINING_STATUS)[keyof typeof HOME_TRAINING_STATUS];

--- a/src/pages/home/types/home.ts
+++ b/src/pages/home/types/home.ts
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+
+import type { StatusBadgeColor } from '@components/chip/StatusBadge';
+
+import type { HOME_TRAINING_STATUS } from '../constants/home';
+
+export type MetricIconTone = 'blue' | 'yellow' | 'green' | 'purple';
+export type TrendTone = 'positive' | 'negative';
+export type MetricIconKey = 'activity' | 'clock' | 'trend' | 'user';
+export type TrendDirection = 'up' | 'down';
+
+export type HomeMetric = {
+  id: string;
+  title: string;
+  value: string;
+  valueSuffix?: string;
+  trend: string;
+  trendTone: TrendTone;
+  iconTone: MetricIconTone;
+  iconKey: MetricIconKey;
+  trendDirection: TrendDirection;
+  icon?: ReactNode;
+  trendIcon?: ReactNode;
+};
+
+export type TrainingRecord = {
+  id: number;
+  name: string;
+  date: string;
+  participants: string;
+  evacuationTime: string;
+  survivalRate: string;
+  grade: string;
+};
+
+export type TrainingStatus = (typeof HOME_TRAINING_STATUS)[keyof typeof HOME_TRAINING_STATUS];
+
+export type ScheduledTraining = {
+  building: string;
+  floor: string;
+  date: string;
+  time: string;
+  participants: string;
+  status: TrainingStatus;
+};
+
+export type SystemStatusItem = {
+  id: string;
+  label: string;
+  value?: string;
+  tone: StatusBadgeColor;
+  dot?: boolean;
+  iconKey?: 'success';
+  icon?: ReactNode;
+};

--- a/src/shared/assets/icons/ic-multi-user.svg
+++ b/src/shared/assets/icons/ic-multi-user.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.50016 9.58333C9.11099 9.58333 10.4168 8.2775 10.4168 6.66667C10.4168 5.05584 9.11099 3.75 7.50016 3.75C5.88933 3.75 4.5835 5.05584 4.5835 6.66667C4.5835 8.2775 5.88933 9.58333 7.50016 9.58333Z" stroke="#8B5CF6" stroke-width="1.41667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.6665 16.6667C1.6665 14.1667 4.1665 12.5 7.49984 12.5C10.8332 12.5 13.3332 14.1667 13.3332 16.6667" stroke="#8B5CF6" stroke-width="1.41667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.1668 9.58332C15.3174 9.58332 16.2502 8.65058 16.2502 7.49999C16.2502 6.3494 15.3174 5.41666 14.1668 5.41666C13.0162 5.41666 12.0835 6.3494 12.0835 7.49999C12.0835 8.65058 13.0162 9.58332 14.1668 9.58332Z" stroke="#8B5CF6" stroke-width="1.41667" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.3332 15.8333C18.3332 14.1667 16.6665 13.3333 14.1665 13.3333" stroke="#8B5CF6" stroke-width="1.41667" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -125,6 +125,13 @@ export const vars = createGlobalTheme(':root', {
       letterSpacing: '-0.02em',
       lineHeight: '1.5',
     },
+    caption13Bold: {
+      fontFamily: baseFontFamily,
+      fontSize: '1.3rem',
+      fontWeight: '700',
+      letterSpacing: '-0.012rem',
+      lineHeight: '1.68rem',
+    },
     h1: {
       fontFamily: baseFontFamily,
       fontSize: '4.8rem',

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -76,7 +76,7 @@ export const vars = createGlobalTheme(':root', {
     s12: '4.8rem',
   },
   typography: {
-    body14_bold: {
+    body14Bold: {
       fontFamily: baseFontFamily,
       fontSize: '1.4rem',
       fontWeight: '700',
@@ -167,7 +167,7 @@ export const vars = createGlobalTheme(':root', {
       letterSpacing: '-0.03em',
       lineHeight: '1.4',
     },
-    title_b_28: {
+    titleBold28: {
       fontFamily: baseFontFamily,
       fontSize: '2.8rem',
       fontWeight: '700',

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -153,6 +153,13 @@ export const vars = createGlobalTheme(':root', {
       letterSpacing: '-0.03em',
       lineHeight: '1.4',
     },
+    title_b_28: {
+      fontFamily: baseFontFamily,
+      fontSize: '2.8rem',
+      fontWeight: '700',
+      letterSpacing: '-0.02em',
+      lineHeight: '1.4',
+    },
   },
 });
 

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -76,6 +76,13 @@ export const vars = createGlobalTheme(':root', {
     s12: '4.8rem',
   },
   typography: {
+    body14_bold: {
+      fontFamily: baseFontFamily,
+      fontSize: '1.4rem',
+      fontWeight: '700',
+      letterSpacing: '-0.02em',
+      lineHeight: '1.5',
+    },
     body14: {
       fontFamily: baseFontFamily,
       fontSize: '1.4rem',


### PR DESCRIPTION
## 📌 Summary
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성 -->
homePage 뷰를 구현했습니다. (목데이터 이용)

## 🔗 관련 이슈

closes #19 

## 📋 작업 내용
홈 화면의 전체 레이아웃을 구성하고, 상단 요약 카드와 메인 섹션들을 퍼블리싱했습니다. 구현 과정에서 홈 화면 전용 컴포넌트, constants, types, mocks를 분리해 구조를 정리했고, 섹션 카드 스타일도 홈 범위 안에서 공통화해 이후 수정이 조금 더 쉽도록 맞췄습니다.

- 최근 훈련 기록 영역은 테이블 형태로 정리
- 등급 뱃지와 액션 버튼을 포함하도록 구현
- 예정된 훈련 영역은 훈련 정보와 상태 변화를 바로 확인할 수 있도록 구성 ('훈련 시작' 버튼 클릭시 '훈련 중'으로 텍스트 변경)



## 🔍 To Reviewer

<!-- 리뷰어에게 요청하는 내용 -->

## 📸 스크린샷
<img width="1512" height="749" alt="스크린샷 2026-06-12 오전 12 43 50" src="https://github.com/user-attachments/assets/c0495cf9-55e2-4897-849c-7b69c49f7419" />

https://github.com/user-attachments/assets/10ec834a-9676-4f19-a496-dfda0e7d4791


<!-- UI 변경 시 첨부 -->


## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
