### PR TITLE
[chore] Axios 및 TanStack Query 기반 네트워크 환경 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 import storybook from "eslint-plugin-storybook";
 import vanillaExtract from '@antebudimir/eslint-plugin-vanilla-extract';
 import eslintPluginPrettier from 'eslint-plugin-prettier';
+import pluginQuery from '@tanstack/eslint-plugin-query';
 
 import js from '@eslint/js';
 import globals from 'globals';
@@ -11,7 +12,10 @@ import tseslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 
-export default tseslint.config({ ignores: ['dist', 'storybook-static/**'] }, {
+export default tseslint.config(
+  { ignores: ['dist', 'storybook-static/**'] },
+  ...pluginQuery.configs['flat/recommended'],
+  {
   extends: [js.configs.recommended, ...tseslint.configs.recommended, prettier],
   files: ['**/*.{ts,tsx}'],
   languageOptions: {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@storybook/addon-mcp": "^0.6.0",
     "@storybook/addon-vitest": "^10.4.1",
     "@storybook/react-vite": "^10.4.1",
+    "@tanstack/eslint-plugin-query": "^5.101.4",
     "@types/node": "^25.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@storybook/react-vite':
         specifier: ^10.4.1
         version: 10.4.1(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@testing-library/dom@10.4.1)(@types/react@18.3.29)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.6.3)(vite@5.4.21(@types/node@25.9.1)(lightningcss@1.32.0))
+      '@tanstack/eslint-plugin-query':
+        specifier: ^5.101.4
+        version: 5.101.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.6.3)
       '@types/node':
         specifier: ^25.9.0
         version: 25.9.1
@@ -1172,6 +1175,15 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@svgr/core': '*'
+
+  '@tanstack/eslint-plugin-query@5.101.4':
+    resolution: {integrity: sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@tanstack/query-core@5.100.13':
     resolution: {integrity: sha512-mlKVKMTzZWGTKAC1CKOgt7axAjJ921emkEvYIp27I/PdP1yEYL/BteLY8iK35gn8hoYeKB4mgJ/ve3lrDI6/Fw==}
@@ -4621,6 +4633,15 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/eslint-plugin-query@5.101.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.6.3)
+      eslint: 9.39.4(jiti@2.7.0)
+    optionalDependencies:
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,11 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router';
 
 import router from '@routes/router';
-import '@styles/global.css';
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      staleTime: 1000 * 60,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
+import { queryClient } from '@apis/config/queryClient';
+import '@styles/global.css';
 
 const App = () => (
   <QueryClientProvider client={queryClient}>

--- a/src/shared/apis/config/axiosInstance.ts
+++ b/src/shared/apis/config/axiosInstance.ts
@@ -2,11 +2,11 @@ import axios from 'axios';
 
 import type { AxiosError } from 'axios';
 
-const Instance_timeout: number = 30_000; // 30초
+const REQUEST_TIMEOUT_MS: number = 30_000; // 30초
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: Instance_timeout,
+  timeout: REQUEST_TIMEOUT_MS,
   withCredentials: true,
 });
 

--- a/src/shared/apis/config/axiosInstance.ts
+++ b/src/shared/apis/config/axiosInstance.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import type { AxiosError } from 'axios';
+
+const Instance_timeout: number = 30_000; // 30초
+
+const axiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  timeout: Instance_timeout,
+  withCredentials: true,
+});
+
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error: AxiosError) => {
+    return Promise.reject(error);
+  },
+);
+
+export default axiosInstance;

--- a/src/shared/apis/config/queryClient.ts
+++ b/src/shared/apis/config/queryClient.ts
@@ -1,0 +1,29 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+
+const MAX_QUERY_RETRY_COUNT = 1;
+
+const shouldRetryQuery = (failureCount: number, error: Error) => {
+  if (failureCount >= MAX_QUERY_RETRY_COUNT || !isAxiosError(error)) {
+    return false;
+  }
+
+  const status = error.response?.status;
+
+  return status === undefined || status === 408 || status === 429 || status >= 500;
+};
+
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => {
+      if (import.meta.env.DEV) console.error('[React Query Error]', error);
+    },
+  }),
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false, // 브라우저 포커싱 시 자동 재요청 방지
+      retry: shouldRetryQuery,
+      staleTime: 1000 * 60 * 5, // 5분
+    },
+  },
+});

--- a/src/shared/apis/config/queryClient.ts
+++ b/src/shared/apis/config/queryClient.ts
@@ -3,7 +3,7 @@ import { isAxiosError } from 'axios';
 
 const MAX_QUERY_RETRY_COUNT = 1;
 
-const shouldRetryQuery = (failureCount: number, error: Error) => {
+const canRetryQuery = (failureCount: number, error: Error) => {
   if (failureCount >= MAX_QUERY_RETRY_COUNT || !isAxiosError(error)) {
     return false;
   }
@@ -17,7 +17,7 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false, // 브라우저 포커싱 시 자동 재요청 방지
-      retry: shouldRetryQuery,
+      retry: canRetryQuery,
       staleTime: 1000 * 60 * 5, // 5분
     },
   },

--- a/src/shared/apis/config/queryClient.ts
+++ b/src/shared/apis/config/queryClient.ts
@@ -1,4 +1,4 @@
-import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 const MAX_QUERY_RETRY_COUNT = 1;
@@ -14,11 +14,6 @@ const shouldRetryQuery = (failureCount: number, error: Error) => {
 };
 
 export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error) => {
-      if (import.meta.env.DEV) console.error('[React Query Error]', error);
-    },
-  }),
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false, // 브라우저 포커싱 시 자동 재요청 방지

--- a/src/shared/apis/config/request.ts
+++ b/src/shared/apis/config/request.ts
@@ -14,28 +14,30 @@ export const HTTPMethod = {
 } as const;
 
 export type HTTPMethodType = (typeof HTTPMethod)[keyof typeof HTTPMethod];
-type QueryValue = string | number | boolean | Array<string | number | boolean>;
-export interface RequestConfig {
+type QueryPrimitive = string | number | boolean;
+type QueryValue = QueryPrimitive | QueryPrimitive[] | null | undefined;
+
+export interface RequestConfig<TBody = unknown> {
   method: HTTPMethodType;
   url: string;
   query?: Record<string, QueryValue>;
-  body?: Record<string, unknown>;
+  body?: TBody;
+  signal?: AbortSignal;
 }
 
-export const request = async <T>(config: RequestConfig): Promise<T> => {
-  const { method, url, query, body } = config;
+export const request = async <TResponse, TBody = unknown>(
+  config: RequestConfig<TBody>,
+): Promise<TResponse> => {
+  const { method, url, query, body, signal } = config;
 
   try {
-    const response = await axiosInstance.request<BaseResponse<T>>({
+    const response = await axiosInstance.request<BaseResponse<TResponse>>({
       method,
       url,
       params: query,
       data: body,
+      signal,
     });
-
-    if (import.meta.env.DEV) {
-      console.log(`[성공] ${url} : ${response.data.message}`);
-    }
 
     return response.data.data;
   } catch (error: unknown) {

--- a/src/shared/apis/config/request.ts
+++ b/src/shared/apis/config/request.ts
@@ -1,11 +1,11 @@
-import { isAxiosError } from 'axios';
+import { isAxiosError, isCancel } from 'axios';
 
 import { RESPONSE_MESSAGE } from '@apis/constants/response';
 import type { BaseResponse } from '@apis/types/baseResponse';
 
 import axiosInstance from './axiosInstance';
 
-export const HTTPMethod = {
+export const HTTP_METHOD = {
   GET: 'GET',
   POST: 'POST',
   PUT: 'PUT',
@@ -13,12 +13,12 @@ export const HTTPMethod = {
   PATCH: 'PATCH',
 } as const;
 
-export type HTTPMethodType = (typeof HTTPMethod)[keyof typeof HTTPMethod];
+export type HttpMethod = (typeof HTTP_METHOD)[keyof typeof HTTP_METHOD];
 type QueryPrimitive = string | number | boolean;
 type QueryValue = QueryPrimitive | QueryPrimitive[] | null | undefined;
 
 export interface RequestConfig<TBody = unknown> {
-  method: HTTPMethodType;
+  method: HttpMethod;
   url: string;
   query?: Record<string, QueryValue>;
   body?: TBody;
@@ -41,6 +41,10 @@ export const request = async <TResponse, TBody = unknown>(
 
     return response.data.data;
   } catch (error: unknown) {
+    if (isCancel(error)) {
+      throw error;
+    }
+
     if (!isAxiosError<BaseResponse<unknown>>(error)) {
       // 클라이언트 내부 런타임 에러
       if (import.meta.env.DEV) {
@@ -56,7 +60,9 @@ export const request = async <TResponse, TBody = unknown>(
       const message = response.data?.message;
 
       const displayMessage =
-        RESPONSE_MESSAGE[status] ?? message ?? '알 수 없는 오류가 발생했습니다.';
+        RESPONSE_MESSAGE[status as keyof typeof RESPONSE_MESSAGE] ??
+        message ??
+        '알 수 없는 오류가 발생했습니다.';
 
       if (import.meta.env.DEV) {
         console.error(`[실패] ${url} : ${displayMessage}`);

--- a/src/shared/apis/config/request.ts
+++ b/src/shared/apis/config/request.ts
@@ -1,0 +1,69 @@
+import { isAxiosError } from 'axios';
+
+import { RESPONSE_MESSAGE } from '@apis/constants/response';
+import type { BaseResponse } from '@apis/types/baseResponse';
+
+import axiosInstance from './axiosInstance';
+
+export const HTTPMethod = {
+  GET: 'GET',
+  POST: 'POST',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+  PATCH: 'PATCH',
+} as const;
+
+export type HTTPMethodType = (typeof HTTPMethod)[keyof typeof HTTPMethod];
+type QueryValue = string | number | boolean | Array<string | number | boolean>;
+export interface RequestConfig {
+  method: HTTPMethodType;
+  url: string;
+  query?: Record<string, QueryValue>;
+  body?: Record<string, unknown>;
+}
+
+export const request = async <T>(config: RequestConfig): Promise<T> => {
+  const { method, url, query, body } = config;
+
+  try {
+    const response = await axiosInstance.request<BaseResponse<T>>({
+      method,
+      url,
+      params: query,
+      data: body,
+    });
+
+    if (import.meta.env.DEV) {
+      console.log(`[성공] ${url} : ${response.data.message}`);
+    }
+
+    return response.data.data;
+  } catch (error: unknown) {
+    if (!isAxiosError(error)) {
+      // 클라이언트 내부 런타임 에러
+      console.error(`[실패] ${url} : 알 수 없는 오류`, error);
+      throw error;
+    }
+
+    const { response } = error;
+
+    if (response) {
+      const { status } = response;
+      const errorData = response.data as BaseResponse<unknown>;
+      const message = errorData?.message;
+
+      const displayMessage =
+        RESPONSE_MESSAGE[status] || message || '알 수 없는 오류가 발생했습니다.';
+
+      if (import.meta.env.DEV) {
+        console.error(`[실패] ${url} : ${displayMessage}`);
+      }
+    } else {
+      // 서버 응답 자체를 못 받은 경우
+      if (import.meta.env.DEV) {
+        console.error(`[실패] ${url} : 서버에 연결할 수 없습니다.`);
+      }
+    }
+    throw error;
+  }
+};

--- a/src/shared/apis/config/request.ts
+++ b/src/shared/apis/config/request.ts
@@ -1,9 +1,10 @@
 import { isAxiosError, isCancel } from 'axios';
 
+import axiosInstance from '@apis/config/axiosInstance';
 import { RESPONSE_MESSAGE } from '@apis/constants/response';
 import type { BaseResponse } from '@apis/types/baseResponse';
 
-import axiosInstance from './axiosInstance';
+import type { Method } from 'axios';
 
 export const HTTP_METHOD = {
   GET: 'GET',
@@ -11,7 +12,7 @@ export const HTTP_METHOD = {
   PUT: 'PUT',
   DELETE: 'DELETE',
   PATCH: 'PATCH',
-} as const;
+} as const satisfies Record<string, Method>;
 
 export type HttpMethod = (typeof HTTP_METHOD)[keyof typeof HTTP_METHOD];
 type QueryPrimitive = string | number | boolean;

--- a/src/shared/apis/config/request.ts
+++ b/src/shared/apis/config/request.ts
@@ -39,9 +39,11 @@ export const request = async <T>(config: RequestConfig): Promise<T> => {
 
     return response.data.data;
   } catch (error: unknown) {
-    if (!isAxiosError(error)) {
+    if (!isAxiosError<BaseResponse<unknown>>(error)) {
       // 클라이언트 내부 런타임 에러
-      console.error(`[실패] ${url} : 알 수 없는 오류`, error);
+      if (import.meta.env.DEV) {
+        console.error(`[실패] ${url} : 알 수 없는 오류`, error);
+      }
       throw error;
     }
 
@@ -49,11 +51,10 @@ export const request = async <T>(config: RequestConfig): Promise<T> => {
 
     if (response) {
       const { status } = response;
-      const errorData = response.data as BaseResponse<unknown>;
-      const message = errorData?.message;
+      const message = response.data?.message;
 
       const displayMessage =
-        RESPONSE_MESSAGE[status] || message || '알 수 없는 오류가 발생했습니다.';
+        RESPONSE_MESSAGE[status] ?? message ?? '알 수 없는 오류가 발생했습니다.';
 
       if (import.meta.env.DEV) {
         console.error(`[실패] ${url} : ${displayMessage}`);

--- a/src/shared/apis/constants/response.ts
+++ b/src/shared/apis/constants/response.ts
@@ -1,0 +1,21 @@
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  SERVER_ERROR: 500,
+};
+
+export const RESPONSE_MESSAGE: Record<number, string> = {
+  [HTTP_STATUS.OK]: '요청이 성공했습니다.',
+  [HTTP_STATUS.CREATED]: '데이터가 성공적으로 생성되었습니다.',
+  [HTTP_STATUS.BAD_REQUEST]: '입력값이 올바르지 않습니다.',
+  [HTTP_STATUS.NOT_FOUND]: '존재하지 않는 데이터입니다.',
+  [HTTP_STATUS.UNAUTHORIZED]: '리소스에 대한 액세스 권한이 존재하지 않습니다.',
+  [HTTP_STATUS.FORBIDDEN]: '리소스에 대한 액세스가 금지되었습니다.',
+  [HTTP_STATUS.CONFLICT]: '이미 존재하는 데이터입니다.',
+  [HTTP_STATUS.SERVER_ERROR]: '서버 에러가 발생했습니다.',
+};

--- a/src/shared/apis/constants/response.ts
+++ b/src/shared/apis/constants/response.ts
@@ -1,6 +1,4 @@
 export const HTTP_STATUS = {
-  OK: 200,
-  CREATED: 201,
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
   FORBIDDEN: 403,
@@ -10,8 +8,6 @@ export const HTTP_STATUS = {
 };
 
 export const RESPONSE_MESSAGE: Record<number, string> = {
-  [HTTP_STATUS.OK]: '요청이 성공했습니다.',
-  [HTTP_STATUS.CREATED]: '데이터가 성공적으로 생성되었습니다.',
   [HTTP_STATUS.BAD_REQUEST]: '입력값이 올바르지 않습니다.',
   [HTTP_STATUS.NOT_FOUND]: '존재하지 않는 데이터입니다.',
   [HTTP_STATUS.UNAUTHORIZED]: '리소스에 대한 액세스 권한이 존재하지 않습니다.',

--- a/src/shared/apis/constants/response.ts
+++ b/src/shared/apis/constants/response.ts
@@ -5,13 +5,13 @@ export const HTTP_STATUS = {
   NOT_FOUND: 404,
   CONFLICT: 409,
   SERVER_ERROR: 500,
-};
+} as const;
 
-export const RESPONSE_MESSAGE: Record<number, string> = {
+export const RESPONSE_MESSAGE = {
   [HTTP_STATUS.BAD_REQUEST]: '입력값이 올바르지 않습니다.',
   [HTTP_STATUS.NOT_FOUND]: '존재하지 않는 데이터입니다.',
   [HTTP_STATUS.UNAUTHORIZED]: '리소스에 대한 액세스 권한이 존재하지 않습니다.',
   [HTTP_STATUS.FORBIDDEN]: '리소스에 대한 액세스가 금지되었습니다.',
   [HTTP_STATUS.CONFLICT]: '이미 존재하는 데이터입니다.',
   [HTTP_STATUS.SERVER_ERROR]: '서버 에러가 발생했습니다.',
-};
+} as const satisfies Record<number, string>;

--- a/src/shared/apis/types/baseResponse.ts
+++ b/src/shared/apis/types/baseResponse.ts
@@ -1,0 +1,6 @@
+export interface BaseResponse<T> {
+  status: number;
+  code: string;
+  message: string;
+  data: T;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## 📌 Summary

- Axios와 TanStack Query 기반의 공통 네트워크 계층을 구성했습니다.
- API별로 중복될 `baseURL`, timeout, 응답 unwrap, 오류 로깅, query 재시도 정책을 공통화했습니다.

## 🔗 관련 이슈

closes #39

## 📋 작업 내용

### 도입 배경

- API 연동 전 공통 요청 규칙을 정의해 API마다 Axios 설정과 오류 처리가 중복되는 것을 방지하고자 했습니다.
- Axios 인스턴스를 통해 다음 설정을 중앙에서 관리합니다.
  - API Base URL
  - 요청 timeout
  - credentials
  - 추후 토큰 주입 및 인증 만료 처리
- TanStack Query를 통해 서버 상태의 캐싱, 재요청, 재시도 정책을 일관되게 관리하도록 구성했습니다.

### 주요 구현 내용

#### `src/shared/apis/config/axiosInstance.ts`

> 공통 Axios 인스턴스 생성
- 요청이 무한정 대기하지 않도록 기본 timeout을 30초로 설정
- 로그인 API 연동 시 인증 처리를 추가할 수 있도록 response interceptor 구조 마련
  - JSON 요청은 Axios가 자동 처리
  - FormData는 브라우저가 multipart boundary를 포함한 헤더를 생성해야 함.

#### `src/shared/apis/config/request.ts`

> API별 공통 호출을 위한 `request()` 함수 구현

- GET, POST, PUT, DELETE, PATCH 메서드를 상수화
- `RequestConfig<TBody>`를 통해 요청 body 타입을 API별로 지정 가능
  - JSON 객체뿐만 아니라 배열, 문자열, FormData 등을 지원
- query parameter는 primitive, 배열, null, undefined를 지원
- 성공 시 `BaseResponse<T>`의 `data`를 반환
- 실패 시 개발 환경에서 공통 오류 메시지를 출력한 후 원본 AxiosError를 다시 throw
- 에러 메시지는 다음 순서로 결정
  1. HTTP 상태별 공통 메시지
  2. 서버에서 내려온 메시지
  3. 기본 오류 메시지

#### `src/shared/apis/config/queryClient.ts`

> 공통 QueryClient를 생성
- 모든 오류를 무조건 재시도하지 않고 다음 오류만 1회 재시도
  - 서버 응답이 없는 네트워크 오류 및 timeout
  - 408 Request Timeout
  - 429 Too Many Requests
  - 5xx 서버 오류
- 400, 401, 403, 404 등 재시도해도 결과가 달라지지 않는 클라이언트 오류는 재시도하지 않음
- `request()`와의 중복 오류 로그를 피하기 위해 `QueryCache.onError`는 별도로 설정하지 않음

#### `src/shared/apis/constants/response.ts`

- 개발 환경 오류 로그에 사용할 HTTP 상태와 기본 메시지 상수화
- 등록되지 않은 HTTP 상태는 서버에서 내려온 메시지를 fallback으로 사용


### 동작 흐름

```
[성공]
컴포넌트 / TanStack Query Hook
→ request()
→ axiosInstance
→ Server API
→ BaseResponse의 data 반환
→ useQuery / useMutation의 data

[실패]
Server API
→ AxiosError 발생
→ request()에서 개발 로그 출력 후 원본 에러를 다시 throw
→ QueryClient에서 재시도 여부 판단
→ 재시도하거나 useQuery / useMutation의 error 상태로 전달
```

- queryFn이 반환한 Promise가 reject되면 TanStack Query가 이를 감지하고 QueryClient의 재시도 정책을 적용합니다.
- 최종 실패한 원본 AxiosError는 `useQuery().error` 또는 `useMutation().error`에서 확인할 수 있습니다.

### 사용법

페이지별로 API 요청 함수와 TanStack Query 훅을 작성합니다.
다음은 예시일 뿐이고 네이밍 등은 연동하면서 변경하시면 됩니다. 

```text
pages/buildings/
├── apis/buildings.ts
└── hooks/useBuildings.ts
```

```ts
// apis/buildings.ts
export const getBuildings = (signal?: AbortSignal) => {
  return request<Building[]>({
    method: HTTPMethod.GET,
    url: '/buildings',
    signal,
  });
};

// hooks/useBuildings.ts
export const useBuildingsQuery = () => {
  return useQuery({
    queryKey: queryKeys.buildings.list(),
    queryFn: ({ signal }) => getBuildings(signal),
  });
};
```

- TanStack Query가 전달하는 `signal`을 `request`에 연결하면 쿼리가 취소될 때 진행 중인 네트워크 요청도 함께 취소됩니다. (선택적으로 사용 가능)


## 🔍 To Reviewer

- 서버에서 url 전달 받으면 노션에 env 추가하겠습니다. 
- 후속 작업
  - 이슈 #39에 명시된 후속 작업은 백엔드 서버 배포 및 API 명세 확정 후 별도 작업으로 진행할 예정입니다.
  - openapi 도입 (swagger-typescript-api)
  - API endpoint 상수화
  - Query Key 및 `queryOptions` 구성
- 로그인/회원가입 api 연동 진행하면서 공통 토큰 주입 


## 📸 스크린샷

- UI 변경 사항 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
- [x] `pnpm lint` 오류 없음