### PR TITLE
[feat] 로그인, 회원가입 페이지, 마이페이지 모달, 랜딩 페이지 UI 구현

### DIFF
--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,19 +1,56 @@
-import { Outlet } from 'react-router';
+import { useMemo, useState } from 'react';
 
+import { Outlet, useLocation } from 'react-router';
+
+import GNB from '@components/gnb';
+import MyPageModal from '@components/myPageModal/MyPageModal';
 import Sidebar from '@components/sideBar/Sidebar';
 
 import { sidebarItems } from '@constants/sidebar';
 
 import * as styles from './AppLayout.css';
+import { getGNBConfig } from '../shared/constants/gnbConfig';
 
-const AppLayout = () => (
-  <div className={styles.container}>
-    <Sidebar brand="SAFE ROUTE" menuItems={sidebarItems} onLogout={() => undefined} />
+const currentUser = {
+  name: '김안전',
+  role: '관리자',
+};
 
-    <main className={styles.main}>
-      <Outlet />
-    </main>
-  </div>
-);
+const AppLayout = () => {
+  const location = useLocation();
+  const [isMyPageOpen, setIsMyPageOpen] = useState(false);
+  const [selectedUserName, setSelectedUserName] = useState(currentUser.name);
+  const gnbConfig = getGNBConfig(location);
+
+  const handleProfileClick = useMemo(
+    () => () => {
+      setSelectedUserName(currentUser.name);
+      setIsMyPageOpen(true);
+    },
+    [],
+  );
+
+  return (
+    <div className={styles.container}>
+      <Sidebar brand="SAFE ROUTE" menuItems={sidebarItems} onLogout={() => undefined} />
+
+      <main className={styles.main}>
+        <GNB
+          {...gnbConfig}
+          userName={currentUser.name}
+          userRole={currentUser.role}
+          onProfileClick={handleProfileClick}
+        />
+        <Outlet />
+      </main>
+
+      <MyPageModal
+        open={isMyPageOpen}
+        initialName={selectedUserName}
+        onClose={() => setIsMyPageOpen(false)}
+      />
+    </div>
+  );
+};
 
 export default AppLayout;

--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Outlet, useLocation } from 'react-router';
 
@@ -6,10 +6,10 @@ import GNB from '@components/gnb';
 import MyPageModal from '@components/myPageModal/MyPageModal';
 import Sidebar from '@components/sideBar/Sidebar';
 
+import { getGNBConfig } from '@constants/gnbConfig';
 import { sidebarItems } from '@constants/sidebar';
 
 import * as styles from './AppLayout.css';
-import { getGNBConfig } from '../shared/constants/gnbConfig';
 
 const currentUser = {
   name: '김안전',
@@ -22,13 +22,10 @@ const AppLayout = () => {
   const [selectedUserName, setSelectedUserName] = useState(currentUser.name);
   const gnbConfig = getGNBConfig(location);
 
-  const handleProfileClick = useMemo(
-    () => () => {
-      setSelectedUserName(currentUser.name);
-      setIsMyPageOpen(true);
-    },
-    [],
-  );
+  const handleProfileClick = useCallback(() => {
+    setSelectedUserName(currentUser.name);
+    setIsMyPageOpen(true);
+  }, []);
 
   return (
     <div className={styles.container}>

--- a/src/pages/buildings/BuildingsPage.tsx
+++ b/src/pages/buildings/BuildingsPage.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import PlusIcon from '@assets/icons/ic-plus.svg?react';
 
 import { Button } from '@components/Button';
-import GNB from '@components/gnb';
 import ToastContainer from '@components/toast/ToastContainer';
 import useToast from '@components/toast/useToast';
 
@@ -86,14 +85,6 @@ const BuildingsPage = () => {
 
   return (
     <>
-      <GNB
-        breadcrumbs={[{ label: '훈련 관리' }]}
-        title="건물 관리"
-        description="등록된 건물과 시설을 관리합니다"
-        userName="김안전"
-        userRole="관리자"
-      />
-
       <div className={styles.container}>
         <OrganizationCard organization={mockOrganization} buildingCount={buildings.length} />
 

--- a/src/pages/cameras/CamerasPage.tsx
+++ b/src/pages/cameras/CamerasPage.tsx
@@ -4,7 +4,6 @@ import PlusIcon from '@assets/icons/ic-plus.svg?react';
 
 import { Button } from '@components/Button';
 import FilterChip from '@components/chip/FilterChip';
-import GNB from '@components/gnb';
 import ToastContainer from '@components/toast/ToastContainer';
 import useToast from '@components/toast/useToast';
 
@@ -89,14 +88,6 @@ const CamerasPage = () => {
 
   return (
     <>
-      <GNB
-        breadcrumbs={[{ label: '관리' }]}
-        title="카메라 관리"
-        description="CCTV 카메라 등록 및 설정 관리"
-        userName="김안전"
-        userRole="관리자"
-      />
-
       <div className={styles.container}>
         <div className={styles.filterRow}>
           {buildingOptions.map((name) => (

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -10,7 +10,6 @@ import XIcon from '@assets/icons/ic-x.svg?react';
 import { Button } from '@components/Button';
 import StatusBadge from '@components/chip/StatusBadge';
 import Dropdown from '@components/dropdown';
-import GNB from '@components/gnb';
 
 import { formatFloor } from '@utils/floor';
 
@@ -1325,14 +1324,6 @@ const FloorPlansDetailPage = () => {
 
   return (
     <>
-      <GNB
-        breadcrumbs={[{ label: '관리' }, { label: '도면 관리' }]}
-        title="도면 관리 상세"
-        description="층별 도면을 확인하고 관리합니다"
-        userName="김안전"
-        userRole="관리자"
-      />
-
       <div className={styles.layout}>
         {/* ── 좌측 사이드바 ── */}
         <aside className={styles.sidebar}>

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router';
 
 import StatusBadge from '@components/chip/StatusBadge';
 import type { StatusBadgeColor } from '@components/chip/StatusBadge';
-import GNB from '@components/gnb';
 import ToastContainer from '@components/toast/ToastContainer';
 import useToast from '@components/toast/useToast';
 
@@ -222,14 +221,6 @@ const FloorPlansPage = () => {
 
   return (
     <>
-      <GNB
-        breadcrumbs={[{ label: '관리' }]}
-        title="도면 관리"
-        description="등록된 건물별 도면을 확인하고 관리할 수 있습니다"
-        userName="김안전"
-        userRole="관리자"
-      />
-
       <div className={styles.container}>
         {loading && (
           <p style={{ color: 'var(--color-textLow)', fontSize: '1.4rem', padding: '2rem 0' }}>

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -10,8 +10,6 @@ import PlayIcon from '@assets/icons/ic-play.svg?react';
 import TrendDownIcon from '@assets/icons/ic-trenddown.svg?react';
 import TrendUpIcon from '@assets/icons/ic-trendup.svg?react';
 
-import GNB from '@components/gnb';
-
 import HomeSummarySection from './components/homeSummarySection/HomeSummarySection';
 import RecentTrainingSection from './components/recentTrainingSection/RecentTrainingSection';
 import ScheduledTrainingSection from './components/scheduledTrainingSection/ScheduledTrainingSection';
@@ -59,14 +57,6 @@ const HomePage = () => {
 
   return (
     <div className={styles.container}>
-      <header>
-        <GNB
-          title="홈"
-          description="화재 대피 훈련 현황을 한눈에 확인하세요."
-          userName="김안전"
-          userRole="관리자"
-        />
-      </header>
       <div className={styles.sectionContainer}>
         <HomeSummarySection
           metrics={homeMetrics.map((metric) => ({

--- a/src/pages/landing/LandingPage.css.ts
+++ b/src/pages/landing/LandingPage.css.ts
@@ -1,0 +1,261 @@
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const page = style({
+  display: 'flex',
+  flexDirection: 'column',
+  background: vars.gradient.landing,
+  minHeight: '100vh',
+  color: vars.color.textHigh,
+});
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderBottom: `1px solid ${vars.color.gray100}`,
+  backgroundColor: vars.color.white,
+  padding: `0 clamp(${vars.space.s6}, 4vw, ${vars.space.s18})`,
+  height: '7.2rem',
+});
+
+export const brand = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  color: vars.color.gray900,
+  ...vars.typography.h4,
+});
+
+export const logoIcon = style({
+  width: vars.space.s7,
+  height: vars.space.s7,
+});
+
+export const authActions = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
+  gap: vars.space.s3,
+});
+
+export const loginButton = style({
+  '@media': {
+    '(max-width: 560px)': {
+      display: 'none',
+    },
+  },
+});
+
+export const main = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: `0 clamp(${vars.space.s5}, 4vw, ${vars.space.s18})`,
+  width: '100%',
+  '@media': {
+    '(max-width: 560px)': {
+      padding: `0 ${vars.space.s4}`,
+    },
+  },
+});
+
+export const hero = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  paddingTop: vars.space.s20,
+  textAlign: 'center',
+});
+
+export const badge = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: vars.radius.pill,
+  backgroundColor: vars.color.primaryLight,
+  padding: `0 ${vars.space.s3}`,
+  height: vars.space.s6,
+  color: vars.color.infoText,
+  ...vars.typography.captionBold,
+});
+
+export const title = style({
+  marginTop: vars.space.s3,
+  color: vars.color.gray900,
+  ...vars.typography.h1Landing,
+});
+
+export const description = style({
+  marginTop: vars.space.s6,
+  color: vars.color.gray500,
+  ...vars.typography.body16,
+});
+
+export const ctaGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.s3,
+  marginTop: vars.space.s8,
+});
+
+const ctaBase = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.s2,
+  borderRadius: vars.radius.md,
+  padding: `0 ${vars.space.s6}`,
+  height: vars.space.s12,
+  ...vars.typography.body14Bold,
+});
+
+export const primaryCta = style([
+  ctaBase,
+  {
+    backgroundColor: vars.color.primary,
+    color: vars.color.white,
+    selectors: {
+      '&:hover': {
+        backgroundColor: vars.color.primaryHover,
+      },
+    },
+  },
+]);
+
+export const secondaryCta = style([
+  ctaBase,
+  {
+    border: `1px solid ${vars.color.gray100}`,
+    backgroundColor: vars.color.white,
+    color: vars.color.gray500,
+
+    selectors: {
+      '&:hover': {
+        backgroundColor: vars.color.gray25,
+      },
+    },
+  },
+]);
+
+globalStyle(`${primaryCta} svg`, {
+  width: vars.space.s4,
+  height: vars.space.s4,
+});
+
+globalStyle(`${secondaryCta} svg`, {
+  width: vars.space.s4,
+  height: vars.space.s4,
+});
+
+export const featureGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: vars.space.s4,
+  marginTop: vars.space.s20,
+  paddingBottom: vars.space.s18,
+  width: 'min(100%, 110rem)',
+});
+
+export const featureCard = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s5,
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  boxShadow: vars.shadow.sm,
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.s5} ${vars.space.s6}`,
+  minHeight: '9rem',
+});
+
+const iconBoxBase = style({
+  display: 'inline-flex',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: vars.radius.md,
+  width: vars.space.s12,
+  height: vars.space.s12,
+});
+
+export const iconBox = styleVariants({
+  blue: [
+    iconBoxBase,
+    {
+      backgroundColor: vars.color.primaryLight,
+      color: vars.color.primary,
+    },
+  ],
+  green: [
+    iconBoxBase,
+    {
+      backgroundColor: vars.color.successLight,
+      color: vars.color.success,
+    },
+  ],
+  purple: [
+    iconBoxBase,
+    {
+      backgroundColor: vars.color.purpleLight,
+      color: vars.color.purple,
+    },
+  ],
+  yellow: [
+    iconBoxBase,
+    {
+      backgroundColor: vars.color.warningLight,
+      color: vars.color.warning,
+    },
+  ],
+});
+
+globalStyle(`${iconBoxBase} svg`, {
+  width: vars.space.s5,
+  height: vars.space.s5,
+});
+
+globalStyle(`${iconBoxBase} svg path`, {
+  stroke: 'currentColor',
+});
+
+export const featureText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s2,
+  minWidth: 0,
+});
+
+globalStyle(`${featureText} h2`, {
+  color: vars.color.gray900,
+  ...vars.typography.body16Bold,
+});
+
+globalStyle(`${featureText} p`, {
+  color: vars.color.gray500,
+  ...vars.typography.captionMedium,
+});
+
+export const footer = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderTop: `1px solid ${vars.color.gray100}`,
+  padding: `0 clamp(${vars.space.s6}, 4vw, ${vars.space.s18})`,
+  minHeight: vars.space.s14,
+  color: vars.color.textLow,
+  ...vars.typography.captionMedium,
+});
+
+export const footerLinks = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s1,
+});
+
+globalStyle(`${footerLinks} a:hover`, {
+  color: vars.color.gray500,
+});

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,0 +1,3 @@
+const LandingPage = () => <>랜딩 페이지</>;
+
+export default LandingPage;

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,3 +1,95 @@
-const LandingPage = () => <>랜딩 페이지</>;
+import { useNavigate } from 'react-router';
+
+import ArrowRightIcon from '@assets/icons/ic-arrow-right.svg?react';
+import PlayIcon from '@assets/icons/ic-play.svg?react';
+import LogoIcon from '@assets/icons/logo.svg?react';
+
+import { Button } from '@components/Button';
+
+import { ROUTES } from '@constants/path';
+
+import { landingFeatures } from './constants/landing';
+import * as styles from './LandingPage.css';
+
+const LandingPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+          <LogoIcon className={styles.logoIcon} />
+          <span>SAFE ROUTE</span>
+        </a>
+
+        <div className={styles.authActions}>
+          <Button
+            className={styles.loginButton}
+            size="md"
+            variant="ghost"
+            onClick={() => navigate(ROUTES.LOGIN)}
+          >
+            로그인
+          </Button>
+          <Button size="md" variant="primary" onClick={() => navigate(ROUTES.SIGNUP)}>
+            회원가입
+          </Button>
+        </div>
+      </header>
+
+      <main className={styles.main}>
+        <section className={styles.hero}>
+          <span className={styles.badge}>AI · IoT · Digital Twin</span>
+          <h1 className={styles.title}>
+            AI 기반
+            <br />
+            실시간 화재 대피 훈련 관리
+          </h1>
+          <p className={styles.description}>
+            CCTV AI 비전 분석과 IoT 센서를 활용한 실시간 군중 밀집도 모니터링으로
+            <br />
+            효과적인 대피 훈련과 능동적 경로 안내를 실현합니다.
+          </p>
+
+          <div className={styles.ctaGroup}>
+            <a className={styles.primaryCta} href={ROUTES.HOME}>
+              시스템 접속
+              <ArrowRightIcon />
+            </a>
+            <button className={styles.secondaryCta} type="button">
+              <PlayIcon />
+              데모 영상
+            </button>
+          </div>
+        </section>
+
+        <section className={styles.featureGrid} aria-label="주요 기능">
+          {landingFeatures.map(({ Icon, ...feature }) => (
+            <article className={styles.featureCard} key={feature.title}>
+              <span className={styles.iconBox[feature.tone]}>
+                <Icon />
+              </span>
+              <div className={styles.featureText}>
+                <h2>{feature.title}</h2>
+                <p>{feature.description}</p>
+              </div>
+            </article>
+          ))}
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
+        <p>© 2026 Safe Route Inc. All rights reserved.</p>
+        <div className={styles.footerLinks}>
+          <a>이용약관</a>
+          <span aria-hidden="true">·</span>
+          <a>개인정보처리방침</a>
+          <span aria-hidden="true">·</span>
+          <a>고객지원</a>
+        </div>
+      </footer>
+    </div>
+  );
+};
 
 export default LandingPage;

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import ArrowRightIcon from '@assets/icons/ic-arrow-right.svg?react';
 import PlayIcon from '@assets/icons/ic-play.svg?react';
@@ -8,7 +8,7 @@ import { Button } from '@components/Button';
 
 import { ROUTES } from '@constants/path';
 
-import { landingFeatures } from './constants/landing';
+import { LANDING_FEATURES } from './constants/landing';
 import * as styles from './LandingPage.css';
 
 const LandingPage = () => {
@@ -17,10 +17,10 @@ const LandingPage = () => {
   return (
     <div className={styles.page}>
       <header className={styles.header}>
-        <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+        <Link className={styles.brand} to={ROUTES.LANDING} aria-label="SAFE ROUTE 홈">
           <LogoIcon className={styles.logoIcon} />
           <span>SAFE ROUTE</span>
-        </a>
+        </Link>
 
         <div className={styles.authActions}>
           <Button
@@ -52,10 +52,10 @@ const LandingPage = () => {
           </p>
 
           <div className={styles.ctaGroup}>
-            <a className={styles.primaryCta} href={ROUTES.HOME}>
+            <Link className={styles.primaryCta} to={ROUTES.HOME}>
               시스템 접속
               <ArrowRightIcon />
-            </a>
+            </Link>
             <button className={styles.secondaryCta} type="button">
               <PlayIcon />
               데모 영상
@@ -64,7 +64,7 @@ const LandingPage = () => {
         </section>
 
         <section className={styles.featureGrid} aria-label="주요 기능">
-          {landingFeatures.map(({ Icon, ...feature }) => (
+          {LANDING_FEATURES.map(({ Icon, ...feature }) => (
             <article className={styles.featureCard} key={feature.title}>
               <span className={styles.iconBox[feature.tone]}>
                 <Icon />
@@ -81,11 +81,11 @@ const LandingPage = () => {
       <footer className={styles.footer}>
         <p>© 2026 Safe Route Inc. All rights reserved.</p>
         <div className={styles.footerLinks}>
-          <a>이용약관</a>
+          <a href="#terms">이용약관</a>
           <span aria-hidden="true">·</span>
-          <a>개인정보처리방침</a>
+          <a href="#privacy">개인정보처리방침</a>
           <span aria-hidden="true">·</span>
-          <a>고객지원</a>
+          <a href="#support">고객지원</a>
         </div>
       </footer>
     </div>

--- a/src/pages/landing/constants/landing.ts
+++ b/src/pages/landing/constants/landing.ts
@@ -1,0 +1,43 @@
+import type { FunctionComponent, SVGProps } from 'react';
+
+import CameraIcon from '@assets/icons/ic-camera.svg?react';
+import LayersIcon from '@assets/icons/ic-layers.svg?react';
+import MapIcon from '@assets/icons/ic-map.svg?react';
+import WifiIcon from '@assets/icons/ic-wifi.svg?react';
+
+type FeatureTone = 'blue' | 'purple' | 'green' | 'yellow';
+type FeatureIcon = FunctionComponent<SVGProps<SVGSVGElement>>;
+
+interface LandingFeature {
+  title: string;
+  description: string;
+  Icon: FeatureIcon;
+  tone: FeatureTone;
+}
+
+export const landingFeatures = [
+  {
+    title: '실시간 CCTV 모니터링',
+    description: 'AI 비전 분석을 통한 혼잡 밀집도와 실시간 추적',
+    Icon: CameraIcon,
+    tone: 'blue',
+  },
+  {
+    title: 'IoT 센서 통합',
+    description: '유동률 점검 상태와 환경 모니터링 시스템 연동',
+    Icon: WifiIcon,
+    tone: 'purple',
+  },
+  {
+    title: 'AI 기반 경로 분석',
+    description: '기존 대피 경로 분석 및 신규 권장 경로 산정',
+    Icon: MapIcon,
+    tone: 'green',
+  },
+  {
+    title: '디지털 트윈 맵',
+    description: '3D 건물 모델 기반 실시간 상황 공유 가시화',
+    Icon: LayersIcon,
+    tone: 'yellow',
+  },
+] as const satisfies readonly LandingFeature[];

--- a/src/pages/landing/constants/landing.ts
+++ b/src/pages/landing/constants/landing.ts
@@ -15,7 +15,7 @@ interface LandingFeature {
   tone: FeatureTone;
 }
 
-export const landingFeatures = [
+export const LANDING_FEATURES = [
   {
     title: '실시간 CCTV 모니터링',
     description: 'AI 비전 분석을 통한 혼잡 밀집도와 실시간 추적',

--- a/src/pages/login/LoginPage.css.ts
+++ b/src/pages/login/LoginPage.css.ts
@@ -1,0 +1,176 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const page = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: vars.gradient.landing,
+  padding: vars.space.s6,
+  minHeight: '100vh',
+  color: vars.color.textHigh,
+});
+
+export const content = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 38rem) minmax(0, 42.4rem)',
+  alignItems: 'center',
+  gap: vars.space.s20,
+  width: 'min(100%, 88.4rem)',
+});
+
+export const intro = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const brand = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  color: vars.color.gray900,
+  ...vars.typography.h4,
+});
+
+export const logoIcon = style({
+  width: vars.space.s7,
+  height: vars.space.s7,
+});
+
+export const title = style({
+  marginTop: vars.space.s8,
+  color: vars.color.gray900,
+  ...vars.typography.h1,
+});
+
+export const description = style({
+  marginTop: vars.space.s6,
+  color: vars.color.gray500,
+  ...vars.typography.body16,
+});
+
+export const featureList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s3,
+  marginTop: vars.space.s8,
+});
+
+export const featureItem = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.s3} ${vars.space.s4}`,
+  width: '30.5rem',
+  minHeight: vars.space.s14,
+  color: vars.color.textHigh,
+  ...vars.typography.body14,
+});
+
+export const featureIcon = style({
+  display: 'inline-flex',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.primaryLight2,
+  width: vars.space.s8,
+  height: vars.space.s8,
+  color: vars.color.primary,
+});
+
+export const featureIconSvg = style({
+  width: vars.space.s4,
+  height: vars.space.s4,
+});
+
+export const loginCard = style({
+  display: 'flex',
+  flexDirection: 'column',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.lg,
+  boxShadow: vars.shadow.lg,
+  backgroundColor: vars.color.white,
+  padding: vars.space.s8,
+});
+
+export const formHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s2,
+});
+
+export const formTitle = style({
+  color: vars.color.gray900,
+  ...vars.typography.h3,
+});
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s3,
+  marginTop: vars.space.s6,
+});
+
+export const formOptions = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s3,
+  marginTop: vars.space.s4,
+  marginBottom: vars.space.s5,
+});
+
+export const checkboxLabel = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+  color: vars.color.gray500,
+  ...vars.typography.captionMedium,
+});
+
+export const checkbox = style({
+  flexShrink: 0,
+  width: vars.space.s4,
+  height: vars.space.s4,
+  accentColor: vars.color.primary,
+});
+
+export const textButton = style({
+  color: vars.color.primary,
+  ...vars.typography.captionBold,
+});
+
+export const divider = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr auto 1fr',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  marginTop: vars.space.s6,
+  color: vars.color.textLow,
+  ...vars.typography.caption,
+});
+
+export const dividerLine = style({
+  backgroundColor: vars.color.gray100,
+  height: '1px',
+});
+
+export const signupGuide = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.s1,
+  marginTop: vars.space.s5,
+  color: vars.color.gray500,
+  ...vars.typography.body14,
+});
+
+export const signupButton = style({
+  color: vars.color.primary,
+  ...vars.typography.body14Bold,
+});

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,3 +1,111 @@
-const LoginPage = () => <>로그인 페이지</>;
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+
+import { useNavigate } from 'react-router';
+
+import LogoIcon from '@assets/icons/logo.svg?react';
+
+import { Button } from '@components/Button';
+import TextField from '@components/inputField/TextField';
+
+import { ROUTES } from '@constants/path';
+
+import { loginFeatures } from './constants/login';
+import * as styles from './LoginPage.css';
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const [isAutoLogin, setIsAutoLogin] = useState(true);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    navigate(ROUTES.HOME);
+  };
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.content} aria-label="로그인">
+        <div className={styles.intro}>
+          <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+            <LogoIcon className={styles.logoIcon} />
+            <span>SAFE ROUTE</span>
+          </a>
+
+          <h1 className={styles.title}>
+            실시간 데이터 기반
+            <br />
+            화재 대피 훈련 및
+            <br />
+            평가 시스템
+          </h1>
+
+          <p className={styles.description}>
+            AI 비전과 IoT 센서로 모든 훈련을 자동 평가하고,
+            <br />
+            개선 권고사항을 즉시 받아보세요.
+          </p>
+
+          <ul className={styles.featureList} aria-label="주요 기능">
+            {loginFeatures.map(({ Icon, title }) => (
+              <li className={styles.featureItem} key={title}>
+                <span className={styles.featureIcon}>
+                  <Icon className={styles.featureIconSvg} />
+                </span>
+                <span>{title}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <form className={styles.loginCard} onSubmit={handleSubmit}>
+          <div className={styles.formHeader}>
+            <h2 className={styles.formTitle}>로그인</h2>
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <TextField label="이메일" type="email" autoComplete="username" />
+            <TextField label="비밀번호" type="password" autoComplete="current-password" />
+          </div>
+
+          <div className={styles.formOptions}>
+            <label className={styles.checkboxLabel}>
+              <input
+                checked={isAutoLogin}
+                className={styles.checkbox}
+                type="checkbox"
+                onChange={(event) => setIsAutoLogin(event.target.checked)}
+              />
+              자동 로그인
+            </label>
+            <button className={styles.textButton} type="button">
+              비밀번호 찾기
+            </button>
+          </div>
+
+          <Button fullWidth size="lg" type="submit" variant="primary">
+            로그인
+          </Button>
+
+          <div className={styles.divider}>
+            <span className={styles.dividerLine} />
+            <p>또는</p>
+            <span className={styles.dividerLine} />
+          </div>
+
+          <p className={styles.signupGuide}>
+            계정이 없으신가요?
+            <button
+              className={styles.signupButton}
+              type="button"
+              onClick={() => navigate(ROUTES.SIGNUP)}
+            >
+              회원가입
+            </button>
+          </p>
+        </form>
+      </section>
+    </main>
+  );
+};
 
 export default LoginPage;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,0 +1,3 @@
+const LoginPage = () => <>로그인 페이지</>;
+
+export default LoginPage;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 import { useState } from 'react';
 
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import LogoIcon from '@assets/icons/logo.svg?react';
 
@@ -10,7 +10,7 @@ import TextField from '@components/inputField/TextField';
 
 import { ROUTES } from '@constants/path';
 
-import { loginFeatures } from './constants/login';
+import { LOGIN_FEATURES } from './constants/login';
 import * as styles from './LoginPage.css';
 
 const LoginPage = () => {
@@ -26,10 +26,10 @@ const LoginPage = () => {
     <main className={styles.page}>
       <section className={styles.content} aria-label="로그인">
         <div className={styles.intro}>
-          <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+          <Link className={styles.brand} to={ROUTES.LANDING} aria-label="SAFE ROUTE 홈">
             <LogoIcon className={styles.logoIcon} />
             <span>SAFE ROUTE</span>
-          </a>
+          </Link>
 
           <h1 className={styles.title}>
             실시간 데이터 기반
@@ -46,7 +46,7 @@ const LoginPage = () => {
           </p>
 
           <ul className={styles.featureList} aria-label="주요 기능">
-            {loginFeatures.map(({ Icon, title }) => (
+            {LOGIN_FEATURES.map(({ Icon, title }) => (
               <li className={styles.featureItem} key={title}>
                 <span className={styles.featureIcon}>
                   <Icon className={styles.featureIconSvg} />

--- a/src/pages/login/constants/login.ts
+++ b/src/pages/login/constants/login.ts
@@ -1,0 +1,27 @@
+import type { FunctionComponent, SVGProps } from 'react';
+
+import CameraIcon from '@assets/icons/ic-camera.svg?react';
+import SparklesIcon from '@assets/icons/ic-sparkles.svg?react';
+import WifiIcon from '@assets/icons/ic-wifi.svg?react';
+
+type LoginFeatureIcon = FunctionComponent<SVGProps<SVGSVGElement>>;
+
+interface LoginFeature {
+  title: string;
+  Icon: LoginFeatureIcon;
+}
+
+export const loginFeatures = [
+  {
+    title: 'CCTV AI 비전 분석',
+    Icon: CameraIcon,
+  },
+  {
+    title: 'IoT 센서 실시간 연동',
+    Icon: WifiIcon,
+  },
+  {
+    title: 'AI 자동 평가 보고서 생성',
+    Icon: SparklesIcon,
+  },
+] as const satisfies readonly LoginFeature[];

--- a/src/pages/login/constants/login.ts
+++ b/src/pages/login/constants/login.ts
@@ -11,7 +11,7 @@ interface LoginFeature {
   Icon: LoginFeatureIcon;
 }
 
-export const loginFeatures = [
+export const LOGIN_FEATURES = [
   {
     title: 'CCTV AI 비전 분석',
     Icon: CameraIcon,

--- a/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
+++ b/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
@@ -2,7 +2,6 @@ import PlayIcon from '@assets/icons/ic-play.svg?react';
 import SparklesIcon from '@assets/icons/ic-sparkles.svg?react';
 
 import { Button } from '@components/Button';
-import GNB from '@components/gnb/GNB';
 
 import RecommendationCard from './components/cards/recommendationCard/RecommendationCard';
 import TrainingPreviewCard from './components/cards/trainingPreviewCard/TrainingPreviewCard';
@@ -19,14 +18,6 @@ import * as styles from './ScenarioSettingsPage.css';
 
 const ScenarioSettingsPage = () => (
   <div className={styles.container}>
-    <header>
-      <GNB
-        title="훈련 관리"
-        description="화재 발생 위치와 조건을 설정하고 시나리오를 시작합니다"
-        userName="김안전"
-        userRole="관리자"
-      />
-    </header>
     <div className={styles.sectionContainer}>
       <div className={styles.contentGrid}>
         <div className={styles.mainColumn}>

--- a/src/pages/signup/SignupPage.css.ts
+++ b/src/pages/signup/SignupPage.css.ts
@@ -1,0 +1,66 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const page = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: vars.gradient.landing,
+  padding: vars.space.s6,
+  minHeight: '100vh',
+  color: vars.color.textHigh,
+});
+
+export const signupCard = style({
+  display: 'flex',
+  flexDirection: 'column',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.lg,
+  boxShadow: vars.shadow.lg,
+  backgroundColor: vars.color.white,
+  padding: vars.space.s8,
+  width: 'min(100%, 47rem)',
+});
+
+export const brand = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  color: vars.color.gray900,
+  ...vars.typography.h4,
+});
+
+export const logoIcon = style({
+  width: vars.space.s7,
+  height: vars.space.s7,
+});
+
+export const title = style({
+  marginTop: vars.space.s8,
+  color: vars.color.gray900,
+  ...vars.typography.h3,
+});
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s5,
+  marginTop: vars.space.s8,
+  marginBottom: vars.space.s8,
+});
+
+export const loginGuide = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.s1,
+  marginTop: vars.space.s3,
+  color: vars.color.gray500,
+  ...vars.typography.body14,
+});
+
+export const loginButton = style({
+  color: vars.color.primary,
+  ...vars.typography.body14Bold,
+});

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,3 +1,69 @@
-const SignupPage = () => <>회원가입 페이지</>;
+import type { FormEvent } from 'react';
+
+import { useNavigate } from 'react-router';
+
+import LogoIcon from '@assets/icons/logo.svg?react';
+
+import { Button } from '@components/Button';
+import TextField from '@components/inputField/TextField';
+
+import { ROUTES } from '@constants/path';
+
+import * as styles from './SignupPage.css';
+
+const SignupPage = () => {
+  const navigate = useNavigate();
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    navigate(ROUTES.LOGIN);
+  };
+
+  return (
+    <main className={styles.page}>
+      <form className={styles.signupCard} onSubmit={handleSubmit}>
+        <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+          <LogoIcon className={styles.logoIcon} />
+          <span>SAFE ROUTE</span>
+        </a>
+
+        <h1 className={styles.title}>회원가입</h1>
+
+        <div className={styles.fieldGroup}>
+          <TextField label="기관명 *" placeholder="예: 00고등학교" autoComplete="organization" />
+          <TextField label="관리자 이름 *" placeholder="홍길동" autoComplete="name" />
+          <TextField
+            label="이메일 *"
+            type="email"
+            placeholder="admin@example.com"
+            autoComplete="email"
+          />
+          <TextField
+            helperText="영문, 숫자, 특수문자 포함 8자 이상"
+            label="비밀번호 *"
+            type="password"
+            autoComplete="new-password"
+          />
+          <TextField label="비밀번호 확인 *" type="password" autoComplete="new-password" />
+        </div>
+
+        <Button fullWidth size="lg" type="submit" variant="primary">
+          회원가입
+        </Button>
+
+        <p className={styles.loginGuide}>
+          이미 계정이 있으신가요?
+          <button
+            className={styles.loginButton}
+            type="button"
+            onClick={() => navigate(ROUTES.LOGIN)}
+          >
+            로그인
+          </button>
+        </p>
+      </form>
+    </main>
+  );
+};
 
 export default SignupPage;

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,6 +1,7 @@
-import type { FormEvent } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
+import { useState } from 'react';
 
-import { useNavigate } from 'react-router';
+import { Link, useNavigate } from 'react-router';
 
 import LogoIcon from '@assets/icons/logo.svg?react';
 
@@ -11,40 +12,77 @@ import { ROUTES } from '@constants/path';
 
 import * as styles from './SignupPage.css';
 
+const INITIAL_SIGNUP_FORM = {
+  organization: '',
+  managerName: '',
+  email: '',
+  password: '',
+  passwordConfirm: '',
+};
+
 const SignupPage = () => {
   const navigate = useNavigate();
+  const [form, setForm] = useState(INITIAL_SIGNUP_FORM);
+
+  const handleChange =
+    (field: keyof typeof INITIAL_SIGNUP_FORM) => (event: ChangeEvent<HTMLInputElement>) => {
+      setForm((prev) => ({ ...prev, [field]: event.target.value }));
+    };
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    // TODO: 회원가입 API 연동 시 form 데이터를 요청 payload로 전달합니다.
     navigate(ROUTES.LOGIN);
   };
 
   return (
     <main className={styles.page}>
       <form className={styles.signupCard} onSubmit={handleSubmit}>
-        <a className={styles.brand} href={`/${ROUTES.LANDING}`} aria-label="SAFE ROUTE 홈">
+        <Link className={styles.brand} to={ROUTES.LANDING} aria-label="SAFE ROUTE 홈">
           <LogoIcon className={styles.logoIcon} />
           <span>SAFE ROUTE</span>
-        </a>
+        </Link>
 
         <h1 className={styles.title}>회원가입</h1>
 
         <div className={styles.fieldGroup}>
-          <TextField label="기관명 *" placeholder="예: 00고등학교" autoComplete="organization" />
-          <TextField label="관리자 이름 *" placeholder="홍길동" autoComplete="name" />
+          <TextField
+            label="기관명 *"
+            placeholder="예: 00고등학교"
+            autoComplete="organization"
+            value={form.organization}
+            onChange={handleChange('organization')}
+          />
+          <TextField
+            label="관리자 이름 *"
+            placeholder="홍길동"
+            autoComplete="name"
+            value={form.managerName}
+            onChange={handleChange('managerName')}
+          />
           <TextField
             label="이메일 *"
             type="email"
             placeholder="admin@example.com"
             autoComplete="email"
+            value={form.email}
+            onChange={handleChange('email')}
           />
           <TextField
             helperText="영문, 숫자, 특수문자 포함 8자 이상"
             label="비밀번호 *"
             type="password"
             autoComplete="new-password"
+            value={form.password}
+            onChange={handleChange('password')}
           />
-          <TextField label="비밀번호 확인 *" type="password" autoComplete="new-password" />
+          <TextField
+            label="비밀번호 확인 *"
+            type="password"
+            autoComplete="new-password"
+            value={form.passwordConfirm}
+            onChange={handleChange('passwordConfirm')}
+          />
         </div>
 
         <Button fullWidth size="lg" type="submit" variant="primary">

--- a/src/pages/signup/SignupPage.tsx
+++ b/src/pages/signup/SignupPage.tsx
@@ -1,0 +1,3 @@
+const SignupPage = () => <>회원가입 페이지</>;
+
+export default SignupPage;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -19,16 +19,16 @@ const router = createBrowserRouter([
     },
   },
   {
+    path: ROUTES.SIGNUP,
+    lazy: async () => {
+      const { default: SignupPage } = await import('@/pages/signup/SignupPage');
+      return { Component: SignupPage };
+    },
+  },
+  {
     path: ROUTES.HOME,
     element: <AppLayout />,
     children: [
-      {
-        path: ROUTES.SIGNUP,
-        lazy: async () => {
-          const { default: SignupPage } = await import('@/pages/signup/SignupPage');
-          return { Component: SignupPage };
-        },
-      },
       {
         path: ROUTES.HOME,
         lazy: async () => {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -12,6 +12,13 @@ const router = createBrowserRouter([
     },
   },
   {
+    path: ROUTES.LOGIN,
+    lazy: async () => {
+      const { default: LoginPage } = await import('@/pages/login/LoginPage');
+      return { Component: LoginPage };
+    },
+  },
+  {
     path: ROUTES.HOME,
     element: <AppLayout />,
     children: [
@@ -20,13 +27,6 @@ const router = createBrowserRouter([
         lazy: async () => {
           const { default: SignupPage } = await import('@/pages/signup/SignupPage');
           return { Component: SignupPage };
-        },
-      },
-      {
-        path: ROUTES.LOGIN,
-        lazy: async () => {
-          const { default: LoginPage } = await import('@/pages/login/LoginPage');
-          return { Component: LoginPage };
         },
       },
       {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -9,6 +9,27 @@ const router = createBrowserRouter([
     element: <AppLayout />,
     children: [
       {
+        path: ROUTES.LANDING,
+        lazy: async () => {
+          const { default: LandingPage } = await import('@/pages/landing/LandingPage');
+          return { Component: LandingPage };
+        },
+      },
+      {
+        path: ROUTES.SIGNUP,
+        lazy: async () => {
+          const { default: SignupPage } = await import('@/pages/signup/SignupPage');
+          return { Component: SignupPage };
+        },
+      },
+      {
+        path: ROUTES.LOGIN,
+        lazy: async () => {
+          const { default: LoginPage } = await import('@/pages/login/LoginPage');
+          return { Component: LoginPage };
+        },
+      },
+      {
         path: ROUTES.HOME,
         lazy: async () => {
           const { default: HomePage } = await import('@/pages/home/HomePage');

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -5,16 +5,16 @@ import { ROUTES } from '@/shared/constants/path';
 
 const router = createBrowserRouter([
   {
+    path: ROUTES.LANDING,
+    lazy: async () => {
+      const { default: LandingPage } = await import('@/pages/landing/LandingPage');
+      return { Component: LandingPage };
+    },
+  },
+  {
     path: ROUTES.HOME,
     element: <AppLayout />,
     children: [
-      {
-        path: ROUTES.LANDING,
-        lazy: async () => {
-          const { default: LandingPage } = await import('@/pages/landing/LandingPage');
-          return { Component: LandingPage };
-        },
-      },
       {
         path: ROUTES.SIGNUP,
         lazy: async () => {

--- a/src/shared/components/gnb/GNB.css.ts
+++ b/src/shared/components/gnb/GNB.css.ts
@@ -59,8 +59,11 @@ export const right = style({
 });
 
 export const profileButton = style({
+  border: 'none',
   borderRadius: vars.radius.md,
+  backgroundColor: 'transparent',
   cursor: 'pointer',
+  padding: 0,
   selectors: {
     '&:focus-visible': {
       outline: `2px solid ${vars.color.primary}`,

--- a/src/shared/components/gnb/GNB.css.ts
+++ b/src/shared/components/gnb/GNB.css.ts
@@ -57,3 +57,14 @@ export const right = style({
   gap: vars.space.s3,
   paddingTop: '0.4rem',
 });
+
+export const profileButton = style({
+  borderRadius: vars.radius.md,
+  cursor: 'pointer',
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${vars.color.primary}`,
+      outlineOffset: '2px',
+    },
+  },
+});

--- a/src/shared/components/gnb/GNB.tsx
+++ b/src/shared/components/gnb/GNB.tsx
@@ -1,4 +1,4 @@
-import type React from 'react';
+import type { ReactNode } from 'react';
 
 import ChevronRightIcon from '@assets/icons/ic-chevron-right.svg?react';
 
@@ -14,12 +14,21 @@ export interface GNBProps {
   breadcrumbs?: BreadcrumbItem[];
   title: string;
   description?: string;
-  userName: string;
+  userName?: string;
   userRole?: string;
-  actions?: React.ReactNode;
+  actions?: ReactNode;
+  onProfileClick?: () => void;
 }
 
-const GNB = ({ breadcrumbs, title, description, userName, userRole, actions }: GNBProps) => (
+const GNB = ({
+  breadcrumbs,
+  title,
+  description,
+  userName = '',
+  userRole,
+  actions,
+  onProfileClick,
+}: GNBProps) => (
   <header className={styles.container}>
     <div className={styles.left}>
       {breadcrumbs && breadcrumbs.length > 0 && (
@@ -42,7 +51,14 @@ const GNB = ({ breadcrumbs, title, description, userName, userRole, actions }: G
 
     <div className={styles.right}>
       {actions}
-      <Avatar name={userName} size="sm" role={userRole} showNameGroup />
+      <button
+        type="button"
+        className={styles.profileButton}
+        aria-label="마이페이지 열기"
+        onClick={onProfileClick}
+      >
+        <Avatar name={userName} size="sm" role={userRole} showNameGroup />
+      </button>
     </div>
   </header>
 );

--- a/src/shared/components/myPageModal/MyPageModal.css.ts
+++ b/src/shared/components/myPageModal/MyPageModal.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s5,
+});

--- a/src/shared/components/myPageModal/MyPageModal.tsx
+++ b/src/shared/components/myPageModal/MyPageModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 
 import { Button } from '@components/Button';
 import TextField from '@components/inputField/TextField';
@@ -6,7 +6,7 @@ import Modal from '@components/modal';
 
 import * as styles from './MyPageModal.css';
 
-interface MyPageForm {
+export interface MyPageForm {
   name: string;
   phone: string;
   email: string;
@@ -17,15 +17,25 @@ export interface MyPageModalProps {
   open: boolean;
   onClose: () => void;
   initialName: string;
+  onSave?: (form: MyPageForm) => void;
 }
 
-const MyPageModal = ({ open, onClose, initialName }: MyPageModalProps) => {
+const getInitialForm = (name: string): MyPageForm => ({
+  name,
+  phone: '010-1234-5678',
+  email: 'hong@example.com',
+  organization: '○○고등학교',
+});
+
+const MyPageModal = ({ open, onClose, initialName, onSave }: MyPageModalProps) => {
   const [form, setForm] = useState<MyPageForm>({
-    name: initialName,
-    phone: '010-1234-5678',
-    email: 'hong@example.com',
-    organization: '○○고등학교',
+    ...getInitialForm(initialName),
   });
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(getInitialForm(initialName));
+  }, [initialName, open]);
 
   const handleChange = (field: keyof MyPageForm) => (event: ChangeEvent<HTMLInputElement>) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
@@ -33,6 +43,7 @@ const MyPageModal = ({ open, onClose, initialName }: MyPageModalProps) => {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    onSave?.(form);
     onClose();
   };
 

--- a/src/shared/components/myPageModal/MyPageModal.tsx
+++ b/src/shared/components/myPageModal/MyPageModal.tsx
@@ -1,0 +1,70 @@
+import { useState, type ChangeEvent, type FormEvent } from 'react';
+
+import { Button } from '@components/Button';
+import TextField from '@components/inputField/TextField';
+import Modal from '@components/modal';
+
+import * as styles from './MyPageModal.css';
+
+interface MyPageForm {
+  name: string;
+  phone: string;
+  email: string;
+  organization: string;
+}
+
+export interface MyPageModalProps {
+  open: boolean;
+  onClose: () => void;
+  initialName: string;
+}
+
+const MyPageModal = ({ open, onClose, initialName }: MyPageModalProps) => {
+  const [form, setForm] = useState<MyPageForm>({
+    name: initialName,
+    phone: '010-1234-5678',
+    email: 'hong@example.com',
+    organization: '○○고등학교',
+  });
+
+  const handleChange = (field: keyof MyPageForm) => (event: ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      size="md"
+      title="마이페이지"
+      footer={
+        <>
+          <Button fullWidth size="lg" type="button" variant="ghost" onClick={onClose}>
+            취소
+          </Button>
+          <Button fullWidth size="lg" type="submit" form="my-page-form">
+            저장
+          </Button>
+        </>
+      }
+      onClose={onClose}
+    >
+      <form className={styles.form} id="my-page-form" onSubmit={handleSubmit}>
+        <TextField label="이름" value={form.name} onChange={handleChange('name')} />
+        <TextField label="전화번호" value={form.phone} onChange={handleChange('phone')} />
+        <TextField label="이메일주소" value={form.email} onChange={handleChange('email')} />
+        <TextField
+          label="기관명"
+          value={form.organization}
+          onChange={handleChange('organization')}
+        />
+      </form>
+    </Modal>
+  );
+};
+
+export default MyPageModal;

--- a/src/shared/constants/gnbConfig.ts
+++ b/src/shared/constants/gnbConfig.ts
@@ -1,0 +1,81 @@
+import { matchPath, type Location } from 'react-router';
+
+import type { GNBProps } from '@components/gnb/GNB';
+
+import { ROUTES } from '@constants/path';
+
+type GNBConfig = Pick<GNBProps, 'breadcrumbs' | 'title' | 'description'>;
+
+const gnbConfigs: Array<{ path: string; config: GNBConfig }> = [
+  {
+    path: ROUTES.HOME,
+    config: {
+      title: '홈',
+      description: '화재 대피 훈련 현황을 한눈에 확인하세요.',
+    },
+  },
+  {
+    path: ROUTES.SCENARIO_SETTINGS,
+    config: {
+      title: '훈련 관리',
+      description: '화재 발생 위치와 조건을 설정하고 시나리오를 시작합니다',
+    },
+  },
+  {
+    path: ROUTES.BUILDINGS,
+    config: {
+      breadcrumbs: [{ label: '훈련 관리' }],
+      title: '건물 관리',
+      description: '등록된 건물과 시설을 관리합니다',
+    },
+  },
+  {
+    path: ROUTES.FLOOR_PLANS,
+    config: {
+      breadcrumbs: [{ label: '관리' }],
+      title: '도면 관리',
+      description: '등록된 건물별 도면을 확인하고 관리할 수 있습니다',
+    },
+  },
+  {
+    path: ROUTES.FLOOR_PLANS_DETAIL,
+    config: {
+      breadcrumbs: [{ label: '관리' }, { label: '도면 관리' }],
+      title: '도면 관리 상세',
+      description: '층별 도면을 확인하고 관리합니다',
+    },
+  },
+  {
+    path: ROUTES.CAMERAS,
+    config: {
+      breadcrumbs: [{ label: '관리' }],
+      title: '카메라 관리',
+      description: 'CCTV 카메라 등록 및 설정 관리',
+    },
+  },
+  {
+    path: ROUTES.TRAINING_ANALYSIS,
+    config: {
+      title: '훈련 분석',
+      description: '훈련 결과와 주요 지표를 분석합니다',
+    },
+  },
+  {
+    path: ROUTES.REPORTS,
+    config: {
+      title: '분석 보고서',
+      description: '훈련 분석 보고서를 확인합니다',
+    },
+  },
+  {
+    path: ROUTES.MANAGEMENT,
+    config: {
+      title: '관리',
+      description: '시스템 관리 항목을 확인합니다',
+    },
+  },
+];
+
+export const getGNBConfig = (location: Location): GNBConfig =>
+  gnbConfigs.find(({ path }) => matchPath({ path, end: true }, location.pathname))?.config ??
+  gnbConfigs[0].config;

--- a/src/shared/constants/gnbConfig.ts
+++ b/src/shared/constants/gnbConfig.ts
@@ -6,7 +6,12 @@ import { ROUTES } from '@constants/path';
 
 type GNBConfig = Pick<GNBProps, 'breadcrumbs' | 'title' | 'description'>;
 
-const gnbConfigs: Array<{ path: string; config: GNBConfig }> = [
+const DEFAULT_GNB_CONFIG = {
+  title: 'SAFE ROUTE',
+  description: '안전 관리 시스템',
+} as const satisfies GNBConfig;
+
+const GNB_CONFIGS = [
   {
     path: ROUTES.HOME,
     config: {
@@ -74,8 +79,8 @@ const gnbConfigs: Array<{ path: string; config: GNBConfig }> = [
       description: '시스템 관리 항목을 확인합니다',
     },
   },
-];
+] as const satisfies readonly { path: string; config: GNBConfig }[];
 
 export const getGNBConfig = (location: Location): GNBConfig =>
-  gnbConfigs.find(({ path }) => matchPath({ path, end: true }, location.pathname))?.config ??
-  gnbConfigs[0].config;
+  GNB_CONFIGS.find(({ path }) => matchPath({ path, end: true }, location.pathname))?.config ??
+  DEFAULT_GNB_CONFIG;

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -2,7 +2,7 @@ export const ROUTES = {
   HOME: '/',
   LOGIN: '/login',
   SIGNUP: '/signup',
-  LANDING: 'landing',
+  LANDING: '/landing',
   SCENARIO_SETTINGS: '/scenarioSettings',
   MANAGEMENT: '/management',
   BUILDINGS: '/buildings',

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -1,5 +1,8 @@
 export const ROUTES = {
   HOME: '/',
+  LOGIN: '/login',
+  SIGNUP: '/signup',
+  LANDING: 'landing',
   SCENARIO_SETTINGS: '/scenarioSettings',
   MANAGEMENT: '/management',
   BUILDINGS: '/buildings',

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -48,6 +48,9 @@ export const vars = createGlobalTheme(':root', {
   fontFamily: {
     base: baseFontFamily,
   },
+  gradient: {
+    landing: 'linear-gradient(180deg, #EFF6FF 0%, #FFFFFF 27%, #FFFFFF 100%)',
+  },
   fontWeight: {
     bold: '700',
     medium: '500',

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -77,8 +77,13 @@ export const vars = createGlobalTheme(':root', {
     s4: '1.6rem',
     s5: '2rem',
     s6: '2.4rem',
+    s7: '2.8rem',
     s8: '3.2rem',
     s12: '4.8rem',
+    s14: '5.6rem',
+    s15: '6rem',
+    s18: '7.2rem',
+    s20: '8rem',
   },
   typography: {
     body14Bold: {
@@ -106,6 +111,13 @@ export const vars = createGlobalTheme(':root', {
       fontFamily: baseFontFamily,
       fontSize: '1.6rem',
       fontWeight: '400',
+      letterSpacing: '-0.02em',
+      lineHeight: '1.5',
+    },
+    body16Bold: {
+      fontFamily: baseFontFamily,
+      fontSize: '1.6rem',
+      fontWeight: '700',
       letterSpacing: '-0.02em',
       lineHeight: '1.5',
     },
@@ -143,6 +155,13 @@ export const vars = createGlobalTheme(':root', {
       fontWeight: '700',
       letterSpacing: '-0.02em',
       lineHeight: '1.25',
+    },
+    h1Landing: {
+      fontFamily: baseFontFamily,
+      fontSize: 'clamp(4rem, 4vw, 5.8rem)',
+      fontWeight: '700',
+      letterSpacing: '-0.02em',
+      lineHeight: '1.16',
     },
     h2: {
       fontFamily: baseFontFamily,


### PR DESCRIPTION
## 📌 Summary
- 로그인 및 회원가입 페이지 UI 구현
- 마이페이지 모달 UI 구현 및 GNB를 AppLayout에 배치하도록 수정
- 랜딩 페이지 UI 구현

## 🔗 관련 이슈

closes #32 

## 📋 작업 내용
#### 랜딩페이지 
- `gradient` 컬러 토큰 추가
- 원래 수치와 관련된 내용이 있었는데, 이 부분은 정보 전달에 있어서 문제가 있을 수 있어 제거
- header에 navigation 제거
- 공개 라우트로 분리하여 사이드바 없이 렌더링되도록 수정


#### 로그인 및 회원가입 페이지
- 공통 TextField, Button 컴포넌트를 활용해 입력 폼 구성
- 공개 라우트로 분리
- 회원가입 페이지가 기존 피그마에서 모달 형태로 구현되어있었는데 일반 페이지 형태로 변경했습니다. 백엔드에 회원가입 api는 명세가 아직 없어 변경될 수도 있을 것 같습니다. 

#### 마이페이지 모달 UI
- 기존 공통 Modal 컴포넌트를 재사용해 마이페이지 폼 모달 구성


#### GNB 구조를 AppLayout 중심으로 수정
- 각 페이지에서 개별 렌더링하던 GNB를 AppLayout에서 공통 렌더링하도록 변경
- route별 GNB title, breadcrumbs, description을 `gnbConfig`로 분리
- GNB 프로필 영역 클릭 시 AppLayout에서 마이페이지 모달이 열리도록 연결
- 각 페이지 내부의 중복 GNB 사용 제거

## 🔍 To Reviewer
- gnb를 레이아웃에 포함시키면서 각 페이지에 연결된 컴포넌트는 제거했으니 이 부분 확인 부탁드립니다!


<!-- 리뷰어에게 요청하는 내용 -->

## 📸 스크린샷
<img width="1512" height="752" alt="image" src="https://github.com/user-attachments/assets/f4437c26-ca3f-43a6-a86d-e7eda3534503" />
<img width="1512" height="755" alt="image" src="https://github.com/user-attachments/assets/8cb70b55-c3dc-4fb8-851a-5df8e5ff61d2" />
<img width="1512" height="756" alt="image" src="https://github.com/user-attachments/assets/cd7ffdca-9f95-448f-aaec-10aec87c425d" />
<img width="1274" height="751" alt="image" src="https://github.com/user-attachments/assets/46dcbdde-e55e-4509-bd9e-6eeefc8e19a8" />



<!-- UI 변경 시 첨부 -->

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
