### PR TITLE
[feat] 공통 컴포넌트 - Toast

### DIFF
--- a/src/shared/components/toast/Toast.css.ts
+++ b/src/shared/components/toast/Toast.css.ts
@@ -1,0 +1,185 @@
+import { keyframes } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '@styles/global.css';
+
+const slideIn = keyframes({
+  from: { transform: 'translateX(110%)', opacity: 0 },
+  to: { transform: 'translateX(0)', opacity: 1 },
+});
+
+const slideOut = keyframes({
+  from: { transform: 'translateX(0)', opacity: 1 },
+  to: { transform: 'translateX(110%)', opacity: 0 },
+});
+
+const progressShrink = keyframes({
+  from: { width: '100%' },
+  to: { width: '0%' },
+});
+
+export const container = recipe({
+  base: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: vars.space.s3,
+    border: '1px solid',
+    borderRadius: vars.radius.xl,
+    boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+    padding: `${vars.space.s4} ${vars.space.s4} ${vars.space.s6} ${vars.space.s4}`,
+    width: '34rem',
+    overflow: 'hidden',
+    animationFillMode: 'forwards',
+  },
+  variants: {
+    variant: {
+      default: {
+        borderColor: vars.color.gray100,
+        backgroundColor: vars.color.white,
+      },
+      success: {
+        borderColor: vars.color.success,
+        backgroundColor: vars.color.successLight,
+      },
+      warning: {
+        borderColor: vars.color.warning,
+        backgroundColor: vars.color.warningLight,
+      },
+      error: {
+        borderColor: vars.color.danger,
+        backgroundColor: vars.color.dangerLight,
+      },
+    },
+    leaving: {
+      true: {
+        animationName: slideOut,
+        animationDuration: '280ms',
+        animationTimingFunction: 'ease-in',
+      },
+      false: {
+        animationName: slideIn,
+        animationDuration: '320ms',
+        animationTimingFunction: 'cubic-bezier(0.16, 1, 0.3, 1)',
+      },
+    },
+  },
+  defaultVariants: { variant: 'default', leaving: false },
+});
+
+export const iconWrapper = recipe({
+  base: {
+    flexShrink: 0,
+    marginTop: '0.1rem',
+    width: '2.4rem',
+    height: '2.4rem',
+  },
+  variants: {
+    variant: {
+      default: { color: vars.color.gray500 },
+      success: { color: vars.color.success },
+      warning: { color: vars.color.warning },
+      error: { color: vars.color.danger },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+export const body = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: '0.4rem',
+});
+
+export const title = recipe({
+  base: {
+    letterSpacing: '-0.02em',
+    fontSize: '1.4rem',
+    fontWeight: vars.fontWeight.semibold,
+  },
+  variants: {
+    variant: {
+      default: { color: vars.color.textHigh },
+      success: { color: vars.color.successText },
+      warning: { color: vars.color.warningText },
+      error: { color: vars.color.dangerText },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+export const description = recipe({
+  base: {
+    lineHeight: '1.5',
+    letterSpacing: '-0.02em',
+    fontSize: '1.3rem',
+  },
+  variants: {
+    variant: {
+      default: { color: vars.color.textMid },
+      success: { color: vars.color.successText },
+      warning: { color: vars.color.warningText },
+      error: { color: vars.color.dangerText },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+export const closeButton = recipe({
+  base: {
+    display: 'flex',
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: vars.radius.md,
+    cursor: 'pointer',
+    width: '2rem',
+    height: '2rem',
+  },
+  variants: {
+    variant: {
+      default: {
+        color: vars.color.textLow,
+        selectors: { '&:hover': { backgroundColor: vars.color.gray50 } },
+      },
+      success: {
+        color: vars.color.successText,
+        selectors: { '&:hover': { backgroundColor: `${vars.color.success}20` } },
+      },
+      warning: {
+        color: vars.color.warningText,
+        selectors: { '&:hover': { backgroundColor: `${vars.color.warning}20` } },
+      },
+      error: {
+        color: vars.color.dangerText,
+        selectors: { '&:hover': { backgroundColor: `${vars.color.danger}20` } },
+      },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});
+
+export const progressBar = style({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  height: '0.3rem',
+  animationName: progressShrink,
+  animationTimingFunction: 'linear',
+  animationFillMode: 'forwards',
+});
+
+export const progressBarVariant = recipe({
+  base: {},
+  variants: {
+    variant: {
+      default: { backgroundColor: vars.color.gray300 },
+      success: { backgroundColor: vars.color.success },
+      warning: { backgroundColor: vars.color.warning },
+      error: { backgroundColor: vars.color.danger },
+    },
+  },
+  defaultVariants: { variant: 'default' },
+});

--- a/src/shared/components/toast/Toast.tsx
+++ b/src/shared/components/toast/Toast.tsx
@@ -65,6 +65,11 @@ const Toast = ({
     }
   };
 
+  const handlePointerCancel = () => {
+    isDraggingRef.current = false;
+    setDragX(0);
+  };
+
   const isDragging = dragX > 0;
   const dragOpacity = isDragging ? Math.max(0, 1 - dragX / 160) : undefined;
 
@@ -87,6 +92,7 @@ const Toast = ({
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       onPointerLeave={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
     >
       <span className={styles.iconWrapper({ variant })}>{ICONS[variant]}</span>
       <div className={styles.body}>

--- a/src/shared/components/toast/Toast.tsx
+++ b/src/shared/components/toast/Toast.tsx
@@ -1,0 +1,114 @@
+import { useRef, useState } from 'react';
+
+import AlertIcon from '@assets/icons/ic-alert.svg?react';
+import BellIcon from '@assets/icons/ic-bell.svg?react';
+import CheckCircleIcon from '@assets/icons/ic-check-circle.svg?react';
+import XCircleIcon from '@assets/icons/ic-x-circle.svg?react';
+import XIcon from '@assets/icons/ic-x.svg?react';
+
+import * as styles from './Toast.css';
+
+export type ToastVariant = 'default' | 'success' | 'warning' | 'error';
+
+export interface ToastProps {
+  id: string;
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+  leaving?: boolean;
+  onClose: (id: string) => void;
+}
+
+const ICONS: Record<ToastVariant, React.ReactElement> = {
+  default: <BellIcon width={22} height={22} />,
+  success: <CheckCircleIcon width={22} height={22} />,
+  warning: <AlertIcon width={22} height={22} />,
+  error: <XCircleIcon width={22} height={22} />,
+};
+
+const SWIPE_THRESHOLD = 80;
+
+const Toast = ({
+  id,
+  title,
+  description,
+  variant = 'default',
+  duration = 3000,
+  leaving = false,
+  onClose,
+}: ToastProps) => {
+  const [dragX, setDragX] = useState(0);
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (leaving) return;
+    isDraggingRef.current = true;
+    startXRef.current = e.clientX;
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDraggingRef.current) return;
+    const delta = e.clientX - startXRef.current;
+    if (delta > 0) setDragX(delta);
+  };
+
+  const handlePointerUp = () => {
+    if (!isDraggingRef.current) return;
+    isDraggingRef.current = false;
+    if (dragX >= SWIPE_THRESHOLD) {
+      onClose(id);
+    } else {
+      setDragX(0);
+    }
+  };
+
+  const isDragging = dragX > 0;
+  const dragOpacity = isDragging ? Math.max(0, 1 - dragX / 160) : undefined;
+
+  return (
+    <div
+      className={styles.container({ variant, leaving })}
+      role="alert"
+      aria-live="polite"
+      style={{
+        transform: isDragging ? `translateX(${dragX}px)` : undefined,
+        opacity: dragOpacity,
+        transition:
+          !isDragging && !isDraggingRef.current
+            ? 'transform 0.25s ease, opacity 0.25s ease'
+            : undefined,
+        cursor: isDragging ? 'grabbing' : 'grab',
+        userSelect: 'none',
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerLeave={handlePointerUp}
+    >
+      <span className={styles.iconWrapper({ variant })}>{ICONS[variant]}</span>
+      <div className={styles.body}>
+        <span className={styles.title({ variant })}>{title}</span>
+        {description && <span className={styles.description({ variant })}>{description}</span>}
+      </div>
+      <button
+        type="button"
+        className={styles.closeButton({ variant })}
+        aria-label="닫기"
+        onClick={() => onClose(id)}
+      >
+        <XIcon width={14} height={14} />
+      </button>
+      {duration > 0 && (
+        <div
+          className={`${styles.progressBar} ${styles.progressBarVariant({ variant })}`}
+          style={{ animationDuration: `${duration}ms` }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/shared/components/toast/ToastContainer.css.ts
+++ b/src/shared/components/toast/ToastContainer.css.ts
@@ -1,0 +1,18 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const containerStyle = style({
+  position: 'fixed',
+  zIndex: 9999,
+  top: vars.space.s6,
+  right: vars.space.s6,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s3,
+  pointerEvents: 'none',
+});
+
+globalStyle(`${containerStyle} > *`, {
+  pointerEvents: 'auto',
+});

--- a/src/shared/components/toast/ToastContainer.tsx
+++ b/src/shared/components/toast/ToastContainer.tsx
@@ -1,0 +1,27 @@
+import { createPortal } from 'react-dom';
+
+import Toast from './Toast';
+import { containerStyle } from './ToastContainer.css';
+
+import type { ToastProps } from './Toast';
+
+interface ToastContainerProps {
+  toasts: Omit<ToastProps, 'onClose' | 'leaving'>[];
+  leavingIds: Set<string>;
+  onClose: (id: string) => void;
+}
+
+const ToastContainer = ({ toasts, leavingIds, onClose }: ToastContainerProps) => {
+  if (toasts.length === 0) return null;
+
+  return createPortal(
+    <div className={containerStyle}>
+      {toasts.map((toast) => (
+        <Toast key={toast.id} {...toast} leaving={leavingIds.has(toast.id)} onClose={onClose} />
+      ))}
+    </div>,
+    document.body,
+  );
+};
+
+export default ToastContainer;

--- a/src/shared/components/toast/useToast.ts
+++ b/src/shared/components/toast/useToast.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ToastProps, ToastVariant } from './Toast';
 
@@ -19,6 +19,14 @@ const useToast = () => {
   const [leavingIds, setLeavingIds] = useState<Set<string>>(new Set());
   const toastsRef = useRef<ToastItem[]>([]);
   const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
 
   const syncToasts = useCallback((updater: (prev: ToastItem[]) => ToastItem[]) => {
     toastsRef.current = updater(toastsRef.current);
@@ -67,14 +75,13 @@ const useToast = () => {
         return existing.id;
       }
 
-      // 최대 개수 초과 시 가장 오래된 토스트 슬라이드아웃
+      // 최대 개수 초과 시 가장 오래된 토스트 슬라이드아웃 후 제거
       if (toastsRef.current.length >= MAX_TOASTS) {
         const evicted = toastsRef.current[0];
         const evictTimer = timersRef.current.get(evicted.id);
         if (evictTimer) clearTimeout(evictTimer);
         timersRef.current.delete(evicted.id);
-        setLeavingIds((prev) => new Set(prev).add(evicted.id));
-        setTimeout(() => remove(evicted.id), LEAVE_DURATION);
+        dismiss(evicted.id);
       }
 
       const id = `toast-${Date.now()}-${Math.random()}`;
@@ -86,7 +93,7 @@ const useToast = () => {
       scheduleRemoval(id, duration);
       return id;
     },
-    [syncToasts, scheduleRemoval, remove],
+    [syncToasts, scheduleRemoval, dismiss],
   );
 
   return { toasts, leavingIds, show, dismiss };

--- a/src/shared/components/toast/useToast.ts
+++ b/src/shared/components/toast/useToast.ts
@@ -1,0 +1,95 @@
+import { useCallback, useRef, useState } from 'react';
+
+import type { ToastProps, ToastVariant } from './Toast';
+
+type ToastItem = Omit<ToastProps, 'onClose' | 'leaving'>;
+
+export interface ShowToastOptions {
+  title: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+const LEAVE_DURATION = 300;
+const MAX_TOASTS = 3;
+
+const useToast = () => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const [leavingIds, setLeavingIds] = useState<Set<string>>(new Set());
+  const toastsRef = useRef<ToastItem[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const syncToasts = useCallback((updater: (prev: ToastItem[]) => ToastItem[]) => {
+    toastsRef.current = updater(toastsRef.current);
+    setToasts([...toastsRef.current]);
+  }, []);
+
+  const remove = useCallback(
+    (id: string) => {
+      syncToasts((prev) => prev.filter((t) => t.id !== id));
+      setLeavingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      timersRef.current.delete(id);
+    },
+    [syncToasts],
+  );
+
+  const dismiss = useCallback(
+    (id: string) => {
+      setLeavingIds((prev) => new Set(prev).add(id));
+      setTimeout(() => remove(id), LEAVE_DURATION);
+    },
+    [remove],
+  );
+
+  const scheduleRemoval = useCallback(
+    (id: string, duration: number) => {
+      const existing = timersRef.current.get(id);
+      if (existing) clearTimeout(existing);
+      if (duration > 0) {
+        const timer = setTimeout(() => dismiss(id), duration);
+        timersRef.current.set(id, timer);
+      }
+    },
+    [dismiss],
+  );
+
+  const show = useCallback(
+    ({ title, description, variant = 'default', duration = 3000 }: ShowToastOptions): string => {
+      // 중복: 같은 title + variant가 이미 있으면 추가하지 않고 타이머만 리셋
+      const existing = toastsRef.current.find((t) => t.title === title && t.variant === variant);
+      if (existing) {
+        scheduleRemoval(existing.id, duration);
+        return existing.id;
+      }
+
+      // 최대 개수 초과 시 가장 오래된 토스트 슬라이드아웃
+      if (toastsRef.current.length >= MAX_TOASTS) {
+        const evicted = toastsRef.current[0];
+        const evictTimer = timersRef.current.get(evicted.id);
+        if (evictTimer) clearTimeout(evictTimer);
+        timersRef.current.delete(evicted.id);
+        setLeavingIds((prev) => new Set(prev).add(evicted.id));
+        setTimeout(() => remove(evicted.id), LEAVE_DURATION);
+      }
+
+      const id = `toast-${Date.now()}-${Math.random()}`;
+      syncToasts((prev) => {
+        const next = prev.length >= MAX_TOASTS ? prev.slice(1) : prev;
+        return [...next, { id, title, description, variant, duration }];
+      });
+
+      scheduleRemoval(id, duration);
+      return id;
+    },
+    [syncToasts, scheduleRemoval, remove],
+  );
+
+  return { toasts, leavingIds, show, dismiss };
+};
+
+export default useToast;

--- a/src/stories/Toast.stories.tsx
+++ b/src/stories/Toast.stories.tsx
@@ -1,0 +1,85 @@
+import { Button } from '@components/Button';
+import Toast from '@components/toast/Toast';
+import ToastContainer from '@components/toast/ToastContainer';
+import useToast from '@components/toast/useToast';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Shared/Toast',
+  component: Toast,
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+export const Playground: Story = {
+  args: {
+    id: 'preview',
+    title: '건물이 추가되었습니다',
+    description: 'A동 본관이 성공적으로 등록되었습니다.',
+    variant: 'success',
+    onClose: () => {},
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '2rem' }}>
+      <Toast {...args} />
+    </div>
+  ),
+};
+
+export const ReferenceSet: Story = {
+  args: { id: '', title: '', onClose: () => {} },
+  render: () => {
+    const { toasts, leavingIds, show, dismiss } = useToast();
+
+    return (
+      <div style={{ padding: '2rem' }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1.2rem', marginBottom: '3.2rem' }}>
+          <Button
+            variant="ghost"
+            onClick={() =>
+              show({ title: '알림', description: '작업이 처리되었습니다.', variant: 'default' })
+            }
+          >
+            Default
+          </Button>
+          <Button
+            onClick={() =>
+              show({
+                title: '성공',
+                description: '건물이 성공적으로 추가되었습니다.',
+                variant: 'success',
+              })
+            }
+          >
+            Success
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={() =>
+              show({ title: '주의', description: '일부 항목을 확인해 주세요.', variant: 'warning' })
+            }
+          >
+            Warning
+          </Button>
+          <Button
+            variant="danger"
+            onClick={() =>
+              show({ title: '오류', description: '요청을 처리하지 못했습니다.', variant: 'error' })
+            }
+          >
+            Error
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => show({ title: '설명 없는 알림', variant: 'default' })}
+          >
+            설명 없음
+          </Button>
+        </div>
+        <ToastContainer toasts={toasts} leavingIds={leavingIds} onClose={dismiss} />
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
## 📌 Summary
> 공통 컴포넌트 Toast를 구현하였습니다.

## 🔗 관련 이슈

closes #26 

## 📋 작업 내용

- variant(4): default / success / warning / error
- 슬라이드인/슬라이드아웃 애니메이션 + 하단 progress bar로 남은 시간 시각화
- 오른쪽 스와이프로 닫기 (80px 이상 시 dismiss, 미만 시 제자리 복귀)
- useToast 훅 — 동시 최대 3개 제한, 동일 title+variant 중복 방지
- ToastContainer — createPortal로 body에 렌더링

## 📸 스크린샷

<img width="1609" height="574" alt="녹화_2026_06_12_08_17_28_725" src="https://github.com/user-attachments/assets/f62b0c33-2cc7-4436-becc-9311826c4bf5" />


## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
