### PR TITLE
[feat] 분석 보고서 페이지 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^18.3.1",
     "react-router": "^7.15.1",
     "react-router-dom": "^7.15.1",
+    "recharts": "^3.9.0",
     "vite-plugin-svgr": "^5.2.0",
     "zustand": "^5.0.13"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,12 +41,15 @@ importers:
       react-router-dom:
         specifier: ^7.15.1
         version: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^3.9.0
+        version: 3.9.0(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1)
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.4)(typescript@5.6.3)(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0))
       zustand:
         specifier: ^5.0.13
-        version: 5.0.13(@types/react@18.3.29)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
+        version: 5.0.13(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@antebudimir/eslint-plugin-vanilla-extract':
         specifier: ^1.16.0
@@ -829,6 +832,17 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -971,6 +985,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-a11y@10.4.1':
     resolution: {integrity: sha512-MGft/IXjJ20a9KbaSVG9bHTAAoanbucKrgEiJJRNqpim8DsXA01+XTdSk17LmiOCB203Rrq9mWgdQ6+79cc8iA==}
@@ -1228,6 +1245,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1277,6 +1321,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.59.4':
     resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
@@ -1733,6 +1780,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -1764,6 +1855,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
@@ -2283,6 +2377,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2298,6 +2398,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2941,6 +3045,18 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -2974,9 +3090,25 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  recharts@3.9.0:
+    resolution: {integrity: sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2999,6 +3131,9 @@ packages:
 
   require-like@0.1.2:
     resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -3421,6 +3556,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -4173,6 +4311,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
@@ -4261,6 +4411,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@10.4.1(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@18.3.29)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
@@ -4561,6 +4713,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -4602,6 +4778,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.6.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.6.3)':
     dependencies:
@@ -5201,6 +5379,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -5228,6 +5444,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   dedent@1.7.2: {}
 
@@ -5785,6 +6003,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5799,6 +6021,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -6489,6 +6713,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      redux: 5.0.1
+
   react-refresh@0.17.0: {}
 
   react-router-dom@7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -6519,10 +6752,36 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  recharts@3.9.0(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+      react-redux: 9.3.0(@types/react@18.3.29)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -6551,6 +6810,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-like@0.1.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -7079,6 +7340,23 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-node@3.2.4(@types/node@25.9.1)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
@@ -7265,8 +7543,9 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  zustand@5.0.13(@types/react@18.3.29)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+  zustand@5.0.13(@types/react@18.3.29)(immer@11.1.8)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.29
+      immer: 11.1.8
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)

--- a/src/pages/reports/ReportsPage.css.ts
+++ b/src/pages/reports/ReportsPage.css.ts
@@ -11,12 +11,12 @@ export const container = style({
 
 export const topGrid = style({
   display: 'grid',
-  gridTemplateColumns: '38.4rem minmax(0, 1fr)',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 38.4rem), 1fr))',
   gap: vars.space.s5,
 });
 
 export const bottomGrid = style({
   display: 'grid',
-  gridTemplateColumns: 'minmax(0, 1fr) 43rem',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 43rem), 1fr))',
   gap: vars.space.s5,
 });

--- a/src/pages/reports/ReportsPage.css.ts
+++ b/src/pages/reports/ReportsPage.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s5,
+  padding: vars.space.s6,
+});
+
+export const topGrid = style({
+  display: 'grid',
+  gridTemplateColumns: '38.4rem minmax(0, 1fr)',
+  gap: vars.space.s5,
+});
+
+export const bottomGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'minmax(0, 1fr) 43rem',
+  gap: vars.space.s5,
+});

--- a/src/pages/reports/ReportsPage.tsx
+++ b/src/pages/reports/ReportsPage.tsx
@@ -1,3 +1,37 @@
-const ReportsPage = () => <>분석 보고서 페이지</>;
+import AiReportCard from './components/card/AiReportCard';
+import GradeSummaryCard from './components/card/GradeSummaryCard';
+import RecommendationsCard from './components/card/RecommendationsCard';
+import ScoreBreakdownCard from './components/card/ScoreBreakdownCard';
+import ReportCharts from './components/chart/ReportCharts';
+import {
+  densityByZone,
+  evacuationAccumulation,
+  recentEvacuationTimes,
+  recommendations,
+  reportNarrative,
+  reportScores,
+  reportSummary,
+} from './mocks/reportData';
+import * as styles from './ReportsPage.css';
+
+const ReportsPage = () => (
+  <div className={styles.container}>
+    <div className={styles.topGrid}>
+      <GradeSummaryCard summary={reportSummary} />
+      <ScoreBreakdownCard scores={reportScores} />
+    </div>
+
+    <ReportCharts
+      evacuationAccumulation={evacuationAccumulation}
+      densityByZone={densityByZone}
+      recentEvacuationTimes={recentEvacuationTimes}
+    />
+
+    <div className={styles.bottomGrid}>
+      <AiReportCard narrative={reportNarrative} />
+      <RecommendationsCard items={recommendations} />
+    </div>
+  </div>
+);
 
 export default ReportsPage;

--- a/src/pages/reports/components/card/AiReportCard.css.ts
+++ b/src/pages/reports/components/card/AiReportCard.css.ts
@@ -1,0 +1,62 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+import { paddedCard } from './ReportCard.css';
+
+export const card = style([
+  paddedCard,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: vars.space.s5,
+  },
+]);
+
+export const header = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s4,
+});
+
+export const titleGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
+export const iconBox = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '2.4rem',
+  height: '2.4rem',
+  color: vars.color.primary,
+});
+
+export const title = style({
+  color: vars.color.textHigh,
+  ...vars.typography.h4,
+});
+
+export const body = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s4,
+  color: vars.color.textMid,
+  ...vars.typography.body16,
+});
+
+export const paragraphLabel = style({
+  color: vars.color.textHigh,
+  fontWeight: vars.fontWeight.bold,
+});
+
+export const successText = style({
+  color: vars.color.success,
+});
+
+export const warningText = style({
+  color: vars.color.warning,
+});

--- a/src/pages/reports/components/card/AiReportCard.tsx
+++ b/src/pages/reports/components/card/AiReportCard.tsx
@@ -1,0 +1,42 @@
+import SparklesIcon from '@assets/icons/ic-sparkles.svg?react';
+
+import StatusBadge from '@components/chip/StatusBadge';
+
+import * as styles from './AiReportCard.css';
+
+import type { ReportNarrative } from '../../types/report';
+
+interface AiReportCardProps {
+  narrative: ReportNarrative;
+}
+
+const AiReportCard = ({ narrative }: AiReportCardProps) => (
+  <section className={styles.card}>
+    <div className={styles.header}>
+      <div className={styles.titleGroup}>
+        <SparklesIcon className={styles.iconBox} aria-hidden="true" focusable="false" />
+        <h2 className={styles.title}>AI 자동 평가 보고서</h2>
+      </div>
+      <StatusBadge label="Claude · 자동 생성" color="blue" />
+    </div>
+
+    <div className={styles.body}>
+      <p>
+        {narrative.headlinePrefix} <span className={styles.successText}>{narrative.grade}</span>
+        {narrative.headlineSuffix}
+      </p>
+      <p>
+        <span className={styles.paragraphLabel}>강점: </span>
+        {narrative.strength}
+      </p>
+      <p>
+        <span className={styles.paragraphLabel}>개선: </span>
+        {narrative.improvementPrefix}{' '}
+        <span className={styles.warningText}>{narrative.improvementScore}</span>
+        {narrative.improvementSuffix}
+      </p>
+    </div>
+  </section>
+);
+
+export default AiReportCard;

--- a/src/pages/reports/components/card/GradeSummaryCard.css.ts
+++ b/src/pages/reports/components/card/GradeSummaryCard.css.ts
@@ -1,0 +1,53 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+import { card } from './ReportCard.css';
+
+export const gradeCard = style([
+  card,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    background: vars.gradient.reportGrade,
+    padding: vars.space.s7,
+    minHeight: '29rem',
+    color: vars.color.textInverse,
+  },
+]);
+
+export const eyebrow = style({
+  color: vars.color.textInverseMid,
+  ...vars.typography.captionMedium,
+});
+
+export const grade = style({
+  marginTop: vars.space.s1,
+  color: vars.color.textInverse,
+  ...vars.typography.reportGrade,
+});
+
+export const summary = style({
+  marginTop: vars.space.s3,
+  color: vars.color.textInverseHigh,
+  ...vars.typography.body16,
+});
+
+export const metricRow = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  gap: vars.space.s6,
+});
+
+export const metricLabel = style({
+  display: 'block',
+  marginBottom: vars.space.s1,
+  color: vars.color.textInverseLow,
+  ...vars.typography.body14,
+});
+
+export const metricValue = style({
+  color: vars.color.textInverse,
+  ...vars.typography.body16Bold,
+});

--- a/src/pages/reports/components/card/GradeSummaryCard.tsx
+++ b/src/pages/reports/components/card/GradeSummaryCard.tsx
@@ -1,10 +1,18 @@
 import * as styles from './GradeSummaryCard.css';
 
-import type { ReportSummary } from '../../types/report';
+import type { ReportDelta, ReportSummary } from '../../types/report';
 
 interface GradeSummaryCardProps {
   summary: ReportSummary;
 }
+
+const deltaArrow: Record<ReportDelta['direction'], string> = {
+  down: '↓',
+  flat: '-',
+  up: '↑',
+};
+
+const formatDelta = (delta: ReportDelta) => `${delta.value} ${deltaArrow[delta.direction]}`;
 
 const GradeSummaryCard = ({ summary }: GradeSummaryCardProps) => (
   <section className={styles.gradeCard} aria-label="종합 평가 등급">
@@ -19,11 +27,11 @@ const GradeSummaryCard = ({ summary }: GradeSummaryCardProps) => (
     <div className={styles.metricRow}>
       <p>
         <span className={styles.metricLabel}>이전 회차 대비</span>
-        <strong className={styles.metricValue}>{summary.previousDelta} ↑</strong>
+        <strong className={styles.metricValue}>{formatDelta(summary.previousDelta)}</strong>
       </p>
       <p>
         <span className={styles.metricLabel}>전국 평균 대비</span>
-        <strong className={styles.metricValue}>{summary.nationalDelta} ↑</strong>
+        <strong className={styles.metricValue}>{formatDelta(summary.nationalDelta)}</strong>
       </p>
     </div>
   </section>

--- a/src/pages/reports/components/card/GradeSummaryCard.tsx
+++ b/src/pages/reports/components/card/GradeSummaryCard.tsx
@@ -1,0 +1,32 @@
+import * as styles from './GradeSummaryCard.css';
+
+import type { ReportSummary } from '../../types/report';
+
+interface GradeSummaryCardProps {
+  summary: ReportSummary;
+}
+
+const GradeSummaryCard = ({ summary }: GradeSummaryCardProps) => (
+  <section className={styles.gradeCard} aria-label="종합 평가 등급">
+    <div>
+      <p className={styles.eyebrow}>OVERALL GRADE</p>
+      <strong className={styles.grade}>{summary.grade}</strong>
+      <p className={styles.summary}>
+        {summary.scoreText} · {summary.percentileText}
+      </p>
+    </div>
+
+    <div className={styles.metricRow}>
+      <p>
+        <span className={styles.metricLabel}>이전 회차 대비</span>
+        <strong className={styles.metricValue}>{summary.previousDelta} ↑</strong>
+      </p>
+      <p>
+        <span className={styles.metricLabel}>전국 평균 대비</span>
+        <strong className={styles.metricValue}>{summary.nationalDelta} ↑</strong>
+      </p>
+    </div>
+  </section>
+);
+
+export default GradeSummaryCard;

--- a/src/pages/reports/components/card/RecommendationsCard.css.ts
+++ b/src/pages/reports/components/card/RecommendationsCard.css.ts
@@ -1,0 +1,58 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+import { paddedCard } from './ReportCard.css';
+
+export const card = style([
+  paddedCard,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: vars.space.s5,
+  },
+]);
+
+export const title = style({
+  color: vars.color.textHigh,
+  ...vars.typography.body16Bold,
+});
+
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+export const item = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s2,
+  borderTop: `1px solid ${vars.color.gray100}`,
+  padding: `${vars.space.s4} 0`,
+
+  selectors: {
+    '&:first-child': {
+      borderTop: 'none',
+      paddingTop: 0,
+    },
+    '&:last-child': {
+      paddingBottom: 0,
+    },
+  },
+});
+
+export const itemHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
+export const itemTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.body14Bold,
+});
+
+export const description = style({
+  color: vars.color.textMid,
+  ...vars.typography.body14,
+});

--- a/src/pages/reports/components/card/RecommendationsCard.tsx
+++ b/src/pages/reports/components/card/RecommendationsCard.tsx
@@ -1,0 +1,41 @@
+import StatusBadge from '@components/chip/StatusBadge';
+import type { StatusBadgeColor } from '@components/chip/StatusBadge';
+
+import * as styles from './RecommendationsCard.css';
+
+import type { RecommendationItem } from '../../types/report';
+
+const priorityLabels: Record<RecommendationItem['level'], string> = {
+  high: '높음',
+  medium: '중간',
+  low: '낮음',
+};
+
+const priorityColors: Record<RecommendationItem['level'], StatusBadgeColor> = {
+  high: 'red',
+  medium: 'yellow',
+  low: 'blue',
+};
+
+interface RecommendationsCardProps {
+  items: RecommendationItem[];
+}
+
+const RecommendationsCard = ({ items }: RecommendationsCardProps) => (
+  <section className={styles.card}>
+    <h2 className={styles.title}>개선 권고사항</h2>
+    <ul className={styles.list}>
+      {items.map((item) => (
+        <li key={item.title} className={styles.item}>
+          <div className={styles.itemHeader}>
+            <StatusBadge label={priorityLabels[item.level]} color={priorityColors[item.level]} />
+            <strong className={styles.itemTitle}>{item.title}</strong>
+          </div>
+          <p className={styles.description}>{item.description}</p>
+        </li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default RecommendationsCard;

--- a/src/pages/reports/components/card/RecommendationsCard.tsx
+++ b/src/pages/reports/components/card/RecommendationsCard.tsx
@@ -5,17 +5,17 @@ import * as styles from './RecommendationsCard.css';
 
 import type { RecommendationItem } from '../../types/report';
 
-const priorityLabels: Record<RecommendationItem['level'], string> = {
+const priorityLabels = {
   high: '높음',
   medium: '중간',
   low: '낮음',
-};
+} as const satisfies Record<RecommendationItem['level'], string>;
 
-const priorityColors: Record<RecommendationItem['level'], StatusBadgeColor> = {
+const priorityColors = {
   high: 'red',
   medium: 'yellow',
   low: 'blue',
-};
+} as const satisfies Record<RecommendationItem['level'], StatusBadgeColor>;
 
 interface RecommendationsCardProps {
   items: RecommendationItem[];
@@ -26,7 +26,7 @@ const RecommendationsCard = ({ items }: RecommendationsCardProps) => (
     <h2 className={styles.title}>개선 권고사항</h2>
     <ul className={styles.list}>
       {items.map((item) => (
-        <li key={item.title} className={styles.item}>
+        <li key={item.id} className={styles.item}>
           <div className={styles.itemHeader}>
             <StatusBadge label={priorityLabels[item.level]} color={priorityColors[item.level]} />
             <strong className={styles.itemTitle}>{item.title}</strong>

--- a/src/pages/reports/components/card/ReportCard.css.ts
+++ b/src/pages/reports/components/card/ReportCard.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const card = style({
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.lg,
+  boxShadow: vars.shadow.card,
+  backgroundColor: vars.color.white,
+});
+
+export const paddedCard = style([
+  card,
+  {
+    padding: vars.space.s6,
+  },
+]);
+
+export const cardTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.body16Bold,
+});

--- a/src/pages/reports/components/card/ReportCard.tsx
+++ b/src/pages/reports/components/card/ReportCard.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+import * as styles from './ReportCard.css';
+
+interface ReportCardProps {
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+const ReportCard = ({ title, className, children }: ReportCardProps) => (
+  <section className={[styles.paddedCard, className].filter(Boolean).join(' ')}>
+    {title && <h2 className={styles.cardTitle}>{title}</h2>}
+    {children}
+  </section>
+);
+
+export default ReportCard;

--- a/src/pages/reports/components/card/ReportCard.tsx
+++ b/src/pages/reports/components/card/ReportCard.tsx
@@ -9,7 +9,7 @@ interface ReportCardProps {
 }
 
 const ReportCard = ({ title, className, children }: ReportCardProps) => (
-  <section className={[styles.paddedCard, className].filter(Boolean).join(' ')}>
+  <section className={[styles.card, className].filter(Boolean).join(' ')}>
     {title && <h2 className={styles.cardTitle}>{title}</h2>}
     {children}
   </section>

--- a/src/pages/reports/components/card/ScoreBreakdownCard.css.ts
+++ b/src/pages/reports/components/card/ScoreBreakdownCard.css.ts
@@ -1,0 +1,67 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const scoreCard = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s6,
+});
+
+export const scoreList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s4,
+});
+
+export const scoreHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s4,
+  marginBottom: vars.space.s1,
+});
+
+export const scoreLabel = style({
+  color: vars.color.textMid,
+  ...vars.typography.body14Medium,
+});
+
+export const weight = style({
+  color: vars.color.textLow,
+  fontWeight: vars.fontWeight.regular,
+});
+
+export const value = style({
+  display: 'inline-flex',
+  alignItems: 'baseline',
+  gap: vars.space.s2,
+  color: vars.color.textHigh,
+  ...vars.typography.body14Bold,
+});
+
+export const denominator = style({
+  color: vars.color.textLow,
+  ...vars.typography.body14Medium,
+});
+
+export const track = style({
+  borderRadius: vars.radius.pill,
+  backgroundColor: vars.color.gray50,
+  height: '0.7rem',
+  overflow: 'hidden',
+});
+
+export const barBase = style({
+  borderRadius: vars.radius.pill,
+  height: '100%',
+});
+
+export const barColor = styleVariants({
+  primary: {
+    backgroundColor: vars.color.primary,
+  },
+  success: {
+    backgroundColor: vars.color.success,
+  },
+});

--- a/src/pages/reports/components/card/ScoreBreakdownCard.css.ts
+++ b/src/pages/reports/components/card/ScoreBreakdownCard.css.ts
@@ -6,6 +6,7 @@ export const scoreCard = style({
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s6,
+  padding: vars.space.s6,
 });
 
 export const scoreList = style({

--- a/src/pages/reports/components/card/ScoreBreakdownCard.tsx
+++ b/src/pages/reports/components/card/ScoreBreakdownCard.tsx
@@ -1,0 +1,36 @@
+import ReportCard from './ReportCard';
+import * as styles from './ScoreBreakdownCard.css';
+
+import type { ReportScoreItem } from '../../types/report';
+
+interface ScoreBreakdownCardProps {
+  scores: ReportScoreItem[];
+}
+
+const ScoreBreakdownCard = ({ scores }: ScoreBreakdownCardProps) => (
+  <ReportCard title="평가 항목별 점수" className={styles.scoreCard}>
+    <ul className={styles.scoreList}>
+      {scores.map((item) => (
+        <li key={item.label}>
+          <div className={styles.scoreHeader}>
+            <span className={styles.scoreLabel}>
+              {item.label} <span className={styles.weight}>({item.weight})</span>
+            </span>
+            <strong className={styles.value}>
+              {item.score}
+              <span className={styles.denominator}>/ 100</span>
+            </strong>
+          </div>
+          <div className={styles.track} aria-hidden="true">
+            <div
+              className={[styles.barBase, styles.barColor[item.color]].join(' ')}
+              style={{ width: `${item.score}%` }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  </ReportCard>
+);
+
+export default ScoreBreakdownCard;

--- a/src/pages/reports/components/card/ScoreBreakdownCard.tsx
+++ b/src/pages/reports/components/card/ScoreBreakdownCard.tsx
@@ -7,28 +7,34 @@ interface ScoreBreakdownCardProps {
   scores: ReportScoreItem[];
 }
 
+const clampScore = (score: number) => Math.min(100, Math.max(0, score));
+
 const ScoreBreakdownCard = ({ scores }: ScoreBreakdownCardProps) => (
   <ReportCard title="평가 항목별 점수" className={styles.scoreCard}>
     <ul className={styles.scoreList}>
-      {scores.map((item) => (
-        <li key={item.label}>
-          <div className={styles.scoreHeader}>
-            <span className={styles.scoreLabel}>
-              {item.label} <span className={styles.weight}>({item.weight})</span>
-            </span>
-            <strong className={styles.value}>
-              {item.score}
-              <span className={styles.denominator}>/ 100</span>
-            </strong>
-          </div>
-          <div className={styles.track} aria-hidden="true">
-            <div
-              className={[styles.barBase, styles.barColor[item.color]].join(' ')}
-              style={{ width: `${item.score}%` }}
-            />
-          </div>
-        </li>
-      ))}
+      {scores.map((item) => {
+        const scoreWidth = clampScore(item.score);
+
+        return (
+          <li key={item.label}>
+            <div className={styles.scoreHeader}>
+              <span className={styles.scoreLabel}>
+                {item.label} <span className={styles.weight}>({item.weight})</span>
+              </span>
+              <strong className={styles.value}>
+                {item.score}
+                <span className={styles.denominator}>/ 100</span>
+              </strong>
+            </div>
+            <div className={styles.track} aria-hidden="true">
+              <div
+                className={[styles.barBase, styles.barColor[item.color]].join(' ')}
+                style={{ width: `${scoreWidth}%` }}
+              />
+            </div>
+          </li>
+        );
+      })}
     </ul>
   </ReportCard>
 );

--- a/src/pages/reports/components/chart/ReportCharts.css.ts
+++ b/src/pages/reports/components/chart/ReportCharts.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+import { paddedCard } from '../card/ReportCard.css';
+
+export const chartGrid = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  gap: vars.space.s5,
+});
+
+export const chartCard = style([
+  paddedCard,
+  {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: vars.space.s6,
+    minHeight: '24rem',
+  },
+]);
+
+export const chartTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.body16Bold,
+});
+
+export const chartBody = style({
+  flex: 1,
+  minHeight: '18rem',
+});

--- a/src/pages/reports/components/chart/ReportCharts.css.ts
+++ b/src/pages/reports/components/chart/ReportCharts.css.ts
@@ -6,7 +6,7 @@ import { paddedCard } from '../card/ReportCard.css';
 
 export const chartGrid = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 32rem), 1fr))',
   gap: vars.space.s5,
 });
 

--- a/src/pages/reports/components/chart/ReportCharts.tsx
+++ b/src/pages/reports/components/chart/ReportCharts.tsx
@@ -1,0 +1,138 @@
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  LabelList,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  XAxis,
+} from 'recharts';
+
+import { vars } from '@styles/global.css';
+
+import * as styles from './ReportCharts.css';
+
+import type { DensityItem, TrendPoint } from '../../types/report';
+
+interface ReportChartsProps {
+  evacuationAccumulation: TrendPoint[];
+  densityByZone: DensityItem[];
+  recentEvacuationTimes: TrendPoint[];
+}
+
+const densityColors: Record<DensityItem['level'], string> = {
+  high: vars.color.danger,
+  medium: vars.color.warning,
+  low: vars.color.success,
+};
+
+const CHART_MARGIN = { top: 16, right: 16, bottom: 8, left: 16 };
+const CHART_STROKE_WIDTH = 3;
+const BAR_SIZE = 40;
+const BAR_RADIUS: [number, number, number, number] = [6, 6, 0, 0];
+const DOT_STYLE = {
+  fill: vars.color.success,
+  r: 4,
+  strokeWidth: 0,
+};
+
+const axisTick = {
+  fill: vars.color.textLow,
+  fontFamily: vars.fontFamily.base,
+  fontSize: vars.typography.caption.fontSize,
+};
+
+const axisTickStrong = {
+  ...axisTick,
+  fill: vars.color.textMid,
+};
+
+const labelText = {
+  fill: vars.color.textHigh,
+  fontFamily: vars.fontFamily.base,
+  fontSize: vars.typography.caption.fontSize,
+  fontWeight: vars.fontWeight.bold,
+};
+
+const ReportCharts = ({
+  evacuationAccumulation,
+  densityByZone,
+  recentEvacuationTimes,
+}: ReportChartsProps) => (
+  <div className={styles.chartGrid}>
+    <section className={styles.chartCard}>
+      <h2 className={styles.chartTitle}>대피 인원 누적</h2>
+      <div className={styles.chartBody}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart data={evacuationAccumulation} margin={CHART_MARGIN}>
+            <CartesianGrid vertical={false} stroke={vars.color.gray100} />
+            <XAxis
+              dataKey="label"
+              axisLine={false}
+              tickLine={false}
+              tick={axisTick}
+              interval="preserveStartEnd"
+            />
+            <Area
+              type="monotone"
+              dataKey="value"
+              stroke={vars.color.primary}
+              strokeWidth={CHART_STROKE_WIDTH}
+              fill={vars.color.primaryLight}
+              fillOpacity={0.72}
+              dot={false}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+
+    <section className={styles.chartCard}>
+      <h2 className={styles.chartTitle}>구역별 평균 밀집도</h2>
+      <div className={styles.chartBody}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={densityByZone} margin={CHART_MARGIN}>
+            <XAxis dataKey="label" axisLine={false} tickLine={false} tick={axisTickStrong} />
+            <Bar dataKey="value" radius={BAR_RADIUS} barSize={BAR_SIZE}>
+              <LabelList
+                dataKey="value"
+                position="top"
+                formatter={(value) => `${value}%`}
+                {...labelText}
+              />
+              {densityByZone.map((item) => (
+                <Cell key={item.label} fill={densityColors[item.level]} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+
+    <section className={styles.chartCard}>
+      <h2 className={styles.chartTitle}>최근 5회 대피 시간</h2>
+      <div className={styles.chartBody}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={recentEvacuationTimes} margin={CHART_MARGIN}>
+            <CartesianGrid vertical={false} stroke={vars.color.gray100} />
+            <XAxis dataKey="label" axisLine={false} tickLine={false} tick={axisTick} />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={vars.color.success}
+              strokeWidth={CHART_STROKE_WIDTH}
+              dot={DOT_STYLE}
+              activeDot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  </div>
+);
+
+export default ReportCharts;

--- a/src/pages/reports/mocks/reportData.ts
+++ b/src/pages/reports/mocks/reportData.ts
@@ -1,0 +1,82 @@
+import type {
+  DensityItem,
+  RecommendationItem,
+  ReportNarrative,
+  ReportScoreItem,
+  ReportSummary,
+  TrendPoint,
+} from '../types/report';
+
+export const reportSummary: ReportSummary = {
+  grade: 'A',
+  scoreText: '92.4 / 100점',
+  percentileText: '상위 12%',
+  previousDelta: '+4.2점',
+  nationalDelta: '+8.1점',
+};
+
+export const reportScores: ReportScoreItem[] = [
+  { label: '대피 완료율', weight: '30%', score: 96, color: 'success' },
+  { label: '평균 대피 시간', weight: '25%', score: 88, color: 'primary' },
+  { label: '병목 회피율', weight: '20%', score: 91, color: 'primary' },
+  { label: '경로 준수율', weight: '15%', score: 94, color: 'primary' },
+  { label: '밀집도 관리', weight: '5%', score: 87, color: 'primary' },
+  { label: 'IoT 활용도', weight: '5%', score: 98, color: 'success' },
+];
+
+export const evacuationAccumulation: TrendPoint[] = [
+  { label: '0:00', value: 8 },
+  { label: '0:40', value: 24 },
+  { label: '1:20', value: 58 },
+  { label: '2:00', value: 79 },
+  { label: '2:40', value: 91 },
+  { label: '3:20', value: 96 },
+  { label: '4:08', value: 98 },
+];
+
+export const densityByZone: DensityItem[] = [
+  { label: 'A구역', value: 62, level: 'low' },
+  { label: 'B구역', value: 92, level: 'high' },
+  { label: 'C구역', value: 48, level: 'low' },
+  { label: 'D구역', value: 71, level: 'medium' },
+  { label: '로비', value: 88, level: 'high' },
+];
+
+export const recentEvacuationTimes: TrendPoint[] = [
+  { label: '1회', value: 62 },
+  { label: '2회', value: 69 },
+  { label: '3회', value: 77 },
+  { label: '4회', value: 72 },
+  { label: '5회', value: 88 },
+];
+
+export const reportNarrative: ReportNarrative = {
+  headlinePrefix:
+    '본 훈련은 A동 3층 305호 발화 시나리오에서 진행되었으며, 참가자 52명 전원이 3분 42초 이내 대피를 완료하여 평가 등급',
+  grade: 'A(92.4점)',
+  headlineSuffix: '을 획득하였습니다.',
+  strength:
+    'IoT 유도등 응답률 98%, 1차 경로 산출 0.5초로 빠른 시스템 반응성을 확보했고, 참가자 96.2%가 권장 경로를 준수하였습니다.',
+  improvementPrefix: '1층 로비 평균 밀집도가',
+  improvementScore: '92%',
+  improvementSuffix:
+    '로 임계치(85%)를 초과해 약 18초간 병목이 발생했습니다. 서측 비상계단 분산 유도와 IoT 유도등 #E3-07 점검이 권고됩니다.',
+};
+
+export const recommendations: RecommendationItem[] = [
+  {
+    level: 'high',
+    title: '1층 로비 분산 유도',
+    description: '서측 비상계단 우회 경로 활성화',
+  },
+  {
+    level: 'medium',
+    title: 'IoT 유도등 #E3-07 점검',
+    description: '응답 지연 1.2초 감지',
+  },
+  {
+    level: 'low',
+    title: 'B구역 사전 안내 추가',
+    description: '훈련 직전 음성 안내 도입',
+  },
+];

--- a/src/pages/reports/mocks/reportData.ts
+++ b/src/pages/reports/mocks/reportData.ts
@@ -11,8 +11,14 @@ export const reportSummary: ReportSummary = {
   grade: 'A',
   scoreText: '92.4 / 100점',
   percentileText: '상위 12%',
-  previousDelta: '+4.2점',
-  nationalDelta: '+8.1점',
+  previousDelta: {
+    value: '+4.2점',
+    direction: 'up',
+  },
+  nationalDelta: {
+    value: '+8.1점',
+    direction: 'up',
+  },
 };
 
 export const reportScores: ReportScoreItem[] = [
@@ -65,16 +71,19 @@ export const reportNarrative: ReportNarrative = {
 
 export const recommendations: RecommendationItem[] = [
   {
+    id: 'lobby-distribution',
     level: 'high',
     title: '1층 로비 분산 유도',
     description: '서측 비상계단 우회 경로 활성화',
   },
   {
+    id: 'iot-sign-e3-07',
     level: 'medium',
     title: 'IoT 유도등 #E3-07 점검',
     description: '응답 지연 1.2초 감지',
   },
   {
+    id: 'zone-b-guide',
     level: 'low',
     title: 'B구역 사전 안내 추가',
     description: '훈련 직전 음성 안내 도입',

--- a/src/pages/reports/types/report.ts
+++ b/src/pages/reports/types/report.ts
@@ -21,6 +21,7 @@ export interface DensityItem {
 }
 
 export interface RecommendationItem {
+  id: string;
   level: DensityLevel;
   title: string;
   description: string;
@@ -40,6 +41,13 @@ export interface ReportSummary {
   grade: string;
   scoreText: string;
   percentileText: string;
-  previousDelta: string;
-  nationalDelta: string;
+  previousDelta: ReportDelta;
+  nationalDelta: ReportDelta;
+}
+
+export type ReportDeltaDirection = 'up' | 'down' | 'flat';
+
+export interface ReportDelta {
+  value: string;
+  direction: ReportDeltaDirection;
 }

--- a/src/pages/reports/types/report.ts
+++ b/src/pages/reports/types/report.ts
@@ -1,0 +1,45 @@
+export type ReportScoreColor = 'primary' | 'success';
+
+export interface ReportScoreItem {
+  label: string;
+  weight: string;
+  score: number;
+  color: ReportScoreColor;
+}
+
+export interface TrendPoint {
+  label: string;
+  value: number;
+}
+
+export type DensityLevel = 'high' | 'medium' | 'low';
+
+export interface DensityItem {
+  label: string;
+  value: number;
+  level: DensityLevel;
+}
+
+export interface RecommendationItem {
+  level: DensityLevel;
+  title: string;
+  description: string;
+}
+
+export interface ReportNarrative {
+  headlinePrefix: string;
+  grade: string;
+  headlineSuffix: string;
+  strength: string;
+  improvementPrefix: string;
+  improvementScore: string;
+  improvementSuffix: string;
+}
+
+export interface ReportSummary {
+  grade: string;
+  scoreText: string;
+  percentileText: string;
+  previousDelta: string;
+  nationalDelta: string;
+}

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -50,6 +50,7 @@ export const vars = createGlobalTheme(':root', {
   },
   gradient: {
     landing: 'linear-gradient(180deg, #EFF6FF 0%, #FFFFFF 27%, #FFFFFF 100%)',
+    reportGrade: 'linear-gradient(135deg, #2563EB 0%, #1E40AF 100%)',
   },
   fontWeight: {
     bold: '700',
@@ -162,6 +163,13 @@ export const vars = createGlobalTheme(':root', {
       fontWeight: '700',
       letterSpacing: '-0.02em',
       lineHeight: '1.16',
+    },
+    reportGrade: {
+      fontFamily: baseFontFamily,
+      fontSize: '10rem',
+      fontWeight: '700',
+      letterSpacing: '-0.02em',
+      lineHeight: '0.9',
     },
     h2: {
       fontFamily: baseFontFamily,

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -15,6 +15,9 @@ export const vars = createGlobalTheme(':root', {
     // Text
     textHigh: '#101828',
     textInverse: '#FFFFFF',
+    textInverseHigh: 'rgba(255, 255, 255, 0.88)',
+    textInverseLow: 'rgba(255, 255, 255, 0.68)',
+    textInverseMid: 'rgba(255, 255, 255, 0.72)',
     textLow: '#99A1AF',
     textMid: '#4A5563',
 


### PR DESCRIPTION
## 📌 Summary
- 분석보고서 페이지 UI 구현
- 목데이터 기반으로 종합 평가, 항목별 점수, 차트, AI 자동 평가 보고서, 개선 권고사항 영역을 구성

## 🔗 관련 이슈

closes #34 

## 📋 작업 내용
### 구현한 화면 구성
- 종합 평가 등급 카드
  - 전체 등급, 점수, 상위 퍼센트, 이전 회차/전국 평균 대비 수치 표시
- 평가 항목별 점수 카드
  - 대피 완료율, 평균 대피 시간 등 항목별 점수를 progress bar 형태로 표시
- 분석 차트 영역
  - 대피 인원 누적
  - 구역별 평균 밀집도
  - 최근 5회 대피 시간
- AI 자동 평가 보고서
  - 훈련 결과 요약, 강점, 개선 포인트 표시
- 개선 권고사항
  - 우선순위별 개선 항목 리스트 표시

### 구현 방식
- 보고서 데이터는 mocks/reportData.ts에 분리
- [recharts](https://recharts.github.io/en-US/examples/)를 사용해 차트 구현 (대피 인원 누적, 구역별 평균 밀집도, 최근 5회 대피 시간)
```tsx
<ReportCharts
  evacuationAccumulation={evacuationAccumulation}
  densityByZone={densityByZone}
  recentEvacuationTimes={recentEvacuationTimes}
/>
```
- 항목별 점수 progress bar는 차트보다는 단순 UI 요소에 가까워 CSS 스타일로 구현

### 파일별 역할 정리
- ReportsPage.tsx: 분석 보고서 페이지의 전체 레이아웃 조합
- mocks/reportData.ts: 보고서 화면에 사용되는 목데이터
- types/report.ts: 보고서 데이터 타입 정의
- components/card/*
  - GradeSummaryCard: 종합 등급 카드
  - ScoreBreakdownCard: 평가 항목별 점수 카드
  - AiReportCard: AI 자동 평가 보고서 카드
  - RecommendationsCard: 개선 권고사항 카드
- components/chart/ReportCharts.tsx: Recharts 기반 차트 3종 구현


## 🔍 To Reviewer
- 라이브러리 설치로 인해 `pnpm install` 필요합니다.
<!-- 리뷰어에게 요청하는 내용 -->

## 📸 스크린샷

https://github.com/user-attachments/assets/7f433163-acf9-428d-903e-20a83c8c9789



<!-- UI 변경 시 첨부 -->

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
