### PR TITLE
[refactor] 카메라 폼 모달 및 도면 관리 UI 개선

### DIFF
--- a/src/pages/buildings/modals/FloorPlanModal.css.ts
+++ b/src/pages/buildings/modals/FloorPlanModal.css.ts
@@ -132,16 +132,11 @@ export const floorLeft = style({
 });
 
 export const floorBadge = style({
-  display: 'flex',
   flexShrink: 0,
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: vars.radius.md,
-  backgroundColor: vars.color.gray50,
-  width: '4rem',
-  height: '4rem',
-  color: vars.color.textMid,
-  fontSize: '1.3rem',
+  minWidth: '3rem',
+  letterSpacing: '0.02em',
+  color: vars.color.textLow,
+  fontSize: '1.2rem',
   fontWeight: vars.fontWeight.semibold,
 });
 

--- a/src/pages/buildings/modals/FloorPlanModal.tsx
+++ b/src/pages/buildings/modals/FloorPlanModal.tsx
@@ -6,6 +6,7 @@ import { Button } from '@components/Button';
 import Modal from '@components/modal';
 
 import * as styles from './FloorPlanModal.css';
+import FloorUploadModal from '../../floorPlans/modals/FloorUploadModal';
 
 import type { Building } from '../types/buildings';
 
@@ -34,6 +35,7 @@ const FloorPlanModal = ({ open, onClose, building, onUpdate }: FloorPlanModalPro
   const [belowFloors, setBelowFloors] = useState(building.belowFloors);
   const [confirm, setConfirm] = useState<ConfirmState>(null);
   const [isEditingFloors, setIsEditingFloors] = useState(false);
+  const [uploadTargetFloor, setUploadTargetFloor] = useState<number | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -48,9 +50,15 @@ const FloorPlanModal = ({ open, onClose, building, onUpdate }: FloorPlanModalPro
   const isUploaded = (floor: number) => uploadedFloors.includes(floor);
 
   const handleUpload = (floor: number) => {
-    const next = Array.from(new Set([...uploadedFloors, floor]));
+    setUploadTargetFloor(floor);
+  };
+
+  const handleUploadConfirm = (_file: File) => {
+    if (uploadTargetFloor === null) return;
+    const next = Array.from(new Set([...uploadedFloors, uploadTargetFloor]));
     setUploadedFloors(next);
     onUpdate(building.id, { floorPlans: next });
+    setUploadTargetFloor(null);
   };
 
   const handleFloorDelete = (floor: number) => setConfirm({ type: 'deleteFloor', floor });
@@ -270,6 +278,14 @@ const FloorPlanModal = ({ open, onClose, building, onUpdate }: FloorPlanModalPro
             </Button>
           </>
         }
+      />
+
+      <FloorUploadModal
+        open={uploadTargetFloor !== null}
+        onClose={() => setUploadTargetFloor(null)}
+        buildingName={building.name}
+        floorNum={uploadTargetFloor ?? 0}
+        onConfirm={handleUploadConfirm}
       />
     </>
   );

--- a/src/pages/cameras/modals/CameraFormModal.css.ts
+++ b/src/pages/cameras/modals/CameraFormModal.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
@@ -78,4 +78,52 @@ export const selectError = style({
 export const errorText = style({
   color: vars.color.danger,
   ...vars.typography.caption,
+});
+
+export const requiredMark = style({
+  color: vars.color.danger,
+});
+
+export const selectWrap = style({
+  position: 'relative',
+});
+
+export const selectButton = style({
+  display: 'flex',
+  appearance: 'none',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  ...vars.typography.body14,
+  cursor: 'pointer',
+  padding: '0 1.4rem',
+  width: '100%',
+  height: '4.4rem',
+  color: vars.color.textHigh,
+  selectors: {
+    '&:focus': {
+      outline: 'none',
+      borderColor: vars.color.primary,
+    },
+    '&:disabled': {
+      backgroundColor: vars.color.gray50,
+      cursor: 'not-allowed',
+      color: vars.color.textLow,
+    },
+  },
+});
+
+const panelOpen = keyframes({
+  from: { transform: 'translateY(-6px)', opacity: 0 },
+  to: { transform: 'translateY(0)', opacity: 1 },
+});
+
+export const dropdownPanelOffset = style({
+  top: '100%',
+  left: 0,
+  marginTop: vars.space.s1,
+  width: '100%',
+  animation: `${panelOpen} 0.15s ease`,
 });

--- a/src/pages/cameras/modals/CameraFormModal.tsx
+++ b/src/pages/cameras/modals/CameraFormModal.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import clsx from 'clsx';
 
+import CheckIcon from '@assets/icons/ic-check.svg?react';
+import ChevronDownIcon from '@assets/icons/ic-chevron-down.svg?react';
+
 import { Button } from '@components/Button';
+import * as dropdownStyles from '@components/dropdown/Dropdown.css';
 import TextField from '@components/inputField/TextField';
 import Modal from '@components/modal';
 
@@ -60,6 +64,86 @@ const getFloorOptions = (building: Building) => {
   return floors;
 };
 
+interface SelectFieldProps {
+  options: { label: string; value: string }[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  error?: boolean;
+}
+
+const SelectField = ({
+  options,
+  value,
+  onChange,
+  placeholder = '선택',
+  disabled = false,
+  error = false,
+}: SelectFieldProps) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className={styles.selectWrap}>
+      <button
+        type="button"
+        className={clsx(styles.selectButton, error && styles.selectError)}
+        onClick={() => setOpen((prev) => !prev)}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        <span>{selected ? selected.label : placeholder}</span>
+        <ChevronDownIcon width={16} height={16} />
+      </button>
+
+      {open && (
+        <ul className={clsx(dropdownStyles.panel, styles.dropdownPanelOffset)} role="listbox">
+          {options.map((option) => (
+            <li
+              key={option.value}
+              className={dropdownStyles.option}
+              role="option"
+              aria-selected={option.value === value}
+              onClick={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+              {option.value === value && (
+                <CheckIcon className={dropdownStyles.checkIcon} width={16} height={16} />
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
 interface CameraFormModalProps {
   open: boolean;
   onClose: () => void;
@@ -88,13 +172,13 @@ const CameraFormModal = ({ open, onClose, camera, buildings, onConfirm }: Camera
     setErrors((prev) => ({ ...prev, [field]: '' }));
   };
 
-  const handleBuildingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setForm((prev) => ({ ...prev, buildingId: e.target.value, floor: '' }));
+  const handleBuildingChange = (value: string) => {
+    setForm((prev) => ({ ...prev, buildingId: value, floor: '' }));
     setErrors((prev) => ({ ...prev, buildingId: '', floor: '' }));
   };
 
-  const handleFloorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setForm((prev) => ({ ...prev, floor: e.target.value }));
+  const handleFloorChange = (value: string) => {
+    setForm((prev) => ({ ...prev, floor: value }));
     setErrors((prev) => ({ ...prev, floor: '' }));
   };
 
@@ -159,56 +243,32 @@ const CameraFormModal = ({ open, onClose, camera, buildings, onConfirm }: Camera
 
         <div className={styles.row}>
           <div className={styles.fieldWrap}>
-            <label htmlFor="camera-building" className={styles.fieldLabel}>
-              건물 *
+            <label className={styles.fieldLabel}>
+              건물 <span className={styles.requiredMark}>*</span>
             </label>
-            <select
-              id="camera-building"
-              className={clsx(styles.select, errors.buildingId && styles.selectError)}
+            <SelectField
+              options={buildings.map((b) => ({ label: b.name, value: String(b.id) }))}
               value={form.buildingId}
               onChange={handleBuildingChange}
-              aria-invalid={Boolean(errors.buildingId)}
-              aria-describedby={errors.buildingId ? 'camera-building-error' : undefined}
-            >
-              <option value="">건물 선택</option>
-              {buildings.map((b) => (
-                <option key={b.id} value={String(b.id)}>
-                  {b.name}
-                </option>
-              ))}
-            </select>
-            {errors.buildingId && (
-              <span id="camera-building-error" className={styles.errorText}>
-                {errors.buildingId}
-              </span>
-            )}
+              placeholder="건물 선택"
+              error={Boolean(errors.buildingId)}
+            />
+            {errors.buildingId && <span className={styles.errorText}>{errors.buildingId}</span>}
           </div>
 
           <div className={styles.fieldWrap}>
-            <label htmlFor="camera-floor" className={styles.fieldLabel}>
-              층수 *
+            <label className={styles.fieldLabel}>
+              층수 <span className={styles.requiredMark}>*</span>
             </label>
-            <select
-              id="camera-floor"
-              className={clsx(styles.select, errors.floor && styles.selectError)}
+            <SelectField
+              options={floorOptions}
               value={form.floor}
               onChange={handleFloorChange}
+              placeholder="층수 선택"
               disabled={!selectedBuilding}
-              aria-invalid={Boolean(errors.floor)}
-              aria-describedby={errors.floor ? 'camera-floor-error' : undefined}
-            >
-              <option value="">층수 선택</option>
-              {floorOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-            {errors.floor && (
-              <span id="camera-floor-error" className={styles.errorText}>
-                {errors.floor}
-              </span>
-            )}
+              error={Boolean(errors.floor)}
+            />
+            {errors.floor && <span className={styles.errorText}>{errors.floor}</span>}
           </div>
         </div>
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -15,6 +15,7 @@ import { formatFloor } from '@utils/floor';
 
 import { getFloorBuildings, getFloorDetail } from './api/floorPlansApi';
 import * as styles from './FloorPlansDetailPage.css';
+import FloorUploadModal from './modals/FloorUploadModal';
 
 import type {
   AiLayer,
@@ -818,6 +819,7 @@ const FloorCanvas = ({
   onPoiRelocate,
   onPoiPopoverClose,
   onDeviceMoved,
+  onUpload,
 }: {
   floor: Floor;
   selected: SelectedItem | null;
@@ -848,6 +850,7 @@ const FloorCanvas = ({
   onPoiRelocate: (id: string) => void;
   onPoiPopoverClose: () => void;
   onDeviceMoved: (id: string, x: number, y: number) => void;
+  onUpload: () => void;
 }) => {
   const hasMockMap = floor.segmentationStatus === 'DONE';
 
@@ -858,7 +861,7 @@ const FloorCanvas = ({
         <p style={{ color: 'inherit', margin: 0 }}>
           도면을 업로드하거나 AI 영역 분할을 실행해 주세요
         </p>
-        <Button variant="primary" size="sm" onClick={() => {}}>
+        <Button variant="primary" size="sm" onClick={onUpload}>
           도면 업로드
         </Button>
       </div>
@@ -1087,6 +1090,7 @@ const FloorPlansDetailPage = () => {
   const [simStart, setSimStart] = useState<{ x: number; y: number } | null>(null);
   const [simClickMode, setSimClickMode] = useState<'fire' | 'start' | null>(null);
   const [segStatusOverride, setSegStatusOverride] = useState<SegmentationStatus | null>(null);
+  const [uploadModalOpen, setUploadModalOpen] = useState(false);
   const [poiMarkers, setPoiMarkers] = useState<
     Array<{ id: string; x: number; y: number; label: string; poiType: PoiType }>
   >([]);
@@ -1631,6 +1635,7 @@ const FloorPlansDetailPage = () => {
                 onDeviceMoved={handleDeviceMoved}
                 addedDevices={addedDevices}
                 onAddedDeviceDelete={handleAddedDeviceDelete}
+                onUpload={() => setUploadModalOpen(true)}
               />
             ) : (
               <div className={styles.canvasPlaceholder}>
@@ -1871,6 +1876,14 @@ const FloorPlansDetailPage = () => {
           );
         })()}
       </div>
+
+      <FloorUploadModal
+        open={uploadModalOpen}
+        onClose={() => setUploadModalOpen(false)}
+        buildingName={currentBuilding?.name ?? ''}
+        floorNum={currentFloor?.floorNum ?? 0}
+        onConfirm={() => setUploadModalOpen(false)}
+      />
     </>
   );
 };

--- a/src/pages/floorPlans/FloorPlansPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansPage.css.ts
@@ -62,24 +62,6 @@ export const cardTop = style({
   justifyContent: 'space-between',
 });
 
-export const cardIconWrap = style({
-  display: 'flex',
-  flexShrink: 0,
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: vars.radius.lg,
-  backgroundColor: vars.color.gray50,
-  width: '5.2rem',
-  height: '5.2rem',
-});
-
-export const cardIconInner = style({
-  borderRadius: vars.radius.sm,
-  backgroundColor: vars.color.primary,
-  width: '2.8rem',
-  height: '2.8rem',
-});
-
 export const floorLabel = style({
   color: vars.color.textHigh,
   ...vars.typography.body14Medium,

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -74,9 +74,7 @@ const FloorCard = ({
   return (
     <div className={styles.floorCard}>
       <div className={styles.cardTop}>
-        <div className={styles.cardIconWrap} aria-hidden="true">
-          <div className={styles.cardIconInner} />
-        </div>
+        <span className={styles.floorLabel}>{formatFloor(floor.floorNum)}</span>
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
           <StatusBadge label={label} color={color} />
           <button
@@ -105,8 +103,6 @@ const FloorCard = ({
           </button>
         </div>
       </div>
-
-      <span className={styles.floorLabel}>{formatFloor(floor.floorNum)}</span>
 
       <div className={styles.divider} />
 
@@ -237,17 +233,19 @@ const FloorPlansPage = () => {
               </div>
 
               <div className={styles.floorGrid}>
-                {building.floors.map((floor) => (
-                  <FloorCard
-                    key={floor.id}
-                    floor={floor}
-                    buildingId={building.id}
-                    buildingName={building.name}
-                    onManage={handleManage}
-                    onUpload={setUploadTarget}
-                    onDelete={setDeleteTarget}
-                  />
-                ))}
+                {[...building.floors]
+                  .sort((a, b) => a.floorNum - b.floorNum)
+                  .map((floor) => (
+                    <FloorCard
+                      key={floor.id}
+                      floor={floor}
+                      buildingId={building.id}
+                      buildingName={building.name}
+                      onManage={handleManage}
+                      onUpload={setUploadTarget}
+                      onDelete={setDeleteTarget}
+                    />
+                  ))}
               </div>
             </section>
           ))}

--- a/src/pages/floorPlans/modals/FloorUploadModal.tsx
+++ b/src/pages/floorPlans/modals/FloorUploadModal.tsx
@@ -80,7 +80,7 @@ const FloorUploadModal = ({
     <Modal
       open={open}
       onClose={handleClose}
-      title="도면 이미지 업로드"
+      title="도면 파일 업로드"
       description={`${buildingName} · ${formatFloor(floorNum)}`}
       footer={
         <>


### PR DESCRIPTION
## 📌 Summary
<!-- 카메라 폼 모달 및 도면 관리 UI 개선 -->

## 📋 변경 사항
### 카메라 관리
- 카메라 추가/수정 모달의 건물·층수 선택을 기존 `Dropdown 컴포넌트`로 교체
- 드롭다운 패널 열림 애니메이션 추가
- 필수 항목(`*`) 표시 빨간색 통일 (건물, 층수)

### 도면 관리
- 건물 관리의 도면 (재)업로드 버튼,  도면 관리 상세의 미업로드 도면 업로드 버튼에 `FloorUploadModal` 재사용
- 모달 제목 '도면 이미지 업로드' → '도면 파일 업로드' 통일
- 층 카드 레이아웃 개선 (층수 좌측 상단, 상태 칩·삭제 버튼 우측 상단)
- 층 카드 정렬 오름차순 변경 (1층 → 2층 → 3층)

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
