### PR TITLE
[feat] 시나리오 목록 및 상세 상태 UI 구현

### DIFF
--- a/src/pages/scenarioSettings/ScenarioListPage.css.ts
+++ b/src/pages/scenarioSettings/ScenarioListPage.css.ts
@@ -1,0 +1,86 @@
+import { globalStyle, style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const container = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: vars.space.s6,
+  padding: vars.space.s6,
+  minHeight: '100%',
+});
+
+export const toolbar = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+});
+
+export const addButton = style({
+  marginLeft: 'auto',
+});
+
+export const list = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s3,
+});
+
+export const emptyState = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.space.s5,
+  border: `1px dashed ${vars.color.gray200}`,
+  borderRadius: vars.radius.lg,
+  backgroundColor: vars.color.white,
+  minHeight: '36rem',
+});
+
+export const emptyIcon = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: '50%',
+  backgroundColor: vars.color.primaryLight2,
+  width: vars.space.s15,
+  height: vars.space.s15,
+  color: vars.color.primary,
+});
+
+globalStyle(`${emptyIcon} svg`, {
+  width: vars.space.s7,
+  height: vars.space.s7,
+});
+
+export const emptyText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: vars.space.s2,
+  textAlign: 'center',
+});
+
+export const emptyTitle = style({
+  color: vars.color.textHigh,
+  ...vars.typography.h4,
+});
+
+export const emptyDescription = style({
+  color: vars.color.textLow,
+  ...vars.typography.body14,
+});
+
+export const filterEmpty = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px dashed ${vars.color.gray200}`,
+  borderRadius: vars.radius.lg,
+  minHeight: '18rem',
+  color: vars.color.textLow,
+  ...vars.typography.body14,
+});

--- a/src/pages/scenarioSettings/ScenarioListPage.tsx
+++ b/src/pages/scenarioSettings/ScenarioListPage.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+
+import { useNavigate } from 'react-router';
+
+import FileTextIcon from '@assets/icons/ic-filetext.svg?react';
+import PlusIcon from '@assets/icons/ic-plus.svg?react';
+
+import { Button } from '@components/Button';
+import Dropdown from '@components/dropdown';
+import useToast from '@components/toast/useToast';
+
+import { ROUTES, getScenarioDetailPath } from '@constants/path';
+
+import ScenarioDeleteModal from './components/scenarioDeleteModal/ScenarioDeleteModal';
+import ScenarioListRow from './components/scenarioList/ScenarioListRow';
+import { scenarioListData, scenarioStatusFilterOptions } from './mocks/scenarioListData';
+import * as styles from './ScenarioListPage.css';
+
+import type { ScenarioSummary } from './types/scenarioList';
+
+type StatusFilter = (typeof scenarioStatusFilterOptions)[number]['value'];
+
+const ScenarioListPage = () => {
+  const navigate = useNavigate();
+  const { show } = useToast();
+  const [scenarios, setScenarios] = useState(scenarioListData);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
+  const [deleteTarget, setDeleteTarget] = useState<ScenarioSummary | null>(null);
+
+  const filteredScenarios = scenarios.filter(
+    (scenario) => statusFilter === 'ALL' || scenario.status === statusFilter,
+  );
+
+  const navigateToCreate = () => void navigate(ROUTES.SCENARIO_CREATE);
+
+  const handleOpen = (scenario: ScenarioSummary) => {
+    void navigate(getScenarioDetailPath(scenario.id));
+  };
+
+  const handleDelete = (scenario: ScenarioSummary) => {
+    if (!scenario.deletable) return;
+    setDeleteTarget(scenario);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) return;
+
+    setScenarios((current) => current.filter((scenario) => scenario.id !== deleteTarget.id));
+    show({
+      title: '시나리오가 삭제되었습니다.',
+      description: `${deleteTarget.name}이(가) 삭제되었습니다.`,
+      variant: 'success',
+    });
+    setDeleteTarget(null);
+  };
+
+  return (
+    <>
+      <div className={styles.container}>
+        <div className={styles.toolbar}>
+          <Dropdown
+            shape="rounded"
+            options={scenarioStatusFilterOptions}
+            value={statusFilter}
+            onChange={setStatusFilter}
+          />
+          <Button
+            type="button"
+            className={styles.addButton}
+            leftIcon={<PlusIcon />}
+            onClick={navigateToCreate}
+          >
+            시나리오 추가
+          </Button>
+        </div>
+
+        {scenarios.length === 0 ? (
+          <div className={styles.emptyState}>
+            <span className={styles.emptyIcon} aria-hidden="true">
+              <FileTextIcon />
+            </span>
+            <div className={styles.emptyText}>
+              <strong className={styles.emptyTitle}>생성된 시나리오가 없습니다.</strong>
+              <p className={styles.emptyDescription}>
+                첫 번째 훈련 시나리오를 만들어 훈련을 준비해 보세요.
+              </p>
+            </div>
+            <Button type="button" leftIcon={<PlusIcon />} onClick={navigateToCreate}>
+              시나리오 만들기
+            </Button>
+          </div>
+        ) : filteredScenarios.length > 0 ? (
+          <div className={styles.list}>
+            {filteredScenarios.map((scenario) => (
+              <ScenarioListRow
+                key={scenario.id}
+                scenario={scenario}
+                onOpen={handleOpen}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className={styles.filterEmpty}>선택한 상태의 시나리오가 없습니다.</div>
+        )}
+      </div>
+
+      {deleteTarget ? (
+        <ScenarioDeleteModal
+          open
+          scenarioName={deleteTarget.name}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={handleConfirmDelete}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default ScenarioListPage;

--- a/src/pages/scenarioSettings/ScenarioListPage.tsx
+++ b/src/pages/scenarioSettings/ScenarioListPage.tsx
@@ -13,17 +13,17 @@ import { ROUTES, getScenarioDetailPath } from '@constants/path';
 
 import ScenarioDeleteModal from './components/scenarioDeleteModal/ScenarioDeleteModal';
 import ScenarioListRow from './components/scenarioList/ScenarioListRow';
-import { scenarioListData, scenarioStatusFilterOptions } from './mocks/scenarioListData';
+import { SCENARIO_LIST_DATA, SCENARIO_STATUS_FILTER_OPTIONS } from './mocks/scenarioListData';
 import * as styles from './ScenarioListPage.css';
 
 import type { ScenarioSummary } from './types/scenarioList';
 
-type StatusFilter = (typeof scenarioStatusFilterOptions)[number]['value'];
+type StatusFilter = (typeof SCENARIO_STATUS_FILTER_OPTIONS)[number]['value'];
 
 const ScenarioListPage = () => {
   const navigate = useNavigate();
   const { show } = useToast();
-  const [scenarios, setScenarios] = useState(scenarioListData);
+  const [scenarios, setScenarios] = useState<ScenarioSummary[]>(() => [...SCENARIO_LIST_DATA]);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
   const [deleteTarget, setDeleteTarget] = useState<ScenarioSummary | null>(null);
 
@@ -60,7 +60,7 @@ const ScenarioListPage = () => {
         <div className={styles.toolbar}>
           <Dropdown
             shape="rounded"
-            options={scenarioStatusFilterOptions}
+            options={SCENARIO_STATUS_FILTER_OPTIONS}
             value={statusFilter}
             onChange={setStatusFilter}
           />

--- a/src/pages/scenarioSettings/ScenarioSettingsPage.css.ts
+++ b/src/pages/scenarioSettings/ScenarioSettingsPage.css.ts
@@ -69,3 +69,15 @@ export const sideColumn = style({
   gap: vars.space.s4,
   minWidth: 0,
 });
+
+export const draftButton = style({
+  borderColor: vars.color.gray100,
+  backgroundColor: vars.color.gray200,
+  color: vars.color.textHigh,
+  selectors: {
+    '&:hover:not(:disabled)': {
+      borderColor: vars.color.gray200,
+      backgroundColor: vars.color.gray100,
+    },
+  },
+});

--- a/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
+++ b/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
@@ -1,11 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
-import { useNavigate } from 'react-router';
+import { Navigate, useNavigate, useParams } from 'react-router';
 
 import PlayIcon from '@assets/icons/ic-play.svg?react';
 import SparklesIcon from '@assets/icons/ic-sparkles.svg?react';
 
 import { Button } from '@components/Button';
+import useToast from '@components/toast/useToast';
 
 import { ROUTES } from '@constants/path';
 
@@ -14,8 +15,10 @@ import TrainingPreviewCard from './components/cards/trainingPreviewCard/Training
 import ScenarioSetupForm from './components/scenarioSetupForm/ScenarioSetupForm';
 import TrainingControlPanel from './components/trainingControlPanel/TrainingControlPanel';
 import TrainingEndModal from './components/trainingEndModal/TrainingEndModal';
+import { scenarioListData } from './mocks/scenarioListData';
 import {
   basicInfo,
+  emptyBasicInfo,
   currentRouteText,
   liveMetrics,
   liveStatus,
@@ -28,17 +31,38 @@ import {
   selectedFireConditions,
 } from './mocks/scenarioSettingsData';
 import * as styles from './ScenarioSettingsPage.css';
+import { SCENARIO_STATUS } from './types/scenarioList';
 
 const ScenarioSettingsPage = () => {
   const navigate = useNavigate();
+  const { scenarioId } = useParams();
+  const { show } = useToast();
+  const isCreatePage = scenarioId === undefined;
+  const scenario = scenarioListData.find((item) => item.id === scenarioId);
+  const isInitiallyEditing = isCreatePage || scenario?.status === SCENARIO_STATUS.DRAFT;
   const [isEndModalOpen, setIsEndModalOpen] = useState(false);
-  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [isEditing, setIsEditing] = useState(isInitiallyEditing);
+  const [startedAt, setStartedAt] = useState<number | null>(() =>
+    scenario?.status === SCENARIO_STATUS.IN_PROGRESS ? Date.now() - 8 * 60 * 1000 : null,
+  );
   const [currentRoute, setCurrentRoute] = useState(currentRouteText);
   const [routeProposal, setRouteProposal] = useState<string | null>(routeProposalText);
   const isRunning = startedAt !== null;
+  const scenarioBasicInfo = isCreatePage
+    ? emptyBasicInfo
+    : { ...basicInfo, scenarioName: scenario?.name ?? basicInfo.scenarioName };
 
   const startTraining = () => {
     setStartedAt(Date.now());
+  };
+
+  const handleSaveDraft = () => {
+    show({ title: '임시 저장되었습니다.', variant: 'success' });
+  };
+
+  const handleComplete = () => {
+    setIsEditing(false);
+    show({ title: '시나리오 작성이 완료되었습니다.', variant: 'success' });
   };
 
   const handleRejectRouteProposal = () => {
@@ -50,17 +74,19 @@ const ScenarioSettingsPage = () => {
     setRouteProposal(null);
   };
 
-  const handleHome = useCallback(() => void navigate(ROUTES.HOME), [navigate]);
-  const handleReport = useCallback(() => void navigate(ROUTES.REPORTS), [navigate]);
+  if (!isCreatePage && !scenario) {
+    return <Navigate replace to={ROUTES.SCENARIO_LIST} />;
+  }
 
   return (
     <div className={styles.container}>
       <div className={styles.contentGrid}>
         <ScenarioSetupForm
-          basicInfo={basicInfo}
+          basicInfo={scenarioBasicInfo}
           conditions={selectedFireConditions}
           options={fireConditionOptions}
           isRunning={isRunning}
+          readOnly={!isEditing && !isRunning}
         />
 
         {startedAt !== null ? (
@@ -76,25 +102,55 @@ const ScenarioSettingsPage = () => {
           />
         ) : (
           <aside className={styles.sideColumn}>
-            <Button
-              type="button"
-              size="lg"
-              fullWidth
-              leftIcon={<PlayIcon />}
-              onClick={startTraining}
-            >
-              시나리오 시작
-            </Button>
-            <RecommendationCard icon={<SparklesIcon />} message={recommendationText} />
-            <TrainingPreviewCard status={previewStatus} metrics={previewMetrics} />
-            <Button type="button" variant="ghost" size="lg" fullWidth>
-              임시 저장
-            </Button>
+            {isEditing ? (
+              <>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="lg"
+                  fullWidth
+                  className={styles.draftButton}
+                  onClick={handleSaveDraft}
+                >
+                  임시 저장
+                </Button>
+                <Button type="button" size="lg" fullWidth onClick={handleComplete}>
+                  작성 완료
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  size="lg"
+                  fullWidth
+                  leftIcon={<PlayIcon />}
+                  onClick={startTraining}
+                >
+                  시나리오 시작
+                </Button>
+                <RecommendationCard icon={<SparklesIcon />} message={recommendationText} />
+                <TrainingPreviewCard status={previewStatus} metrics={previewMetrics} />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="md"
+                  fullWidth
+                  onClick={() => setIsEditing(true)}
+                >
+                  수정하기
+                </Button>
+              </>
+            )}
           </aside>
         )}
       </div>
 
-      <TrainingEndModal open={isEndModalOpen} onHome={handleHome} onReport={handleReport} />
+      <TrainingEndModal
+        open={isEndModalOpen}
+        onHome={() => void navigate(ROUTES.HOME)}
+        onReport={() => void navigate(ROUTES.REPORTS)}
+      />
     </div>
   );
 };

--- a/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
+++ b/src/pages/scenarioSettings/ScenarioSettingsPage.tsx
@@ -15,42 +15,47 @@ import TrainingPreviewCard from './components/cards/trainingPreviewCard/Training
 import ScenarioSetupForm from './components/scenarioSetupForm/ScenarioSetupForm';
 import TrainingControlPanel from './components/trainingControlPanel/TrainingControlPanel';
 import TrainingEndModal from './components/trainingEndModal/TrainingEndModal';
-import { scenarioListData } from './mocks/scenarioListData';
+import { SCENARIO_LIST_DATA } from './mocks/scenarioListData';
 import {
-  basicInfo,
-  emptyBasicInfo,
-  currentRouteText,
-  liveMetrics,
-  liveStatus,
-  previewStatus,
-  fireConditionOptions,
-  previewMetrics,
-  recommendationText,
-  proposedRouteText,
-  routeProposalText,
-  selectedFireConditions,
+  CURRENT_ROUTE_TEXT,
+  DEFAULT_FIRE_CONDITIONS,
+  EMPTY_BASIC_INFO,
+  FIRE_CONDITION_OPTIONS,
+  LIVE_METRICS,
+  LIVE_STATUS,
+  PREVIEW_METRICS,
+  PREVIEW_STATUS,
+  PROPOSED_ROUTE_TEXT,
+  RECOMMENDATION_TEXT,
+  ROUTE_PROPOSAL_TEXT,
+  SCENARIO_DETAIL_DATA,
 } from './mocks/scenarioSettingsData';
 import * as styles from './ScenarioSettingsPage.css';
 import { SCENARIO_STATUS } from './types/scenarioList';
 
-const ScenarioSettingsPage = () => {
+import type { ScenarioSummary } from './types/scenarioList';
+import type { ScenarioDetail } from './types/scenarioSettings';
+
+interface ScenarioSettingsContentProps {
+  scenario?: ScenarioSummary;
+  scenarioDetail?: ScenarioDetail;
+}
+
+const ScenarioSettingsContent = ({ scenario, scenarioDetail }: ScenarioSettingsContentProps) => {
   const navigate = useNavigate();
-  const { scenarioId } = useParams();
   const { show } = useToast();
-  const isCreatePage = scenarioId === undefined;
-  const scenario = scenarioListData.find((item) => item.id === scenarioId);
+  const isCreatePage = scenario === undefined;
   const isInitiallyEditing = isCreatePage || scenario?.status === SCENARIO_STATUS.DRAFT;
   const [isEndModalOpen, setIsEndModalOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(isInitiallyEditing);
   const [startedAt, setStartedAt] = useState<number | null>(() =>
     scenario?.status === SCENARIO_STATUS.IN_PROGRESS ? Date.now() - 8 * 60 * 1000 : null,
   );
-  const [currentRoute, setCurrentRoute] = useState(currentRouteText);
-  const [routeProposal, setRouteProposal] = useState<string | null>(routeProposalText);
+  const [currentRoute, setCurrentRoute] = useState(CURRENT_ROUTE_TEXT);
+  const [routeProposal, setRouteProposal] = useState<string | null>(ROUTE_PROPOSAL_TEXT);
   const isRunning = startedAt !== null;
-  const scenarioBasicInfo = isCreatePage
-    ? emptyBasicInfo
-    : { ...basicInfo, scenarioName: scenario?.name ?? basicInfo.scenarioName };
+  const scenarioBasicInfo = scenarioDetail?.basicInfo ?? EMPTY_BASIC_INFO;
+  const fireConditions = scenarioDetail?.fireConditions ?? DEFAULT_FIRE_CONDITIONS;
 
   const startTraining = () => {
     setStartedAt(Date.now());
@@ -70,21 +75,17 @@ const ScenarioSettingsPage = () => {
   };
 
   const handleApplyRouteProposal = () => {
-    setCurrentRoute(proposedRouteText);
+    setCurrentRoute(PROPOSED_ROUTE_TEXT);
     setRouteProposal(null);
   };
-
-  if (!isCreatePage && !scenario) {
-    return <Navigate replace to={ROUTES.SCENARIO_LIST} />;
-  }
 
   return (
     <div className={styles.container}>
       <div className={styles.contentGrid}>
         <ScenarioSetupForm
           basicInfo={scenarioBasicInfo}
-          conditions={selectedFireConditions}
-          options={fireConditionOptions}
+          conditions={fireConditions}
+          options={FIRE_CONDITION_OPTIONS}
           isRunning={isRunning}
           readOnly={!isEditing && !isRunning}
         />
@@ -94,8 +95,8 @@ const ScenarioSettingsPage = () => {
             startedAt={startedAt}
             currentRoute={currentRoute}
             routeProposal={routeProposal}
-            liveStatus={liveStatus}
-            liveMetrics={liveMetrics}
+            liveStatus={LIVE_STATUS}
+            liveMetrics={LIVE_METRICS}
             onEnd={() => setIsEndModalOpen(true)}
             onRejectRouteProposal={handleRejectRouteProposal}
             onApplyRouteProposal={handleApplyRouteProposal}
@@ -129,8 +130,8 @@ const ScenarioSettingsPage = () => {
                 >
                   시나리오 시작
                 </Button>
-                <RecommendationCard icon={<SparklesIcon />} message={recommendationText} />
-                <TrainingPreviewCard status={previewStatus} metrics={previewMetrics} />
+                <RecommendationCard icon={<SparklesIcon />} message={RECOMMENDATION_TEXT} />
+                <TrainingPreviewCard status={PREVIEW_STATUS} metrics={PREVIEW_METRICS} />
                 <Button
                   type="button"
                   variant="ghost"
@@ -152,6 +153,26 @@ const ScenarioSettingsPage = () => {
         onReport={() => void navigate(ROUTES.REPORTS)}
       />
     </div>
+  );
+};
+
+const ScenarioSettingsPage = () => {
+  const { scenarioId } = useParams();
+  const scenario = scenarioId
+    ? SCENARIO_LIST_DATA.find((item) => item.id === scenarioId)
+    : undefined;
+  const scenarioDetail = scenarioId ? SCENARIO_DETAIL_DATA[scenarioId] : undefined;
+
+  if (scenarioId && (!scenario || !scenarioDetail)) {
+    return <Navigate replace to={ROUTES.SCENARIO_LIST} />;
+  }
+
+  return (
+    <ScenarioSettingsContent
+      key={scenarioId ?? 'new'}
+      scenario={scenario}
+      scenarioDetail={scenarioDetail}
+    />
   );
 };
 

--- a/src/pages/scenarioSettings/components/inputField/dateTimeField/DateTimeField.css.ts
+++ b/src/pages/scenarioSettings/components/inputField/dateTimeField/DateTimeField.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '@styles/global.css';
 
@@ -14,18 +15,36 @@ export const label = style({
   ...vars.typography.body14Medium,
 });
 
-export const trigger = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: vars.space.s4,
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.md,
-  backgroundColor: vars.color.white,
-  padding: '0 1.6rem',
-  width: '100%',
-  height: '4.4rem',
-  textAlign: 'left',
-  color: vars.color.textHigh,
+export const trigger = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: vars.space.s4,
+    border: `1px solid ${vars.color.gray100}`,
+    borderRadius: vars.radius.md,
+    backgroundColor: vars.color.white,
+    cursor: 'pointer',
+    padding: '0 1.6rem',
+    width: '100%',
+    height: '4.4rem',
+    textAlign: 'left',
+    color: vars.color.textHigh,
+  },
+  variants: {
+    disabled: {
+      true: {
+        backgroundColor: vars.color.gray50,
+        cursor: 'not-allowed',
+      },
+      false: {},
+    },
+    readOnly: {
+      true: {
+        cursor: 'default',
+      },
+      false: {},
+    },
+  },
 });
 
 export const icon = style({
@@ -41,9 +60,19 @@ globalStyle(`${icon} svg`, {
   height: '2rem',
 });
 
-export const value = style({
-  color: vars.color.textHigh,
-  ...vars.typography.body14,
+export const value = recipe({
+  base: {
+    color: vars.color.textHigh,
+    ...vars.typography.body14,
+  },
+  variants: {
+    disabled: {
+      true: {
+        color: vars.color.textLow,
+      },
+      false: {},
+    },
+  },
 });
 
 export const hiddenInput = style({

--- a/src/pages/scenarioSettings/components/inputField/dateTimeField/DateTimeField.tsx
+++ b/src/pages/scenarioSettings/components/inputField/dateTimeField/DateTimeField.tsx
@@ -8,6 +8,7 @@ interface DateTimeFieldProps {
   label: string;
   defaultValue: string;
   disabled?: boolean;
+  readOnly?: boolean;
 }
 
 const formatDateTime = (value: string) => {
@@ -23,17 +24,23 @@ const formatDateTime = (value: string) => {
   return `${year}.${month}.${day}`;
 };
 
-const DateTimeField = ({ label, defaultValue, disabled = false }: DateTimeFieldProps) => {
+const DateTimeField = ({
+  label,
+  defaultValue,
+  disabled = false,
+  readOnly = false,
+}: DateTimeFieldProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(defaultValue);
+  const isInactive = disabled || readOnly;
 
   return (
     <label className={styles.root}>
       <span className={styles.label}>{label}</span>
       <button
         type="button"
-        className={styles.trigger}
-        disabled={disabled}
+        className={styles.trigger({ disabled, readOnly })}
+        disabled={isInactive}
         onClick={() => {
           inputRef.current?.showPicker?.();
           inputRef.current?.focus();
@@ -42,12 +49,12 @@ const DateTimeField = ({ label, defaultValue, disabled = false }: DateTimeFieldP
         <span className={styles.icon}>
           <CalendarIcon />
         </span>
-        <span className={styles.value}>{formatDateTime(value)}</span>
+        <span className={styles.value({ disabled })}>{formatDateTime(value)}</span>
       </button>
       <input
         ref={inputRef}
         type="date"
-        disabled={disabled}
+        disabled={isInactive}
         value={value}
         className={styles.hiddenInput}
         onChange={(event) => {

--- a/src/pages/scenarioSettings/components/inputField/scenarioField/ScenarioField.css.ts
+++ b/src/pages/scenarioSettings/components/inputField/scenarioField/ScenarioField.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { vars } from '@styles/global.css';
 
@@ -14,17 +15,27 @@ export const label = style({
   ...vars.typography.body14Medium,
 });
 
-export const fieldShell = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: vars.space.s3,
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.md,
-  backgroundColor: vars.color.white,
-  padding: '0 1.6rem',
-  height: '4.4rem',
-  color: vars.color.textHigh,
-  ...vars.typography.body14,
+export const fieldShell = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: vars.space.s3,
+    border: `1px solid ${vars.color.gray100}`,
+    borderRadius: vars.radius.md,
+    backgroundColor: vars.color.white,
+    padding: '0 1.6rem',
+    height: '4.4rem',
+    color: vars.color.textHigh,
+    ...vars.typography.body14,
+  },
+  variants: {
+    disabled: {
+      true: {
+        backgroundColor: vars.color.gray50,
+      },
+      false: {},
+    },
+  },
 });
 
 export const withLeadingIcon = style({
@@ -40,15 +51,34 @@ globalStyle(`${withLeadingIcon} svg`, {
   height: '1.4rem',
 });
 
-export const select = style({
-  appearance: 'none',
-  outline: 'none',
-  border: 'none',
-  background: 'transparent',
-  width: '100%',
-  color: vars.color.textHigh,
-  WebkitAppearance: 'none',
-  ...vars.typography.body14,
+export const select = recipe({
+  base: {
+    appearance: 'none',
+    opacity: 1,
+    outline: 'none',
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    width: '100%',
+    color: vars.color.textHigh,
+    WebkitAppearance: 'none',
+    ...vars.typography.body14,
+  },
+  variants: {
+    disabled: {
+      true: {
+        cursor: 'not-allowed',
+        color: vars.color.textLow,
+      },
+      false: {},
+    },
+    readOnly: {
+      true: {
+        cursor: 'default',
+      },
+      false: {},
+    },
+  },
 });
 
 export const trailingIcon = style({

--- a/src/pages/scenarioSettings/components/inputField/scenarioField/ScenarioField.tsx
+++ b/src/pages/scenarioSettings/components/inputField/scenarioField/ScenarioField.tsx
@@ -10,6 +10,7 @@ interface ScenarioFieldProps {
   options: readonly string[];
   leadingIcon?: ReactNode;
   disabled?: boolean;
+  readOnly?: boolean;
 }
 
 const ScenarioField = ({
@@ -18,25 +19,35 @@ const ScenarioField = ({
   options,
   leadingIcon,
   disabled = false,
-}: ScenarioFieldProps) => (
-  <label className={styles.root}>
-    <span className={styles.label}>{label}</span>
-    <span className={styles.fieldShell}>
-      {leadingIcon ? <span className={styles.withLeadingIcon}>{leadingIcon}</span> : null}
-      <select className={styles.select} defaultValue={value} aria-label={label} disabled={disabled}>
-        {options.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
-      {!disabled && (
-        <span className={styles.trailingIcon}>
-          <ChevronDownIcon />
-        </span>
-      )}
-    </span>
-  </label>
-);
+  readOnly = false,
+}: ScenarioFieldProps) => {
+  const isInactive = disabled || readOnly;
+
+  return (
+    <label className={styles.root}>
+      <span className={styles.label}>{label}</span>
+      <span className={styles.fieldShell({ disabled })}>
+        {leadingIcon ? <span className={styles.withLeadingIcon}>{leadingIcon}</span> : null}
+        <select
+          className={styles.select({ disabled, readOnly })}
+          defaultValue={value}
+          aria-label={label}
+          disabled={isInactive}
+        >
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        {!isInactive ? (
+          <span className={styles.trailingIcon}>
+            <ChevronDownIcon />
+          </span>
+        ) : null}
+      </span>
+    </label>
+  );
+};
 
 export default ScenarioField;

--- a/src/pages/scenarioSettings/components/scenarioDeleteModal/ScenarioDeleteModal.css.ts
+++ b/src/pages/scenarioSettings/components/scenarioDeleteModal/ScenarioDeleteModal.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const modal = style({
+  width: '48rem',
+});
+
+export const confirmBody = style({
+  gap: vars.space.s4,
+  padding: `${vars.space.s8} 4rem 0`,
+});
+
+export const footer = style({
+  gap: vars.space.s3,
+  padding: `${vars.space.s7} 4rem 4rem`,
+});

--- a/src/pages/scenarioSettings/components/scenarioDeleteModal/ScenarioDeleteModal.tsx
+++ b/src/pages/scenarioSettings/components/scenarioDeleteModal/ScenarioDeleteModal.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@components/Button';
+import Modal from '@components/modal';
+
+import * as styles from './ScenarioDeleteModal.css';
+
+interface ScenarioDeleteModalProps {
+  open: boolean;
+  scenarioName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ScenarioDeleteModal = ({
+  open,
+  scenarioName,
+  onClose,
+  onConfirm,
+}: ScenarioDeleteModalProps) => (
+  <Modal
+    open={open}
+    onClose={onClose}
+    variant="confirm"
+    className={styles.modal}
+    confirmBodyClassName={styles.confirmBody}
+    footerClassName={styles.footer}
+    title="시나리오 삭제"
+    description={`정말로 '${scenarioName}'을(를) 삭제하시겠습니까?`}
+    warning="경고: 이 작업은 되돌릴 수 없습니다. 삭제된 시나리오와 관련된 모든 설정 정보가 영구적으로 삭제됩니다."
+    footer={
+      <>
+        <Button type="button" variant="ghost" size="lg" onClick={onClose}>
+          취소
+        </Button>
+        <Button type="button" variant="danger" size="lg" onClick={onConfirm}>
+          삭제
+        </Button>
+      </>
+    }
+  />
+);
+
+export default ScenarioDeleteModal;

--- a/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
+++ b/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
@@ -5,11 +5,17 @@ import { vars } from '@styles/global.css';
 export const row = style({
   display: 'flex',
   alignItems: 'center',
+  transition: 'background-color 120ms ease',
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.lg,
   backgroundColor: vars.color.white,
   minHeight: '9.2rem',
   overflow: 'visible',
+  selectors: {
+    '&:hover': {
+      backgroundColor: vars.color.gray25,
+    },
+  },
 });
 
 export const mainButton = style({
@@ -25,7 +31,6 @@ export const mainButton = style({
   minWidth: 0,
   textAlign: 'left',
   selectors: {
-    '&:hover': { backgroundColor: vars.color.gray25 },
     '&:focus-visible': {
       outline: `2px solid ${vars.color.primary}`,
       outlineOffset: '-2px',

--- a/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
+++ b/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
@@ -68,3 +68,17 @@ export const actions = style({
 export const deleteButton = style({
   backgroundColor: vars.color.dangerSurface,
 });
+
+export const disabledDeleteButton = style({
+  borderColor: vars.color.gray100,
+  backgroundColor: vars.color.gray50,
+  cursor: 'not-allowed',
+  color: vars.color.gray300,
+  selectors: {
+    '&[aria-disabled="true"]:hover': {
+      borderColor: vars.color.gray100,
+      backgroundColor: vars.color.gray50,
+      color: vars.color.gray300,
+    },
+  },
+});

--- a/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
+++ b/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.css.ts
@@ -1,0 +1,65 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const row = style({
+  display: 'flex',
+  alignItems: 'center',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.lg,
+  backgroundColor: vars.color.white,
+  minHeight: '9.2rem',
+  overflow: 'visible',
+});
+
+export const mainButton = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  alignItems: 'flex-start',
+  alignSelf: 'stretch',
+  justifyContent: 'center',
+  gap: vars.space.s2,
+  borderRadius: `${vars.radius.lg} 0 0 ${vars.radius.lg}`,
+  padding: vars.space.s5,
+  minWidth: 0,
+  textAlign: 'left',
+  selectors: {
+    '&:hover': { backgroundColor: vars.color.gray25 },
+    '&:focus-visible': {
+      outline: `2px solid ${vars.color.primary}`,
+      outlineOffset: '-2px',
+    },
+  },
+});
+
+export const titleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s3,
+  minWidth: 0,
+});
+
+export const title = style({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: vars.color.textHigh,
+  ...vars.typography.body16Bold,
+});
+
+export const detail = style({
+  color: vars.color.textMid,
+  ...vars.typography.body14,
+});
+
+export const actions = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+  paddingRight: vars.space.s5,
+});
+
+export const deleteButton = style({
+  backgroundColor: vars.color.dangerSurface,
+});

--- a/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.tsx
+++ b/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.tsx
@@ -25,10 +25,13 @@ const ScenarioListRow = ({ scenario, onOpen, onDelete }: ScenarioListRowProps) =
       variant={scenario.deletable ? 'dangerOutlined' : 'ghost'}
       size="sm"
       iconOnly
-      disabled={!scenario.deletable}
-      className={scenario.deletable ? styles.deleteButton : undefined}
+      aria-disabled={scenario.deletable ? undefined : true}
+      className={scenario.deletable ? styles.deleteButton : styles.disabledDeleteButton}
       aria-label={`${scenario.name} 삭제`}
-      onClick={() => onDelete(scenario)}
+      onClick={() => {
+        if (!scenario.deletable) return;
+        onDelete(scenario);
+      }}
     >
       <TrashIcon />
     </Button>

--- a/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.tsx
+++ b/src/pages/scenarioSettings/components/scenarioList/ScenarioListRow.tsx
@@ -1,0 +1,62 @@
+import TrashIcon from '@assets/icons/ic-trash.svg?react';
+
+import { Button } from '@components/Button';
+import StatusBadge from '@components/chip/StatusBadge';
+
+import * as styles from './ScenarioListRow.css';
+import { SCENARIO_STATUS_VIEW } from '../../types/scenarioList';
+import ScenarioListTooltip from '../tooltip/ScenarioListTooltip';
+
+import type { ScenarioSummary } from '../../types/scenarioList';
+
+interface ScenarioListRowProps {
+  scenario: ScenarioSummary;
+  onOpen: (scenario: ScenarioSummary) => void;
+  onDelete: (scenario: ScenarioSummary) => void;
+}
+
+const DELETE_DISABLED_MESSAGE = '훈련 이력이 있어 삭제할 수 없습니다';
+
+const ScenarioListRow = ({ scenario, onOpen, onDelete }: ScenarioListRowProps) => {
+  const statusView = SCENARIO_STATUS_VIEW[scenario.status];
+  const deleteButton = (
+    <Button
+      type="button"
+      variant={scenario.deletable ? 'dangerOutlined' : 'ghost'}
+      size="sm"
+      iconOnly
+      disabled={!scenario.deletable}
+      className={scenario.deletable ? styles.deleteButton : undefined}
+      aria-label={`${scenario.name} 삭제`}
+      onClick={() => onDelete(scenario)}
+    >
+      <TrashIcon />
+    </Button>
+  );
+
+  return (
+    <article className={styles.row}>
+      <button type="button" className={styles.mainButton} onClick={() => onOpen(scenario)}>
+        <span className={styles.titleRow}>
+          <strong className={styles.title}>{scenario.name}</strong>
+          <StatusBadge label={statusView.label} color={statusView.color} dot />
+        </span>
+        <span className={styles.detail}>
+          {scenario.location} · {scenario.scheduledAt} · {scenario.expectedParticipants}명
+        </span>
+      </button>
+
+      <div className={styles.actions}>
+        {scenario.deletable ? (
+          deleteButton
+        ) : (
+          <ScenarioListTooltip content={DELETE_DISABLED_MESSAGE}>
+            {deleteButton}
+          </ScenarioListTooltip>
+        )}
+      </div>
+    </article>
+  );
+};
+
+export default ScenarioListRow;

--- a/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
+++ b/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
@@ -21,6 +21,7 @@ interface ScenarioSetupFormProps {
   conditions: FireConditionField[];
   options: FireConditionOptions;
   isRunning?: boolean;
+  readOnly?: boolean;
 }
 
 const TRAINING_LOCK_MESSAGE = '🔒 잠금 · 훈련 중 수정 불가';
@@ -30,6 +31,7 @@ const ScenarioSetupForm = ({
   conditions,
   options,
   isRunning = false,
+  readOnly = false,
 }: ScenarioSetupFormProps) => (
   <div className={styles.container}>
     <section className={pageStyles.mainSectionCard}>
@@ -43,18 +45,19 @@ const ScenarioSetupForm = ({
           label="시나리오명"
           defaultValue={basicInfo.scenarioName}
           placeholder="시나리오명을 입력하세요"
+          readOnly={readOnly}
           disabled={isRunning}
         />
         <ScenarioField
           label="대상 건물"
           value={basicInfo.targetBuilding}
           options={SCENARIO_BUILDING_OPTIONS}
-          disabled={isRunning}
+          disabled={isRunning || readOnly}
         />
         <DateTimeField
           label="실시 일시"
           defaultValue={basicInfo.scheduledAt}
-          disabled={isRunning}
+          disabled={isRunning || readOnly}
         />
         <TextField
           label="예상 참가 인원"
@@ -62,6 +65,7 @@ const ScenarioSetupForm = ({
           defaultValue={basicInfo.expectedParticipants}
           placeholder="예상 참가 인원을 입력하세요"
           leftIcon={<UsersIcon />}
+          readOnly={readOnly}
           disabled={isRunning}
         />
       </div>
@@ -83,7 +87,7 @@ const ScenarioSetupForm = ({
               value={condition.value}
               options={options[condition.key]}
               leadingIcon={condition.key === 'origin' ? <AlertIcon /> : undefined}
-              disabled={isRunning}
+              disabled={isRunning || readOnly}
             />
           ))}
       </div>

--- a/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
+++ b/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
@@ -18,7 +18,7 @@ import type {
 
 interface ScenarioSetupFormProps {
   basicInfo: BasicInfo;
-  conditions: FireConditionField[];
+  conditions: readonly FireConditionField[];
   options: FireConditionOptions;
   isRunning?: boolean;
   readOnly?: boolean;

--- a/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
+++ b/src/pages/scenarioSettings/components/scenarioSetupForm/ScenarioSetupForm.tsx
@@ -52,12 +52,14 @@ const ScenarioSetupForm = ({
           label="대상 건물"
           value={basicInfo.targetBuilding}
           options={SCENARIO_BUILDING_OPTIONS}
-          disabled={isRunning || readOnly}
+          disabled={isRunning}
+          readOnly={readOnly}
         />
         <DateTimeField
           label="실시 일시"
           defaultValue={basicInfo.scheduledAt}
-          disabled={isRunning || readOnly}
+          disabled={isRunning}
+          readOnly={readOnly}
         />
         <TextField
           label="예상 참가 인원"
@@ -87,7 +89,8 @@ const ScenarioSetupForm = ({
               value={condition.value}
               options={options[condition.key]}
               leadingIcon={condition.key === 'origin' ? <AlertIcon /> : undefined}
-              disabled={isRunning || readOnly}
+              disabled={isRunning}
+              readOnly={readOnly}
             />
           ))}
       </div>

--- a/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.css.ts
+++ b/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.css.ts
@@ -1,0 +1,48 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+export const trigger = style({
+  position: 'relative',
+  display: 'inline-flex',
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${vars.color.primary}`,
+      outlineOffset: '2px',
+      borderRadius: vars.radius.md,
+    },
+  },
+});
+
+export const content = style({
+  position: 'absolute',
+  zIndex: 300,
+  right: 0,
+  bottom: 'calc(100% + 0.8rem)',
+  transform: 'translateY(0.4rem)',
+  transition: 'opacity 120ms ease, transform 120ms ease, visibility 120ms ease',
+  visibility: 'hidden',
+  opacity: 0,
+  borderRadius: vars.radius.sm,
+  boxShadow: vars.shadow.md,
+  backgroundColor: vars.color.gray700,
+  pointerEvents: 'none',
+  padding: `${vars.space.s2} ${vars.space.s3}`,
+  width: 'max-content',
+  maxWidth: '24rem',
+  textAlign: 'center',
+  color: vars.color.white,
+  ...vars.typography.caption,
+  selectors: {
+    [`${trigger}:hover &`]: {
+      transform: 'translateY(0)',
+      visibility: 'visible',
+      opacity: 1,
+    },
+    [`${trigger}:focus-visible &`]: {
+      transform: 'translateY(0)',
+      visibility: 'visible',
+      opacity: 1,
+    },
+  },
+});

--- a/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.css.ts
+++ b/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.css.ts
@@ -5,13 +5,6 @@ import { vars } from '@styles/global.css';
 export const trigger = style({
   position: 'relative',
   display: 'inline-flex',
-  selectors: {
-    '&:focus-visible': {
-      outline: `2px solid ${vars.color.primary}`,
-      outlineOffset: '2px',
-      borderRadius: vars.radius.md,
-    },
-  },
 });
 
 export const content = style({
@@ -39,7 +32,7 @@ export const content = style({
       visibility: 'visible',
       opacity: 1,
     },
-    [`${trigger}:focus-visible &`]: {
+    [`${trigger}:focus-within &`]: {
       transform: 'translateY(0)',
       visibility: 'visible',
       opacity: 1,

--- a/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.tsx
+++ b/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.tsx
@@ -1,18 +1,18 @@
-import { useId, type ReactNode } from 'react';
+import { cloneElement, useId, type ReactElement } from 'react';
 
 import * as styles from './ScenarioListTooltip.css';
 
 interface ScenarioListTooltipProps {
   content: string;
-  children: ReactNode;
+  children: ReactElement<{ 'aria-describedby'?: string }>;
 }
 
 const ScenarioListTooltip = ({ content, children }: ScenarioListTooltipProps) => {
   const tooltipId = useId();
 
   return (
-    <span className={styles.trigger} tabIndex={0} aria-describedby={tooltipId}>
-      {children}
+    <span className={styles.trigger}>
+      {cloneElement(children, { 'aria-describedby': tooltipId })}
       <span id={tooltipId} className={styles.content} role="tooltip">
         {content}
       </span>

--- a/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.tsx
+++ b/src/pages/scenarioSettings/components/tooltip/ScenarioListTooltip.tsx
@@ -1,0 +1,23 @@
+import { useId, type ReactNode } from 'react';
+
+import * as styles from './ScenarioListTooltip.css';
+
+interface ScenarioListTooltipProps {
+  content: string;
+  children: ReactNode;
+}
+
+const ScenarioListTooltip = ({ content, children }: ScenarioListTooltipProps) => {
+  const tooltipId = useId();
+
+  return (
+    <span className={styles.trigger} tabIndex={0} aria-describedby={tooltipId}>
+      {children}
+      <span id={tooltipId} className={styles.content} role="tooltip">
+        {content}
+      </span>
+    </span>
+  );
+};
+
+export default ScenarioListTooltip;

--- a/src/pages/scenarioSettings/components/trainingControlPanel/TrainingControlPanel.tsx
+++ b/src/pages/scenarioSettings/components/trainingControlPanel/TrainingControlPanel.tsx
@@ -1,6 +1,6 @@
 import { sideColumn } from '@pages/scenarioSettings/ScenarioSettingsPage.css';
 
-import PlayIcon from '@assets/icons/ic-play.svg?react';
+import PauseIcon from '@assets/icons/ic-pause.svg?react';
 import SparklesIcon from '@assets/icons/ic-sparkles.svg?react';
 
 import { Button } from '@components/Button';
@@ -42,7 +42,7 @@ const TrainingControlPanel = ({
         variant="danger"
         size="lg"
         fullWidth
-        leftIcon={<PlayIcon />}
+        leftIcon={<PauseIcon />}
         onClick={onEnd}
       >
         종료

--- a/src/pages/scenarioSettings/constants/scenarioSettings.ts
+++ b/src/pages/scenarioSettings/constants/scenarioSettings.ts
@@ -3,6 +3,9 @@ export const SCENARIO_BUILDING_OPTIONS = [
   'A동 · 본관 · 5층',
   'B동 · 별관 · 4층',
   'C동 · 연구동 · 2층',
+  'B동 · 별관 · 2층',
+  'A동 · 본관 · 1층',
+  'C동 · 체육관 · 2층',
 ] as const;
 
 export const FIRE_ORIGIN_OPTIONS = [

--- a/src/pages/scenarioSettings/mocks/scenarioListData.ts
+++ b/src/pages/scenarioSettings/mocks/scenarioListData.ts
@@ -1,6 +1,6 @@
-import { SCENARIO_STATUS, type ScenarioSummary } from '../types/scenarioList';
+import { SCENARIO_STATUS, type ScenarioSummary } from '@pages/scenarioSettings/types/scenarioList';
 
-export const scenarioListData: ScenarioSummary[] = [
+export const SCENARIO_LIST_DATA: readonly ScenarioSummary[] = [
   {
     id: 'april-regular',
     name: '2026년 4월 정기 훈련',
@@ -39,7 +39,7 @@ export const scenarioListData: ScenarioSummary[] = [
   },
 ];
 
-export const scenarioStatusFilterOptions = [
+export const SCENARIO_STATUS_FILTER_OPTIONS = [
   { label: '전체 상태', value: 'ALL' },
   { label: '임시저장', value: SCENARIO_STATUS.DRAFT },
   { label: '준비완료', value: SCENARIO_STATUS.READY },

--- a/src/pages/scenarioSettings/mocks/scenarioListData.ts
+++ b/src/pages/scenarioSettings/mocks/scenarioListData.ts
@@ -1,0 +1,48 @@
+import { SCENARIO_STATUS, type ScenarioSummary } from '../types/scenarioList';
+
+export const scenarioListData: ScenarioSummary[] = [
+  {
+    id: 'april-regular',
+    name: '2026년 4월 정기 훈련',
+    location: 'A동 · 본관 · 3층',
+    scheduledAt: '2026.04.15 10:00',
+    expectedParticipants: 52,
+    status: SCENARIO_STATUS.READY,
+    deletable: true,
+  },
+  {
+    id: 'march-night',
+    name: '3월 야간 대피 훈련',
+    location: 'B동 · 별관 · 2층',
+    scheduledAt: '2026.03.20 14:00',
+    expectedParticipants: 38,
+    status: SCENARIO_STATUS.COMPLETED,
+    deletable: false,
+  },
+  {
+    id: 'freshmen-evacuation',
+    name: '신입생 대상 대피 훈련',
+    location: 'A동 · 본관 · 1층',
+    scheduledAt: '2026.04.16 09:00',
+    expectedParticipants: 45,
+    status: SCENARIO_STATUS.IN_PROGRESS,
+    deletable: false,
+  },
+  {
+    id: 'draft-scenario',
+    name: '임시 저장된 시나리오',
+    location: 'C동 · 체육관 · 2층',
+    scheduledAt: '2026.04.10 11:00',
+    expectedParticipants: 30,
+    status: SCENARIO_STATUS.DRAFT,
+    deletable: true,
+  },
+];
+
+export const scenarioStatusFilterOptions = [
+  { label: '전체 상태', value: 'ALL' },
+  { label: '임시저장', value: SCENARIO_STATUS.DRAFT },
+  { label: '준비완료', value: SCENARIO_STATUS.READY },
+  { label: '진행중', value: SCENARIO_STATUS.IN_PROGRESS },
+  { label: '완료', value: SCENARIO_STATUS.COMPLETED },
+] as const;

--- a/src/pages/scenarioSettings/mocks/scenarioSettingsData.ts
+++ b/src/pages/scenarioSettings/mocks/scenarioSettingsData.ts
@@ -12,67 +12,127 @@ import type {
   FireConditionOptions,
   PreviewMetric,
   PreviewStatus,
+  ScenarioDetail,
 } from '../types/scenarioSettings';
 
-export const basicInfo: BasicInfo = {
-  scenarioName: '2026년 4월 정기 훈련',
-  targetBuilding: SCENARIO_BUILDING_OPTIONS[0],
-  scheduledAt: '2026-04-15T10:00',
-  expectedParticipants: '52',
-};
-
-export const emptyBasicInfo: BasicInfo = {
+export const EMPTY_BASIC_INFO: BasicInfo = {
   scenarioName: '',
   targetBuilding: SCENARIO_BUILDING_OPTIONS[0],
   scheduledAt: '',
   expectedParticipants: '',
 };
 
-export const selectedFireConditions: FireConditionField[] = [
-  { key: 'origin', label: '발화 위치', value: FIRE_ORIGIN_OPTIONS[0] },
-  { key: 'spread', label: '확산 속도', value: FIRE_SPREAD_OPTIONS[1] },
-  { key: 'smoke', label: '연기 밀도', value: SMOKE_DENSITY_OPTIONS[2] },
-  { key: 'guideLight', label: '유도등 차단', value: GUIDE_LIGHT_OPTIONS[0] },
+const createFireConditions = (
+  origin: string,
+  spread: string,
+  smoke: string,
+  guideLight: string,
+): FireConditionField[] => [
+  { key: 'origin', label: '발화 위치', value: origin },
+  { key: 'spread', label: '확산 속도', value: spread },
+  { key: 'smoke', label: '연기 밀도', value: smoke },
+  { key: 'guideLight', label: '유도등 차단', value: guideLight },
 ];
 
-export const fireConditionOptions: FireConditionOptions = {
+export const DEFAULT_FIRE_CONDITIONS = createFireConditions(
+  FIRE_ORIGIN_OPTIONS[0],
+  FIRE_SPREAD_OPTIONS[1],
+  SMOKE_DENSITY_OPTIONS[2],
+  GUIDE_LIGHT_OPTIONS[0],
+);
+
+export const SCENARIO_DETAIL_DATA: Readonly<Record<string, ScenarioDetail>> = {
+  'april-regular': {
+    basicInfo: {
+      scenarioName: '2026년 4월 정기 훈련',
+      targetBuilding: SCENARIO_BUILDING_OPTIONS[0],
+      scheduledAt: '2026-04-15T10:00',
+      expectedParticipants: '52',
+    },
+    fireConditions: DEFAULT_FIRE_CONDITIONS,
+  },
+  'march-night': {
+    basicInfo: {
+      scenarioName: '3월 야간 대피 훈련',
+      targetBuilding: SCENARIO_BUILDING_OPTIONS[4],
+      scheduledAt: '2026-03-20T14:00',
+      expectedParticipants: '38',
+    },
+    fireConditions: createFireConditions(
+      FIRE_ORIGIN_OPTIONS[1],
+      FIRE_SPREAD_OPTIONS[0],
+      SMOKE_DENSITY_OPTIONS[1],
+      GUIDE_LIGHT_OPTIONS[1],
+    ),
+  },
+  'freshmen-evacuation': {
+    basicInfo: {
+      scenarioName: '신입생 대상 대피 훈련',
+      targetBuilding: SCENARIO_BUILDING_OPTIONS[5],
+      scheduledAt: '2026-04-16T09:00',
+      expectedParticipants: '45',
+    },
+    fireConditions: createFireConditions(
+      FIRE_ORIGIN_OPTIONS[2],
+      FIRE_SPREAD_OPTIONS[2],
+      SMOKE_DENSITY_OPTIONS[2],
+      GUIDE_LIGHT_OPTIONS[2],
+    ),
+  },
+  'draft-scenario': {
+    basicInfo: {
+      scenarioName: '임시 저장된 시나리오',
+      targetBuilding: SCENARIO_BUILDING_OPTIONS[6],
+      scheduledAt: '2026-04-10T11:00',
+      expectedParticipants: '30',
+    },
+    fireConditions: createFireConditions(
+      FIRE_ORIGIN_OPTIONS[3],
+      FIRE_SPREAD_OPTIONS[1],
+      SMOKE_DENSITY_OPTIONS[0],
+      GUIDE_LIGHT_OPTIONS[3],
+    ),
+  },
+};
+
+export const FIRE_CONDITION_OPTIONS: FireConditionOptions = {
   origin: FIRE_ORIGIN_OPTIONS,
   spread: FIRE_SPREAD_OPTIONS,
   smoke: SMOKE_DENSITY_OPTIONS,
   guideLight: GUIDE_LIGHT_OPTIONS,
 };
 
-export const recommendationText =
+export const RECOMMENDATION_TEXT =
   '과거 7회 훈련에서 1층 로비 밀집도가 평균 92%로 병목이 발생했습니다. 서측 계단 우회 경로를 추가 권장합니다.';
 
-export const previewStatus: PreviewStatus = {
+export const PREVIEW_STATUS: PreviewStatus = {
   label: '준비 완료',
   color: 'green',
   dot: true,
 };
 
-export const previewMetrics: PreviewMetric[] = [
+export const PREVIEW_METRICS: PreviewMetric[] = [
   { id: 'route', label: '초기 경로 산출', value: '0.5초' },
   { id: 'cctv', label: '감지 CCTV', value: '4대' },
   { id: 'iot', label: '활성 IoT 유도등', value: '12개' },
   { id: 'evacuation', label: '예상 대피 시간', value: '3분 50초' },
 ];
 
-export const liveStatus: PreviewStatus = {
+export const LIVE_STATUS: PreviewStatus = {
   label: '진행중',
   color: 'green',
   dot: true,
 };
 
-export const liveMetrics: PreviewMetric[] = [
+export const LIVE_METRICS: PreviewMetric[] = [
   { id: 'route', label: '마지막 경로 재산출', value: '10초 전' },
   { id: 'cctv', label: '감지 CCTV', value: '4대' },
   { id: 'iot', label: '활성 IoT 유도등', value: '12개' },
   { id: 'evacuation', label: '잔여 예상 대피 시간', value: '1분 30초' },
 ];
 
-export const currentRouteText = '3층 305호 → 서측 계단 → 1층 로비 출구. 마지막 재산출 10초 전';
+export const CURRENT_ROUTE_TEXT = '3층 305호 → 서측 계단 → 1층 로비 출구. 마지막 재산출 10초 전';
 
-export const routeProposalText = '1층 로비 밀집도 92% 감지 · 서측 계단 경유로 우회 경로 재산출';
+export const ROUTE_PROPOSAL_TEXT = '1층 로비 밀집도 92% 감지 · 서측 계단 경유로 우회 경로 재산출';
 
-export const proposedRouteText = '3층 305호 → 서측 계단 → 1층 서측 출구. 마지막 재산출 방금 전';
+export const PROPOSED_ROUTE_TEXT = '3층 305호 → 서측 계단 → 1층 서측 출구. 마지막 재산출 방금 전';

--- a/src/pages/scenarioSettings/mocks/scenarioSettingsData.ts
+++ b/src/pages/scenarioSettings/mocks/scenarioSettingsData.ts
@@ -15,9 +15,16 @@ import type {
 } from '../types/scenarioSettings';
 
 export const basicInfo: BasicInfo = {
+  scenarioName: '2026년 4월 정기 훈련',
+  targetBuilding: SCENARIO_BUILDING_OPTIONS[0],
+  scheduledAt: '2026-04-15T10:00',
+  expectedParticipants: '52',
+};
+
+export const emptyBasicInfo: BasicInfo = {
   scenarioName: '',
   targetBuilding: SCENARIO_BUILDING_OPTIONS[0],
-  scheduledAt: '2026-04-15',
+  scheduledAt: '',
   expectedParticipants: '',
 };
 

--- a/src/pages/scenarioSettings/types/scenarioList.ts
+++ b/src/pages/scenarioSettings/types/scenarioList.ts
@@ -1,0 +1,30 @@
+import type { StatusBadgeColor } from '@components/chip/StatusBadge';
+
+export const SCENARIO_STATUS = {
+  DRAFT: 'DRAFT',
+  READY: 'READY',
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
+} as const;
+
+export type ScenarioStatus = (typeof SCENARIO_STATUS)[keyof typeof SCENARIO_STATUS];
+
+export interface ScenarioSummary {
+  id: string;
+  name: string;
+  location: string;
+  scheduledAt: string;
+  expectedParticipants: number;
+  status: ScenarioStatus;
+  deletable: boolean;
+}
+
+export const SCENARIO_STATUS_VIEW: Record<
+  ScenarioStatus,
+  { label: string; color: StatusBadgeColor }
+> = {
+  DRAFT: { label: '임시저장', color: 'purple' },
+  READY: { label: '준비완료', color: 'green' },
+  IN_PROGRESS: { label: '진행중', color: 'yellow' },
+  COMPLETED: { label: '완료', color: 'neutral' },
+};

--- a/src/pages/scenarioSettings/types/scenarioSettings.ts
+++ b/src/pages/scenarioSettings/types/scenarioSettings.ts
@@ -22,6 +22,11 @@ export interface FireConditionOptions {
   guideLight: readonly string[];
 }
 
+export interface ScenarioDetail {
+  basicInfo: BasicInfo;
+  fireConditions: readonly FireConditionField[];
+}
+
 export interface PreviewMetric {
   id: string;
   label: string;

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,6 +4,12 @@ import AppLayout from '@/layout/AppLayout';
 import ProtectedRoute from '@/routes/ProtectedRoute';
 import { ROUTES } from '@/shared/constants/path';
 
+const loadScenarioSettingsPage = async () => {
+  const { default: ScenarioSettingsPage } =
+    await import('@/pages/scenarioSettings/ScenarioSettingsPage');
+  return { Component: ScenarioSettingsPage };
+};
+
 const router = createBrowserRouter([
   {
     path: ROUTES.LANDING,
@@ -42,12 +48,20 @@ const router = createBrowserRouter([
         },
       },
       {
-        path: ROUTES.SCENARIO_SETTINGS,
+        path: ROUTES.SCENARIO_LIST,
         lazy: async () => {
-          const { default: ScenarioSettingsPage } =
-            await import('@/pages/scenarioSettings/ScenarioSettingsPage');
-          return { Component: ScenarioSettingsPage };
+          const { default: ScenarioListPage } =
+            await import('@/pages/scenarioSettings/ScenarioListPage');
+          return { Component: ScenarioListPage };
         },
+      },
+      {
+        path: ROUTES.SCENARIO_CREATE,
+        lazy: loadScenarioSettingsPage,
+      },
+      {
+        path: ROUTES.SCENARIO_DETAIL,
+        lazy: loadScenarioSettingsPage,
       },
       {
         path: ROUTES.MANAGEMENT,

--- a/src/shared/components/dropdown/Dropdown.css.ts
+++ b/src/shared/components/dropdown/Dropdown.css.ts
@@ -13,12 +13,13 @@ export const trigger = recipe({
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
+    justifyContent: 'space-between',
     gap: vars.space.s2,
     border: `1px solid ${vars.color.gray100}`,
-    borderRadius: vars.radius.pill,
     backgroundColor: vars.color.white,
     cursor: 'pointer',
     padding: `${vars.space.s2} ${vars.space.s3} ${vars.space.s2} ${vars.space.s4}`,
+    minWidth: '14rem',
     color: vars.color.textHigh,
     ...vars.typography.body14Medium,
     selectors: {
@@ -27,6 +28,10 @@ export const trigger = recipe({
     },
   },
   variants: {
+    shape: {
+      pill: { borderRadius: vars.radius.pill },
+      rounded: { borderRadius: vars.radius.md },
+    },
     disabled: {
       true: {
         opacity: 0.4,

--- a/src/shared/components/dropdown/Dropdown.tsx
+++ b/src/shared/components/dropdown/Dropdown.tsx
@@ -13,12 +13,13 @@ export interface DropdownOption<T extends string = string> {
 }
 
 export interface DropdownProps<T extends string = string> {
-  options: DropdownOption<T>[];
+  options: readonly DropdownOption<T>[];
   value: T;
   onChange: (value: T) => void;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  shape?: 'pill' | 'rounded';
 }
 
 const Dropdown = <T extends string = string>({
@@ -28,6 +29,7 @@ const Dropdown = <T extends string = string>({
   placeholder = '선택',
   disabled = false,
   className,
+  shape = 'pill',
 }: DropdownProps<T>) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -65,7 +67,7 @@ const Dropdown = <T extends string = string>({
     <div ref={containerRef} className={clsx(styles.container, className)}>
       <button
         type="button"
-        className={styles.trigger({ disabled })}
+        className={styles.trigger({ disabled, shape })}
         aria-expanded={open}
         aria-haspopup="listbox"
         disabled={disabled}

--- a/src/shared/components/modal/Modal.css.ts
+++ b/src/shared/components/modal/Modal.css.ts
@@ -120,9 +120,9 @@ export const confirmDescription = style({
 });
 
 export const warningBox = style({
-  border: `1px solid ${vars.color.dangerLight}`,
+  border: `1px solid ${vars.color.dangerBorder}`,
   borderRadius: vars.radius.md,
-  backgroundColor: '#FFF5F5',
+  backgroundColor: vars.color.dangerSurface,
   padding: vars.space.s4,
   color: vars.color.danger,
   ...vars.typography.body14,

--- a/src/shared/components/modal/Modal.tsx
+++ b/src/shared/components/modal/Modal.tsx
@@ -22,6 +22,7 @@ export interface ModalProps {
   icon?: ReactNode;
   className?: string;
   confirmBodyClassName?: string;
+  footerClassName?: string;
 }
 
 const FOCUSABLE = [
@@ -46,6 +47,7 @@ const Modal = ({
   icon,
   className,
   confirmBodyClassName,
+  footerClassName,
 }: ModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<Element | null>(null);
@@ -143,7 +145,7 @@ const Modal = ({
 
         {children && <div className={styles.body}>{children}</div>}
 
-        {footer && <div className={styles.footer}>{footer}</div>}
+        {footer && <div className={clsx(styles.footer, footerClassName)}>{footer}</div>}
       </div>
     </div>,
     document.body,

--- a/src/shared/constants/gnbConfig.ts
+++ b/src/shared/constants/gnbConfig.ts
@@ -11,6 +11,11 @@ const DEFAULT_GNB_CONFIG = {
   description: '안전 관리 시스템',
 } as const satisfies GNBConfig;
 
+const SCENARIO_SETTINGS_GNB_CONFIG = {
+  title: '시나리오 설정',
+  description: '화재 발생 위치와 조건을 설정하고 시나리오를 시작합니다',
+} as const satisfies GNBConfig;
+
 const GNB_CONFIGS = [
   {
     path: ROUTES.HOME,
@@ -20,10 +25,18 @@ const GNB_CONFIGS = [
     },
   },
   {
-    path: ROUTES.SCENARIO_SETTINGS,
+    path: ROUTES.SCENARIO_CREATE,
+    config: SCENARIO_SETTINGS_GNB_CONFIG,
+  },
+  {
+    path: ROUTES.SCENARIO_DETAIL,
+    config: SCENARIO_SETTINGS_GNB_CONFIG,
+  },
+  {
+    path: ROUTES.SCENARIO_LIST,
     config: {
-      title: '훈련 관리',
-      description: '화재 발생 위치와 조건을 설정하고 시나리오를 시작합니다',
+      title: '시나리오 설정',
+      description: '등록된 훈련 시나리오를 확인하고 관리합니다',
     },
   },
   {

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -3,7 +3,9 @@ export const ROUTES = {
   LOGIN: '/login',
   SIGNUP: '/signup',
   LANDING: '/landing',
-  SCENARIO_SETTINGS: '/scenarioSettings',
+  SCENARIO_LIST: '/scenarioSettings',
+  SCENARIO_CREATE: '/scenarioSettings/new',
+  SCENARIO_DETAIL: '/scenarioSettings/:scenarioId',
   MANAGEMENT: '/management',
   BUILDINGS: '/buildings',
   FLOOR_PLANS: '/floorPlans',
@@ -13,3 +15,6 @@ export const ROUTES = {
   TRAINING_MONITORING: '/trainingAnalysis/monitoring',
   REPORTS: '/reports',
 } as const;
+
+export const getScenarioDetailPath = (scenarioId: string) =>
+  ROUTES.SCENARIO_DETAIL.replace(':scenarioId', scenarioId);

--- a/src/shared/constants/path.ts
+++ b/src/shared/constants/path.ts
@@ -17,4 +17,4 @@ export const ROUTES = {
 } as const;
 
 export const getScenarioDetailPath = (scenarioId: string) =>
-  ROUTES.SCENARIO_DETAIL.replace(':scenarioId', scenarioId);
+  ROUTES.SCENARIO_DETAIL.replace(':scenarioId', encodeURIComponent(scenarioId));

--- a/src/shared/constants/sidebar.ts
+++ b/src/shared/constants/sidebar.ts
@@ -10,7 +10,7 @@ import { ROUTES } from '@constants/path';
 
 export const sidebarItems = [
   { label: '홈', icon: HomeIcon, path: ROUTES.HOME },
-  { label: '시나리오 설정', icon: DashBoardIcon, path: ROUTES.SCENARIO_SETTINGS },
+  { label: '시나리오 설정', icon: DashBoardIcon, path: ROUTES.SCENARIO_LIST },
   {
     label: '관리',
     icon: LayersIcon,

--- a/src/shared/styles/global.css.ts
+++ b/src/shared/styles/global.css.ts
@@ -23,6 +23,8 @@ export const vars = createGlobalTheme(':root', {
 
     danger: '#EF4444',
     dangerLight: '#FEE2E2',
+    dangerSurface: '#FEF2F2',
+    dangerBorder: '#FECACA',
     dangerText: '#991B1B',
     info: '#2563EB',
     infoLight: '#DBEAFE',


### PR DESCRIPTION
## 📌 Summary

- 시나리오 목록 및 Empty UI 추가
- 시나리오 신규 작성·상세 조회·수정·훈련 진행 흐름 구성
- 시나리오 삭제 정책 및 확인 모달 추가
- 목록·신규·상세 라우팅과 사이드바 연결 변경

## 🔗 관련 이슈

closes #49

## 📋 작업 내용

### 시나리오 목록 추가

> 기존 사이드바에서 시나리오 설정 클릭 시 나타나던 화면을 상세 페이지로 활용하고, 현재 목록 페이지가 바로 뜨도록 플로우를 변경하였습니다. 

- 시나리오 목록 및 상태 배지 추가
- 시나리오 상태 필터 추가
- 목록 행 클릭 시 상세 페이지 이동
- `시나리오 추가` 클릭 시 신규 작성 페이지 이동
- 목록이 없을 경우 Empty UI 및 `시나리오 만들기` 버튼 표시
- 삭제 가능 여부에 따른 삭제 버튼 활성·비활성 처리
  - 삭제 불가 버튼에 사유 안내 Tooltip 적용

### 시나리오 삭제 구성

- `deletable` 값을 기준으로 삭제 가능 여부 처리
- 삭제 정책 (현재는 목데이터 기준, 서버에서도 같은 내용으로 진행될 예정)
  - `DRAFT`, `READY`: 삭제 가능
  - `IN_PROGRESS`, `COMPLETED`: 삭제 불가

### 신규 작성·상세·수정 구성
- 신규 작성과 상세 조회를 동일한 `ScenarioSettingsPage`에서 처리
  - 신규 작성은 빈 입력값으로 초기화
  - 상세 조회는 `scenarioId`에 해당하는 데이터로 초기화
- 작성 중에는 `임시 저장`, `작성 완료` 버튼 표시
- 작성 완료 상세는 입력 필드를 읽기 전용으로 표시
- `수정하기` 클릭 시 동일한 상세 페이지에서 편집 상태로 전환
- 임시 저장 및 작성 완료 결과는 Toast로 안내

### 화면 상태 구성

| 구분 | 판단 기준 | 의미 | 왼쪽 영역 | 오른쪽 영역 |
| --- | --- | --- | --- | --- |
| 신규 작성 | `scenarioId` 없음 | 아직 저장되지 않은 신규 시나리오 | 빈 입력값·수정 가능 | 임시 저장·작성 완료 |
| 작성 중 | `scenario.status === DRAFT` | 임시 저장된 시나리오 | 저장된 값·수정 가능 | 임시 저장·작성 완료 |
| 작성 완료 상세 | `startedAt === null`, `isEditing === false` | 설정 완료 후 훈련 시작 전 상태 | 저장된 값·읽기 전용 | 시작·AI 추천·미리보기·수정하기 |
| 수정 중 | `isEditing === true` | 작성 완료 상세에서 수정하기를 선택한 상태 | 저장된 값·수정 가능 | 임시 저장·작성 완료 |
| 훈련 진행 중 | `startedAt !== null` | 훈련 시작 시각이 존재하는 실행 상태 | 설정 필드 잠금 | 종료·경과 시간·경로·실시간 상태 |

- `scenarioId`
  - 신규 작성과 저장된 시나리오 상세 조회를 구분하는 식별자
- `scenario.status`
  - 서버에서 관리하는 시나리오 업무 상태
  - `DRAFT`, `READY`, `IN_PROGRESS`, `COMPLETED` 사용
- `isEditing`
  - 상세 페이지의 현재 편집 여부를 나타내는 UI 상태 
  - 신규 작성과 `DRAFT`는 `true`로 시작
- `startedAt`
  - 훈련 진행 여부와 경과 시간 계산 기준
  - 값이 있으면 훈련 진행중 UI 표시 


## 🔍 To Reviewer

- 목록의 수정 아이콘 제거
  - 행 클릭과 수정 아이콘의 상세 이동 동작이 중복되므로 제거했습니다. 
  - 상세 페이지 내부의 `수정하기` 버튼으로 편집 모드 진입할 수 있습니다. 
- 건물 드롭다운 필터 제거
  - 건물 목록을 서버에서 추가적으로 받아와야 해서 건물별 정렬을 제거하고 목록에서는 상태 필터만 제공합니다. 
- 신규 작성과 상세 조회는 동일한 폼과 레이아웃을 사용하므로 하나의 페이지로 구성했습니다.


## 📸 스크린샷
<img width="1423" height="761" alt="image" src="https://github.com/user-attachments/assets/190df654-7411-482c-b256-fda4402a192b" />
<img width="1094" height="668" alt="image" src="https://github.com/user-attachments/assets/b92327f1-1ac9-4519-bd1f-3fb59b078a22" />
<img width="319" height="294" alt="image" src="https://github.com/user-attachments/assets/a8ebc670-2b9e-4b03-9785-eefb20937854" />
<img width="1202" height="741" alt="image" src="https://github.com/user-attachments/assets/91d13e92-72dc-46e8-a4d3-917c8ad63d0a" />
<img width="1197" height="733" alt="image" src="https://github.com/user-attachments/assets/83a42304-549e-41df-9229-049848dc2b4c" />
<img width="1203" height="651" alt="image" src="https://github.com/user-attachments/assets/7e72ac32-4ccf-4fba-8be4-20be75a7dfbc" />




## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료