### PR TITLE
[feat] 마이페이지 조회 및 수정, 로그아웃 API 연동

### DIFF
--- a/src/layout/AppLayout.tsx
+++ b/src/layout/AppLayout.tsx
@@ -1,51 +1,18 @@
-import { useCallback, useState } from 'react';
-
-import { Outlet, useLocation } from 'react-router';
-
-import GNB from '@components/gnb';
-import MyPageModal from '@components/myPageModal/MyPageModal';
-import Sidebar from '@components/sideBar/Sidebar';
-
-import { getGNBConfig } from '@constants/gnbConfig';
-import { sidebarItems } from '@constants/sidebar';
+import { Outlet } from 'react-router';
 
 import * as styles from './AppLayout.css';
-
-const currentUser = {
-  name: '김안전',
-  role: '관리자',
-};
+import AppHeader from './components/AppHeader';
+import AppSidebar from './components/AppSidebar';
 
 const AppLayout = () => {
-  const location = useLocation();
-  const [isMyPageOpen, setIsMyPageOpen] = useState(false);
-  const [selectedUserName, setSelectedUserName] = useState(currentUser.name);
-  const gnbConfig = getGNBConfig(location);
-
-  const handleProfileClick = useCallback(() => {
-    setSelectedUserName(currentUser.name);
-    setIsMyPageOpen(true);
-  }, []);
-
   return (
     <div className={styles.container}>
-      <Sidebar brand="SAFE ROUTE" menuItems={sidebarItems} onLogout={() => undefined} />
+      <AppSidebar />
 
       <main className={styles.main}>
-        <GNB
-          {...gnbConfig}
-          userName={currentUser.name}
-          userRole={currentUser.role}
-          onProfileClick={handleProfileClick}
-        />
+        <AppHeader />
         <Outlet />
       </main>
-
-      <MyPageModal
-        open={isMyPageOpen}
-        initialName={selectedUserName}
-        onClose={() => setIsMyPageOpen(false)}
-      />
     </div>
   );
 };

--- a/src/layout/components/AppHeader.tsx
+++ b/src/layout/components/AppHeader.tsx
@@ -26,6 +26,8 @@ const AppHeader = () => {
   const gnbConfig = getGNBConfig(location);
 
   const handleSaveProfile = async (form: UpdateUserProfileRequest) => {
+    if (!currentUser) return;
+
     try {
       await updateMyProfileMutation.mutateAsync(form);
       show({ title: '회원 정보가 수정되었습니다.', variant: 'success' });
@@ -35,19 +37,30 @@ const AppHeader = () => {
     }
   };
 
+  const handleProfileClick = () => {
+    if (isProfileLoading) return;
+
+    if (!currentUser) {
+      show({ title: '회원 정보를 불러오지 못했습니다.', variant: 'error' });
+      return;
+    }
+
+    setIsMyPageOpen(true);
+  };
+
   return (
     <>
       <GNB
         {...gnbConfig}
         userName={currentUser?.username ?? ''}
         userRole={currentUser?.role ? USER_ROLE_LABEL[currentUser.role] : undefined}
-        onProfileClick={() => setIsMyPageOpen(true)}
+        onProfileClick={handleProfileClick}
       />
 
       <MyPageModal
         open={isMyPageOpen}
         profile={currentUser}
-        isLoading={isProfileLoading}
+        isLoading={isProfileLoading || !currentUser}
         isSaving={updateMyProfileMutation.isPending}
         onClose={() => setIsMyPageOpen(false)}
         onSave={handleSaveProfile}

--- a/src/layout/components/AppHeader.tsx
+++ b/src/layout/components/AppHeader.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+import { useLocation } from 'react-router';
+
+import type { UpdateUserProfileRequest } from '@apis/__generated__/data-contracts';
+import { useMyProfileQuery } from '@apis/users/useMyProfileQuery';
+import { useUpdateMyProfileMutation } from '@apis/users/useUpdateMyProfileMutation';
+
+import GNB from '@components/gnb';
+import MyPageModal from '@components/myPageModal/MyPageModal';
+import useToast from '@components/toast/useToast';
+
+import { getGNBConfig } from '@constants/gnbConfig';
+
+const USER_ROLE_LABEL = {
+  MANAGER: '관리자',
+  NORMAL: '일반 사용자',
+} as const;
+
+const AppHeader = () => {
+  const location = useLocation();
+  const { show } = useToast();
+  const [isMyPageOpen, setIsMyPageOpen] = useState(false);
+  const { data: currentUser, isPending: isProfileLoading } = useMyProfileQuery();
+  const updateMyProfileMutation = useUpdateMyProfileMutation();
+  const gnbConfig = getGNBConfig(location);
+
+  const handleSaveProfile = async (form: UpdateUserProfileRequest) => {
+    try {
+      await updateMyProfileMutation.mutateAsync(form);
+      show({ title: '회원 정보가 수정되었습니다.', variant: 'success' });
+      setIsMyPageOpen(false);
+    } catch {
+      show({ title: '회원 정보 수정에 실패했습니다.', variant: 'error' });
+    }
+  };
+
+  return (
+    <>
+      <GNB
+        {...gnbConfig}
+        userName={currentUser?.username ?? ''}
+        userRole={currentUser?.role ? USER_ROLE_LABEL[currentUser.role] : undefined}
+        onProfileClick={() => setIsMyPageOpen(true)}
+      />
+
+      <MyPageModal
+        open={isMyPageOpen}
+        profile={currentUser}
+        isLoading={isProfileLoading}
+        isSaving={updateMyProfileMutation.isPending}
+        onClose={() => setIsMyPageOpen(false)}
+        onSave={handleSaveProfile}
+      />
+    </>
+  );
+};
+
+export default AppHeader;

--- a/src/layout/components/AppSidebar.tsx
+++ b/src/layout/components/AppSidebar.tsx
@@ -1,0 +1,46 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
+
+import { useLogoutMutation } from '@apis/auth/useLogoutMutation';
+
+import Sidebar from '@components/sideBar/Sidebar';
+import useToast from '@components/toast/useToast';
+
+import { ROUTES } from '@constants/path';
+import { sidebarItems } from '@constants/sidebar';
+
+import { clearAccessToken } from '@shared/auth/tokenStorage';
+
+const AppSidebar = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { show } = useToast();
+  const logoutMutation = useLogoutMutation();
+
+  const handleLogout = async () => {
+    try {
+      await logoutMutation.mutateAsync();
+      show({ title: '로그아웃되었습니다.', variant: 'success' });
+    } catch {
+      show({
+        title: '서버 로그아웃에 실패했지만 이 기기에서는 로그아웃되었습니다.',
+        variant: 'error',
+      });
+    } finally {
+      clearAccessToken();
+      queryClient.clear();
+      navigate(ROUTES.LOGIN, { replace: true });
+    }
+  };
+
+  return (
+    <Sidebar
+      brand="SAFE ROUTE"
+      menuItems={sidebarItems}
+      onLogout={handleLogout}
+      isLoggingOut={logoutMutation.isPending}
+    />
+  );
+};
+
+export default AppSidebar;

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -19,6 +19,27 @@ export interface ApiResponseBuildingResponse {
   result?: BuildingResponse;
 }
 
+export interface ApiResponseCctvRegistrationResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: CctvRegistrationResponse;
+}
+
+export interface ApiResponseCctvResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: CctvResponse;
+}
+
+export interface ApiResponseDeviceTokenIssueResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: DeviceTokenIssueResponse;
+}
+
 export interface ApiResponseEvacuationRouteResponse {
   code?: string;
   isSuccess?: boolean;
@@ -31,6 +52,20 @@ export interface ApiResponseFloorGraphResponse {
   isSuccess?: boolean;
   message?: string;
   result?: FloorGraphResponse;
+}
+
+export interface ApiResponseFloorGridCellPageResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: FloorGridCellPageResponse;
+}
+
+export interface ApiResponseFloorGridResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: FloorGridResponse;
 }
 
 export interface ApiResponseFloorResponse {
@@ -59,6 +94,13 @@ export interface ApiResponseListBuildingResponse {
   isSuccess?: boolean;
   message?: string;
   result?: BuildingResponse[];
+}
+
+export interface ApiResponseListCctvResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: CctvResponse[];
 }
 
 export interface ApiResponseListFloorResponse {
@@ -124,6 +166,13 @@ export interface ApiResponseTrainingSessionResponse {
   result?: TrainingSessionResponse;
 }
 
+export interface ApiResponseUserProfileResponse {
+  code?: string;
+  isSuccess?: boolean;
+  message?: string;
+  result?: UserProfileResponse;
+}
+
 export interface ApiResponseVoid {
   code?: string;
   isSuccess?: boolean;
@@ -150,11 +199,60 @@ export interface BuildingResponse {
   updatedAt?: string;
 }
 
+export interface CctvGridCellResponse {
+  /** @format double */
+  centerX?: number;
+  /** @format double */
+  centerY?: number;
+  /** @format int32 */
+  columnIndex?: number;
+  /** @format uuid */
+  id?: string;
+  /** @format int32 */
+  rowIndex?: number;
+  walkable?: boolean;
+}
+
+export interface CctvRegistrationResponse {
+  cctv?: CctvResponse;
+  deviceToken?: string;
+}
+
+export interface CctvResponse {
+  /** @format double */
+  monitoredAreaM2?: number;
+  code?: string;
+  /** @format uuid */
+  customNodeId?: string;
+  enabled?: boolean;
+  /** @format uuid */
+  floorId?: string;
+  /** @format double */
+  gridCellSizeMeter?: number;
+  gridCells?: CctvGridCellResponse[];
+  /** @format uuid */
+  id?: string;
+  /** @format int32 */
+  monitoredGridCellCount?: number;
+  name?: string;
+  /** @format double */
+  x?: number;
+  /** @format double */
+  y?: number;
+}
+
 export type ChangeDirectionData = ApiResponseLightDirectionResponse;
 
 export interface ChangeLightDirectionRequest {
   direction: "LEFT" | "RIGHT" | "OFF";
 }
+
+export interface ConfigureCctvGridCellsRequest {
+  /** @minItems 1 */
+  gridCellIds: string[];
+}
+
+export type ConfigureGridCellsData = ApiResponseCctvResponse;
 
 export type ConfigureGuidanceData = ApiResponseIoTLightResponse;
 
@@ -165,6 +263,15 @@ export interface ConfigureGuidanceRequest {
   leftEdgeId: string;
   /** @format uuid */
   rightEdgeId: string;
+}
+
+export type ConnectEventImageData = any;
+
+export interface ConnectEventImageRequest {
+  /** @minLength 1 */
+  eventImageKey: string;
+  /** @format int64 */
+  uploadedAt: number;
 }
 
 export type CreateBuildingData = ApiResponseBuildingResponse;
@@ -183,6 +290,32 @@ export interface CreateBuildingRequest {
   name: string;
   /** @format int32 */
   totalFloors: number;
+}
+
+export type CreateCctvData = ApiResponseCctvRegistrationResponse;
+
+export interface CreateCctvRequest {
+  /** @format uuid */
+  floorId: string;
+  /** @minItems 1 */
+  gridCellIds: string[];
+  /**
+   * @minLength 0
+   * @maxLength 100
+   */
+  name: string;
+  /**
+   * @format double
+   * @min 0
+   * @max 1
+   */
+  x: number;
+  /**
+   * @format double
+   * @min 0
+   * @max 1
+   */
+  y: number;
 }
 
 export type CreateEdgeData = ApiResponseMapEdgeResponse;
@@ -231,6 +364,37 @@ export interface CreateMapNodeRequest {
 }
 
 export type CreateNodeData = ApiResponseMapNodeResponse;
+
+export type CreateOrRegenerateGridData = ApiResponseFloorGridResponse;
+
+export interface CreateOrUpdateFloorGridRequest {
+  /** @format double */
+  cellSizeMeter?: number;
+}
+
+export interface CreatePresignedImageUrlRequest {
+  /** @format int64 */
+  capturedAt: number;
+  /**
+   * @minLength 1
+   * @pattern [A-Za-z0-9_-]+
+   */
+  cctvCode: string;
+  /**
+   * @minLength 1
+   * @pattern image/jpeg
+   */
+  contentType: string;
+  imageType: "MONITORING" | "CONGESTION_EVENT";
+  /** @format uuid */
+  referenceId: string;
+  /** @format uuid */
+  requestId: string;
+  /** @format uuid */
+  trainingSessionId: string;
+}
+
+export type CreatePresignedUrlData = PresignedImageUrlResponse;
 
 export type CreateReportData = ReportResponse;
 
@@ -308,7 +472,15 @@ export type DeleteNodeData = ApiResponseVoid;
 
 export type DeleteScenarioData = any;
 
+export interface DeviceTokenIssueResponse {
+  deviceToken?: string;
+}
+
+export type DisableCctvData = ApiResponseCctvResponse;
+
 export type DisableLightData = ApiResponseIoTLightResponse;
+
+export type EnableCctvData = ApiResponseCctvResponse;
 
 export type EnableLightData = ApiResponseIoTLightResponse;
 
@@ -323,6 +495,46 @@ export interface EvacuationRouteResponse {
 export interface FloorGraphResponse {
   edges?: MapEdgeResponse[];
   nodes?: MapNodeResponse[];
+}
+
+export interface FloorGridCellPageResponse {
+  content?: FloorGridCellResponse[];
+  first?: boolean;
+  last?: boolean;
+  /** @format int32 */
+  page?: number;
+  /** @format int32 */
+  size?: number;
+  /** @format int64 */
+  totalElements?: number;
+  /** @format int32 */
+  totalPages?: number;
+}
+
+export interface FloorGridCellResponse {
+  /** @format double */
+  centerX?: number;
+  /** @format double */
+  centerY?: number;
+  /** @format int32 */
+  columnIndex?: number;
+  fired?: boolean;
+  /** @format uuid */
+  id?: string;
+  /** @format int32 */
+  rowIndex?: number;
+  walkable?: boolean;
+}
+
+export interface FloorGridResponse {
+  /** @format double */
+  cellSizeMeter?: number;
+  /** @format int32 */
+  columns?: number;
+  /** @format uuid */
+  floorId?: string;
+  /** @format int32 */
+  rows?: number;
 }
 
 export interface FloorResponse {
@@ -346,15 +558,25 @@ export type GetBuildingData = ApiResponseBuildingResponse;
 
 export type GetBuildingsData = ApiResponseListBuildingResponse;
 
+export type GetCctvData = ApiResponseCctvResponse;
+
+export type GetCctvsData = ApiResponseListCctvResponse;
+
 export type GetFloorData = ApiResponseFloorResponse;
 
 export type GetFloorsData = ApiResponseListFloorResponse;
 
 export type GetGraphData = ApiResponseFloorGraphResponse;
 
+export type GetGridCells1Data = ApiResponseFloorGridCellPageResponse;
+
+export type GetGridCellsData = ApiResponseCctvResponse;
+
 export type GetLightData = ApiResponseIoTLightResponse;
 
 export type GetLightsData = ApiResponseListIoTLightResponse;
+
+export type GetMyProfileData = ApiResponseUserProfileResponse;
 
 export type GetRecentReportsData = RecentTrainingReportResponse[];
 
@@ -390,6 +612,8 @@ export interface IoTLightResponse {
   y?: number;
 }
 
+export type IssueDeviceTokenData = ApiResponseDeviceTokenIssueResponse;
+
 export interface LightDirectionResponse {
   direction?: "LEFT" | "RIGHT" | "OFF";
   /** @format uuid */
@@ -414,11 +638,14 @@ export interface LoginResponse {
   expiresIn?: number;
   /** @format uuid */
   id?: string;
+  phoneNumber?: string;
   role?: "MANAGER" | "NORMAL";
   schoolName?: string;
   tokenType?: string;
   username?: string;
 }
+
+export type LogoutData = ApiResponseVoid;
 
 export interface MapEdgeResponse {
   bidirectional?: boolean;
@@ -445,6 +672,39 @@ export interface MapNodeResponse {
   y?: number;
 }
 
+export interface ObservationResponse {
+  /** @format double */
+  avgHeadcount?: number;
+  /** @format int64 */
+  capturedAt?: number;
+  cctvCode?: string;
+  /** @format int64 */
+  configVersion?: number;
+  congestionLevel?: "NORMAL" | "CAUTION" | "CROWDED" | "VERY_CROWDED";
+  /** @format double */
+  density?: number;
+  eventId?: string;
+  /** @format int64 */
+  expiresAt?: number;
+  monitoringImageKey?: string;
+  /** @format int32 */
+  peakHeadcount?: number;
+  /** @format int32 */
+  sampleCount?: number;
+  trainingSessionId?: string;
+  /** @format int64 */
+  windowEnd?: number;
+  /** @format int64 */
+  windowStart?: number;
+}
+
+export interface PresignedImageUrlResponse {
+  /** @format int64 */
+  expiresAt?: number;
+  objectKey?: string;
+  uploadUrl?: string;
+}
+
 export interface RecentTrainingReportResponse {
   /** @format int32 */
   avgEvacuationSec?: number;
@@ -459,19 +719,32 @@ export interface RecentTrainingReportResponse {
 
 export type RejectData = ApiResponseRouteRecalculationResponse;
 
-export type ReportCongestionData = any;
+export type ReportCongestionData = ObservationResponse;
 
 export interface ReportCongestionRequest {
-  s3ImageKey?: string;
-  /** @format int32 */
+  /** @format double */
   avgHeadcount: number;
-  cctvCode?: string;
-  congestionLevel: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+  /** @format int64 */
+  capturedAt: number;
+  /** @minLength 1 */
+  cctvCode: string;
+  /** @format int64 */
+  configVersion: number;
+  congestionLevel: "NORMAL" | "CAUTION" | "CROWDED" | "VERY_CROWDED";
+  /** @format double */
+  density: number;
   /** @format uuid */
   edgeId: string;
+  /** @format uuid */
+  eventId: string;
   headcountValid?: boolean;
+  monitoringImageKey?: string;
   /** @format int32 */
   peakHeadcount: number;
+  /** @format int32 */
+  sampleCount: number;
+  /** @format uuid */
+  trainingSessionId: string;
   /** @format int64 */
   windowEnd: number;
   /** @format int64 */
@@ -493,7 +766,7 @@ export interface ReportResponse {
 }
 
 export interface RouteRecalculationResponse {
-  congestionLevel?: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+  congestionLevel?: "NORMAL" | "CAUTION" | "CROWDED" | "VERY_CROWDED";
   /** @format uuid */
   id?: string;
   recalculatedNodeIds?: string[];
@@ -549,6 +822,8 @@ export interface SignupRequest {
    * @maxLength 100
    */
   password: string;
+  /** @pattern ^$|^[0-9-]{9,20}$ */
+  phoneNumber?: string;
   role?: "MANAGER" | "NORMAL";
   /**
    * @minLength 5
@@ -568,6 +843,7 @@ export interface SignupResponse {
   email?: string;
   /** @format uuid */
   id?: string;
+  phoneNumber?: string;
   role?: "MANAGER" | "NORMAL";
   schoolName?: string;
   username?: string;
@@ -611,6 +887,13 @@ export interface UpdateBuildingRequest {
   totalFloors: number;
 }
 
+export type UpdateFloorData = ApiResponseFloorResponse;
+
+export interface UpdateFloorRequest {
+  /** @format int32 */
+  floorNum: number;
+}
+
 export interface UpdateIoTLightRequest {
   /** @minLength 1 */
   name: string;
@@ -628,6 +911,8 @@ export interface UpdateMapNodePositionRequest {
   /** @format double */
   y: number;
 }
+
+export type UpdateMyProfileData = ApiResponseUserProfileResponse;
 
 export type UpdateNodePositionData = ApiResponseMapNodeResponse;
 
@@ -650,6 +935,26 @@ export interface UpdateScenarioRequest {
   scheduledAt?: string;
 }
 
+export interface UpdateUserProfileRequest {
+  /**
+   * @minLength 1
+   * @maxLength 255
+   */
+  email?: string;
+  /** @pattern ^$|^[0-9-]{9,20}$ */
+  phoneNumber?: string;
+  /**
+   * @minLength 5
+   * @maxLength 20
+   */
+  schoolName?: string;
+  /**
+   * @minLength 2
+   * @maxLength 20
+   */
+  username?: string;
+}
+
 export type UploadData = ApiResponseS3UploadResponse;
 
 export type UploadFloorData = ApiResponseFloorResponse;
@@ -668,4 +973,14 @@ export interface UploadFloorRequest {
 export interface UploadPayload {
   /** @format binary */
   file: File;
+}
+
+export interface UserProfileResponse {
+  email?: string;
+  /** @format uuid */
+  id?: string;
+  phoneNumber?: string;
+  role?: "MANAGER" | "NORMAL";
+  schoolName?: string;
+  username?: string;
 }

--- a/src/shared/apis/auth/logoutApi.ts
+++ b/src/shared/apis/auth/logoutApi.ts
@@ -1,0 +1,10 @@
+import type { LogoutData } from '@apis/__generated__/data-contracts';
+import { request, HTTP_METHOD } from '@apis/config/request';
+import { API_ENDPOINTS } from '@apis/constants/endpoints';
+
+export const postLogout = () => {
+  return request<LogoutData['result']>({
+    method: HTTP_METHOD.POST,
+    url: API_ENDPOINTS.AUTH.LOGOUT,
+  });
+};

--- a/src/shared/apis/auth/useLogoutMutation.ts
+++ b/src/shared/apis/auth/useLogoutMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { postLogout } from './logoutApi';
+
+export const useLogoutMutation = () => {
+  return useMutation({
+    mutationFn: postLogout,
+  });
+};

--- a/src/shared/apis/constants/endpoints.ts
+++ b/src/shared/apis/constants/endpoints.ts
@@ -5,7 +5,12 @@ export const API_ENDPOINTS = {
   // 사용자
   AUTH: {
     LOGIN: `${API_V1}/auth/login`,
+    LOGOUT: `${API_V1}/auth/logout`,
     SIGNUP: `${API_V1}/auth/signup`,
+  },
+
+  USERS: {
+    ME: `${API_V1}/users/me`,
   },
 
   // 건물

--- a/src/shared/apis/users/myProfileApi.ts
+++ b/src/shared/apis/users/myProfileApi.ts
@@ -1,0 +1,21 @@
+import type {
+  UpdateUserProfileRequest,
+  UserProfileResponse,
+} from '@apis/__generated__/data-contracts';
+import { request, HTTP_METHOD } from '@apis/config/request';
+import { API_ENDPOINTS } from '@apis/constants/endpoints';
+
+export const getMyProfile = () => {
+  return request<UserProfileResponse>({
+    method: HTTP_METHOD.GET,
+    url: API_ENDPOINTS.USERS.ME,
+  });
+};
+
+export const patchMyProfile = (body: UpdateUserProfileRequest) => {
+  return request<UserProfileResponse, UpdateUserProfileRequest>({
+    method: HTTP_METHOD.PATCH,
+    url: API_ENDPOINTS.USERS.ME,
+    body,
+  });
+};

--- a/src/shared/apis/users/useMyProfileQuery.ts
+++ b/src/shared/apis/users/useMyProfileQuery.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyProfile } from './myProfileApi';
+
+export const MY_PROFILE_QUERY_KEY = ['my-profile'] as const;
+
+export const useMyProfileQuery = () => {
+  return useQuery({
+    queryKey: MY_PROFILE_QUERY_KEY,
+    queryFn: getMyProfile,
+  });
+};

--- a/src/shared/apis/users/useUpdateMyProfileMutation.ts
+++ b/src/shared/apis/users/useUpdateMyProfileMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { patchMyProfile } from './myProfileApi';
+import { MY_PROFILE_QUERY_KEY } from './useMyProfileQuery';
+
+export const useUpdateMyProfileMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchMyProfile,
+    onSuccess: (profile) => {
+      queryClient.setQueryData(MY_PROFILE_QUERY_KEY, profile);
+    },
+  });
+};

--- a/src/shared/components/myPageModal/MyPageModal.tsx
+++ b/src/shared/components/myPageModal/MyPageModal.tsx
@@ -52,6 +52,8 @@ const MyPageModal = ({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (isSaving) return;
+
     await onSave(form);
   };
 

--- a/src/shared/components/myPageModal/MyPageModal.tsx
+++ b/src/shared/components/myPageModal/MyPageModal.tsx
@@ -1,50 +1,62 @@
 import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 
+import type {
+  UpdateUserProfileRequest,
+  UserProfileResponse,
+} from '@apis/__generated__/data-contracts';
+
 import { Button } from '@components/Button';
 import TextField from '@components/inputField/TextField';
 import Modal from '@components/modal';
 
 import * as styles from './MyPageModal.css';
 
-export interface MyPageForm {
-  name: string;
-  phone: string;
-  email: string;
-  organization: string;
-}
+type MyPageForm = Required<
+  Pick<UpdateUserProfileRequest, 'username' | 'phoneNumber' | 'email' | 'schoolName'>
+>;
 
 export interface MyPageModalProps {
   open: boolean;
+  profile?: UserProfileResponse;
+  isLoading?: boolean;
+  isSaving?: boolean;
   onClose: () => void;
-  initialName: string;
-  onSave?: (form: MyPageForm) => void;
+  onSave: (form: MyPageForm) => Promise<void>;
 }
 
-const getInitialForm = (name: string): MyPageForm => ({
-  name,
-  phone: '010-1234-5678',
-  email: 'hong@example.com',
-  organization: '○○고등학교',
+const getInitialForm = (profile?: UserProfileResponse): MyPageForm => ({
+  username: profile?.username ?? '',
+  phoneNumber: profile?.phoneNumber ?? '',
+  email: profile?.email ?? '',
+  schoolName: profile?.schoolName ?? '',
 });
 
-const MyPageModal = ({ open, onClose, initialName, onSave }: MyPageModalProps) => {
-  const [form, setForm] = useState<MyPageForm>({
-    ...getInitialForm(initialName),
-  });
+const MyPageModal = ({
+  open,
+  profile,
+  isLoading = false,
+  isSaving = false,
+  onClose,
+  onSave,
+}: MyPageModalProps) => {
+  const [form, setForm] = useState<MyPageForm>(() => getInitialForm(profile));
 
   useEffect(() => {
     if (!open) return;
-    setForm(getInitialForm(initialName));
-  }, [initialName, open]);
+    setForm(getInitialForm(profile));
+  }, [open, profile]);
 
   const handleChange = (field: keyof MyPageForm) => (event: ChangeEvent<HTMLInputElement>) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
   };
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    onSave?.(form);
-    onClose();
+    await onSave(form);
+  };
+
+  const handleClose = () => {
+    if (!isSaving) onClose();
   };
 
   return (
@@ -54,24 +66,55 @@ const MyPageModal = ({ open, onClose, initialName, onSave }: MyPageModalProps) =
       title="마이페이지"
       footer={
         <>
-          <Button fullWidth size="lg" type="button" variant="ghost" onClick={onClose}>
+          <Button
+            fullWidth
+            size="lg"
+            type="button"
+            variant="ghost"
+            disabled={isSaving}
+            onClick={handleClose}
+          >
             취소
           </Button>
-          <Button fullWidth size="lg" type="submit" form="my-page-form">
+          <Button
+            fullWidth
+            size="lg"
+            type="submit"
+            form="my-page-form"
+            isLoading={isSaving}
+            disabled={isLoading}
+          >
             저장
           </Button>
         </>
       }
-      onClose={onClose}
+      onClose={handleClose}
     >
       <form className={styles.form} id="my-page-form" onSubmit={handleSubmit}>
-        <TextField label="이름" value={form.name} onChange={handleChange('name')} />
-        <TextField label="전화번호" value={form.phone} onChange={handleChange('phone')} />
-        <TextField label="이메일주소" value={form.email} onChange={handleChange('email')} />
+        <TextField
+          label="이름"
+          value={form.username}
+          disabled={isLoading || isSaving}
+          onChange={handleChange('username')}
+        />
+        <TextField
+          label="전화번호"
+          value={form.phoneNumber}
+          disabled={isLoading || isSaving}
+          onChange={handleChange('phoneNumber')}
+        />
+        <TextField
+          label="이메일주소"
+          type="email"
+          value={form.email}
+          disabled={isLoading || isSaving}
+          onChange={handleChange('email')}
+        />
         <TextField
           label="기관명"
-          value={form.organization}
-          onChange={handleChange('organization')}
+          value={form.schoolName}
+          disabled={isLoading || isSaving}
+          onChange={handleChange('schoolName')}
         />
       </form>
     </Modal>

--- a/src/shared/components/sideBar/Sidebar.tsx
+++ b/src/shared/components/sideBar/Sidebar.tsx
@@ -20,9 +20,10 @@ interface SidebarProps {
     }>;
   }>;
   onLogout?: () => void;
+  isLoggingOut?: boolean;
 }
 
-const Sidebar = ({ brand, menuItems, onLogout }: SidebarProps) => {
+const Sidebar = ({ brand, menuItems, onLogout, isLoggingOut = false }: SidebarProps) => {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -113,7 +114,13 @@ const Sidebar = ({ brand, menuItems, onLogout }: SidebarProps) => {
       </nav>
 
       <footer className={styles.footer}>
-        <button type="button" onClick={onLogout} className={styles.item()}>
+        <button
+          type="button"
+          onClick={onLogout}
+          className={styles.item()}
+          disabled={isLoggingOut}
+          aria-busy={isLoggingOut}
+        >
           <LogoutIcon className={styles.icon} aria-hidden="true" focusable="false" />
           <span>로그아웃</span>
         </button>

--- a/src/shared/components/toast/Toast.tsx
+++ b/src/shared/components/toast/Toast.tsx
@@ -103,6 +103,7 @@ const Toast = ({
         type="button"
         className={styles.closeButton({ variant })}
         aria-label="닫기"
+        onPointerDown={(event) => event.stopPropagation()}
         onClick={() => onClose(id)}
       >
         <XIcon width={14} height={14} />


### PR DESCRIPTION
## 📌 Summary

- 공통 레이아웃의 UI 조합 책임과 인증·프로필 연결 책임 분리
- 로그아웃 API 연동 및 인증 상태 관리
- 마이페이지 조회·수정 API 연동
- 토스트 닫기 버튼 이벤트 충돌 해결

## 🔗 관련 이슈

closes #58 

## 📋 작업 내용

### 1. AppLayout 책임 분리

```text
src/layout/
├── AppLayout.tsx
└── components/
    ├── AppHeader.tsx
    └── AppSidebar.tsx
```

레이아웃 컴포넌트에 API 호출, 토스트, 인증 상태 정리가 집중되지 않도록 책임을 분리했습니다. 기존 `GNB`, `Sidebar`, `MyPageModal`은 재사용 가능한 UI 컴포넌트로 유지했습니다.
- `AppLayout`
  - `AppHeader`, `AppSidebar`, `Outlet` 배치만 담당
- `AppHeader`
  - GNB 프로필 표시
  - 마이페이지 모달 상태 및 프로필 조회·수정 연결
- `AppSidebar`
  - 사이드바 렌더링 및 로그아웃 흐름 연결

### 2. 로그아웃 API 연동

```text
src/shared/apis/auth/
├── logoutApi.ts
└── useLogoutMutation.ts
```

- Axios 인터셉터를 통한 Authorization 헤더 자동 주입
- 로그아웃 완료 후 access token 및 Query 캐시 초기화
- 서버 요청 실패 시에도 클라이언트 인증 정보를 제거하고 로그인 화면으로 이동

### 3. 마이페이지 조회·수정 API 연동

```text
src/shared/apis/users/
├── myProfileApi.ts
├── useMyProfileQuery.ts
└── useUpdateMyProfileMutation.ts
```

- 사용자 정보 조회 연동
  - GNB 사용자명 표시
  - 마이페이지 모달 초기값 적용
- 사용자 정보 수정 연동
  - 수정 완료 후 프로필 Query 캐시 갱신
  - GNB와 마이페이지 모달에 변경사항 즉시 반영
- 사용자 API를 `shared/apis/users`로 분리해 GNB와 마이페이지에서 동일한 캐시 공유
- 기존 하드코딩 사용자 정보 제거

### 4. 토스트 닫기 버튼 수정
토스트 드래그 영역의 pointer capture가 X 버튼 클릭을 가로채 닫기 동작이 되지 않는 문제를 발견했습니다.
- 닫기 버튼의 `pointerdown` 이벤트 전파 차단으로 해결

## 🔍 To Reviewer

- 0821 기준으로 업데이트된 스웨거 api 명세까지 반영되었습니다. (`pnpm api:generate`)

## 📸 스크린샷

- 별도 UI 디자인 변경 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료