### PR TITLE
[feat] 자동 로그인 및 토큰 재발급 API 연동

### DIFF
--- a/src/layout/components/AppSidebar.tsx
+++ b/src/layout/components/AppSidebar.tsx
@@ -9,7 +9,7 @@ import useToast from '@components/toast/useToast';
 import { ROUTES } from '@constants/path';
 import { sidebarItems } from '@constants/sidebar';
 
-import { clearAccessToken } from '@shared/auth/tokenStorage';
+import { clearTokens } from '@shared/auth/tokenStorage';
 
 const AppSidebar = () => {
   const navigate = useNavigate();
@@ -27,7 +27,7 @@ const AppSidebar = () => {
         variant: 'error',
       });
     } finally {
-      clearAccessToken();
+      clearTokens();
       queryClient.clear();
       navigate(ROUTES.LOGIN, { replace: true });
     }

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -12,7 +12,7 @@ import useToast from '@components/toast/useToast';
 
 import { ROUTES } from '@constants/path';
 
-import { setAccessToken } from '@shared/auth/tokenStorage';
+import { setTokens } from '@shared/auth/tokenStorage';
 
 import { useLoginMutation } from './api/useLoginMutation';
 import { LOGIN_FEATURES } from './constants/login';
@@ -37,9 +37,9 @@ const LoginPage = () => {
 
   const handleLogin = handleSubmit(async (values) => {
     try {
-      const { accessToken } = await loginMutation.mutateAsync(values);
+      const { accessToken, refreshToken } = await loginMutation.mutateAsync(values);
 
-      setAccessToken(accessToken, isAutoLogin);
+      setTokens(accessToken, refreshToken, isAutoLogin);
       show({ title: '로그인되었습니다.', variant: 'success' });
       navigate(ROUTES.HOME, { replace: true });
     } catch {

--- a/src/pages/login/api/loginApi.ts
+++ b/src/pages/login/api/loginApi.ts
@@ -4,16 +4,20 @@ import { API_ENDPOINTS } from '@apis/constants/endpoints';
 
 export const postLogin = async (
   body: LoginRequest,
-): Promise<LoginResponse & { accessToken: string }> => {
+): Promise<LoginResponse & { accessToken: string; refreshToken: string }> => {
   const response = await request<LoginResponse, LoginRequest>({
     method: HTTP_METHOD.POST,
     url: API_ENDPOINTS.AUTH.LOGIN,
     body,
   });
 
-  if (!response.accessToken) {
-    throw new Error('로그인 응답에 access token이 없습니다.');
+  if (!response.accessToken || !response.refreshToken) {
+    throw new Error('로그인 응답에 인증 토큰이 없습니다.');
   }
 
-  return { ...response, accessToken: response.accessToken };
+  return {
+    ...response,
+    accessToken: response.accessToken,
+    refreshToken: response.refreshToken,
+  };
 };

--- a/src/shared/apis/config/axiosInstance.ts
+++ b/src/shared/apis/config/axiosInstance.ts
@@ -18,9 +18,26 @@ import {
 import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 const REQUEST_TIMEOUT_MS: number = 30_000; // 30초
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+// 로컬 실행을 제외한 운영 환경에서 인증 토큰이 HTTP로 전송되지 않도록 차단
+const validateSecureApiUrl = () => {
+  if (!import.meta.env.PROD || LOCAL_HOSTNAMES.has(window.location.hostname)) {
+    return;
+  }
+
+  const apiUrl = new URL(API_BASE_URL || window.location.origin, window.location.origin);
+
+  if (window.location.protocol !== 'https:' || apiUrl.protocol !== 'https:') {
+    throw new Error('운영 환경에서는 HTTPS API만 사용할 수 있습니다.');
+  }
+};
+
+validateSecureApiUrl();
 
 const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: API_BASE_URL,
   timeout: REQUEST_TIMEOUT_MS,
   withCredentials: true,
 });
@@ -33,9 +50,15 @@ const PUBLIC_AUTH_ENDPOINTS: readonly string[] = [
 
 type RetryableRequestConfig = InternalAxiosRequestConfig & {
   _retry?: boolean;
+  _sessionRefreshToken?: string;
 };
 
-let reissuePromise: Promise<string> | null = null;
+interface ReissueTask {
+  refreshToken: string;
+  promise: Promise<string>;
+}
+
+let reissueTask: ReissueTask | null = null;
 
 // 공개 인증 API 확인 (로그인, 토큰 재발급, 회원가입)
 const isPublicAuthEndpoint = (url?: string) => {
@@ -53,13 +76,7 @@ const clearSession = () => {
 };
 
 // token을 재발급하고 기존 저장 방식으로 갱신
-const reissueAccessToken = async () => {
-  const refreshToken = getRefreshToken();
-
-  if (!refreshToken) {
-    throw new Error('refresh token이 없습니다.');
-  }
-
+const reissueAccessToken = async (refreshToken: string) => {
   const isPersistent = isTokenPersistent();
   const { data } = await axiosInstance.post<BaseResponse<ReissueResponse>>(
     API_ENDPOINTS.AUTH.REISSUE,
@@ -76,18 +93,27 @@ const reissueAccessToken = async () => {
     throw new Error('토큰 재발급 응답에 인증 토큰이 없습니다.');
   }
 
+  if (getRefreshToken() !== refreshToken) {
+    throw new Error('토큰 재발급 중 인증 세션이 변경되었습니다.');
+  }
+
   setTokens(accessToken, rotatedRefreshToken, isPersistent);
   return accessToken;
 };
 
-const getReissuedAccessToken = () => {
-  if (!reissuePromise) {
-    reissuePromise = reissueAccessToken().finally(() => {
-      reissuePromise = null;
-    });
+const getReissuedAccessToken = (refreshToken: string) => {
+  if (reissueTask?.refreshToken === refreshToken) {
+    return reissueTask.promise;
   }
 
-  return reissuePromise;
+  const promise = reissueAccessToken(refreshToken).finally(() => {
+    if (reissueTask?.promise === promise) {
+      reissueTask = null;
+    }
+  });
+
+  reissueTask = { refreshToken, promise };
+  return promise;
 };
 
 // access token 추가
@@ -117,32 +143,44 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    const requestAuthorization = requestConfig.headers.get('Authorization');
+
     if (requestConfig._retry) {
-      clearSession();
+      if (requestConfig._sessionRefreshToken === getRefreshToken()) {
+        clearSession();
+      }
+
       return Promise.reject(error);
     }
 
     const currentAccessToken = getAccessToken();
-    const requestAuthorization = requestConfig.headers.get('Authorization');
+    const currentRefreshToken = getRefreshToken();
 
-    if (!currentAccessToken || !requestAuthorization) {
-      clearSession();
+    if (!currentAccessToken || !currentRefreshToken || !requestAuthorization) {
+      if (!currentAccessToken) {
+        clearSession();
+      }
+
       return Promise.reject(error);
     }
 
     requestConfig._retry = true;
+    requestConfig._sessionRefreshToken = currentRefreshToken;
 
     try {
       // 대기 중 다른 요청이 이미 토큰을 갱신했다면 추가 재발급 없이 최신 토큰 사용
       const accessToken =
         requestAuthorization === `Bearer ${currentAccessToken}`
-          ? await getReissuedAccessToken()
+          ? await getReissuedAccessToken(currentRefreshToken)
           : currentAccessToken;
 
       requestConfig.headers.set('Authorization', `Bearer ${accessToken}`);
       return axiosInstance(requestConfig);
     } catch (reissueError: unknown) {
-      clearSession();
+      if (getRefreshToken() === currentRefreshToken) {
+        clearSession();
+      }
+
       return Promise.reject(reissueError);
     }
   },

--- a/src/shared/apis/config/axiosInstance.ts
+++ b/src/shared/apis/config/axiosInstance.ts
@@ -1,13 +1,21 @@
 import axios from 'axios';
 
+import type { ReissueResponse } from '@apis/__generated__/data-contracts';
 import { queryClient } from '@apis/config/queryClient';
 import { API_ENDPOINTS } from '@apis/constants/endpoints';
+import type { BaseResponse } from '@apis/types/baseResponse';
 
 import { ROUTES } from '@constants/path';
 
-import { clearAccessToken, getAccessToken } from '@shared/auth/tokenStorage';
+import {
+  clearTokens,
+  getAccessToken,
+  getRefreshToken,
+  isTokenPersistent,
+  setTokens,
+} from '@shared/auth/tokenStorage';
 
-import type { AxiosError } from 'axios';
+import type { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
 const REQUEST_TIMEOUT_MS: number = 30_000; // 30초
 
@@ -19,13 +27,70 @@ const axiosInstance = axios.create({
 
 const PUBLIC_AUTH_ENDPOINTS: readonly string[] = [
   API_ENDPOINTS.AUTH.LOGIN,
+  API_ENDPOINTS.AUTH.REISSUE,
   API_ENDPOINTS.AUTH.SIGNUP,
 ];
 
+type RetryableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
+let reissuePromise: Promise<string> | null = null;
+
+// 공개 인증 API 확인 (로그인, 토큰 재발급, 회원가입)
 const isPublicAuthEndpoint = (url?: string) => {
   return PUBLIC_AUTH_ENDPOINTS.some((endpoint) => endpoint === url);
 };
 
+// 인증 정보를 초기화, 로그인 페이지로 리다이렉트
+const clearSession = () => {
+  clearTokens();
+  queryClient.clear();
+
+  if (window.location.pathname !== ROUTES.LOGIN) {
+    window.location.replace(ROUTES.LOGIN);
+  }
+};
+
+// token을 재발급하고 기존 저장 방식으로 갱신
+const reissueAccessToken = async () => {
+  const refreshToken = getRefreshToken();
+
+  if (!refreshToken) {
+    throw new Error('refresh token이 없습니다.');
+  }
+
+  const isPersistent = isTokenPersistent();
+  const { data } = await axiosInstance.post<BaseResponse<ReissueResponse>>(
+    API_ENDPOINTS.AUTH.REISSUE,
+    { refreshToken },
+  );
+
+  if (!data.isSuccess) {
+    throw new Error(data.message);
+  }
+
+  const { accessToken, refreshToken: rotatedRefreshToken } = data.result;
+
+  if (!accessToken || !rotatedRefreshToken) {
+    throw new Error('토큰 재발급 응답에 인증 토큰이 없습니다.');
+  }
+
+  setTokens(accessToken, rotatedRefreshToken, isPersistent);
+  return accessToken;
+};
+
+const getReissuedAccessToken = () => {
+  if (!reissuePromise) {
+    reissuePromise = reissueAccessToken().finally(() => {
+      reissuePromise = null;
+    });
+  }
+
+  return reissuePromise;
+};
+
+// access token 추가
 axiosInstance.interceptors.request.use((config) => {
   const accessToken = getAccessToken();
 
@@ -36,30 +101,50 @@ axiosInstance.interceptors.request.use((config) => {
   return config;
 });
 
+// 401 응답이면 토큰을 재발급 및 재시도
 axiosInstance.interceptors.response.use(
   (response) => {
     return response;
   },
-  (error: AxiosError) => {
-    const currentAccessToken = getAccessToken();
-    const requestAuthorization = error.config?.headers.get('Authorization');
-    const isCurrentSessionRequest =
-      currentAccessToken !== null && requestAuthorization === `Bearer ${currentAccessToken}`;
+  async (error: AxiosError) => {
+    const requestConfig = error.config as RetryableRequestConfig | undefined;
 
     if (
-      error.response?.status === 401 &&
-      !isPublicAuthEndpoint(error.config?.url) &&
-      isCurrentSessionRequest
+      error.response?.status !== 401 ||
+      !requestConfig ||
+      isPublicAuthEndpoint(requestConfig.url)
     ) {
-      clearAccessToken();
-      queryClient.clear();
-
-      if (window.location.pathname !== ROUTES.LOGIN) {
-        window.location.replace(ROUTES.LOGIN);
-      }
+      return Promise.reject(error);
     }
 
-    return Promise.reject(error);
+    if (requestConfig._retry) {
+      clearSession();
+      return Promise.reject(error);
+    }
+
+    const currentAccessToken = getAccessToken();
+    const requestAuthorization = requestConfig.headers.get('Authorization');
+
+    if (!currentAccessToken || !requestAuthorization) {
+      clearSession();
+      return Promise.reject(error);
+    }
+
+    requestConfig._retry = true;
+
+    try {
+      // 대기 중 다른 요청이 이미 토큰을 갱신했다면 추가 재발급 없이 최신 토큰 사용
+      const accessToken =
+        requestAuthorization === `Bearer ${currentAccessToken}`
+          ? await getReissuedAccessToken()
+          : currentAccessToken;
+
+      requestConfig.headers.set('Authorization', `Bearer ${accessToken}`);
+      return axiosInstance(requestConfig);
+    } catch (reissueError: unknown) {
+      clearSession();
+      return Promise.reject(reissueError);
+    }
   },
 );
 

--- a/src/shared/apis/constants/endpoints.ts
+++ b/src/shared/apis/constants/endpoints.ts
@@ -6,6 +6,7 @@ export const API_ENDPOINTS = {
   AUTH: {
     LOGIN: `${API_V1}/auth/login`,
     LOGOUT: `${API_V1}/auth/logout`,
+    REISSUE: `${API_V1}/auth/reissue`,
     SIGNUP: `${API_V1}/auth/signup`,
   },
 

--- a/src/shared/auth/tokenStorage.ts
+++ b/src/shared/auth/tokenStorage.ts
@@ -1,21 +1,37 @@
 const ACCESS_TOKEN_STORAGE_KEY = 'safeRoute.accessToken';
+const REFRESH_TOKEN_STORAGE_KEY = 'safeRoute.refreshToken';
 
-export const getAccessToken = () => {
-  return (
-    sessionStorage.getItem(ACCESS_TOKEN_STORAGE_KEY) ??
-    localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY)
-  );
+const getStoredToken = (key: string) => {
+  return sessionStorage.getItem(key) ?? localStorage.getItem(key);
 };
 
-export const setAccessToken = (accessToken: string, isPersistent: boolean) => {
+export const getAccessToken = () => {
+  return getStoredToken(ACCESS_TOKEN_STORAGE_KEY);
+};
+
+export const getRefreshToken = () => {
+  return getStoredToken(REFRESH_TOKEN_STORAGE_KEY);
+};
+
+// refresh token의 저장 위치 기준으로 자동 로그인 여부 확인
+export const isTokenPersistent = () => {
+  return localStorage.getItem(REFRESH_TOKEN_STORAGE_KEY) !== null;
+};
+
+// 자동 로그인 여부에 따라 토큰 저장
+export const setTokens = (accessToken: string, refreshToken: string, isPersistent: boolean) => {
   const storage = isPersistent ? localStorage : sessionStorage;
   const otherStorage = isPersistent ? sessionStorage : localStorage;
 
   otherStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  otherStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY);
   storage.setItem(ACCESS_TOKEN_STORAGE_KEY, accessToken);
+  storage.setItem(REFRESH_TOKEN_STORAGE_KEY, refreshToken);
 };
 
-export const clearAccessToken = () => {
+export const clearTokens = () => {
   localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY);
   sessionStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  sessionStorage.removeItem(REFRESH_TOKEN_STORAGE_KEY);
 };


### PR DESCRIPTION
## 📌 Summary

자동 로그인 선택 여부에 따라 인증 토큰의 저장 위치를 구분하고, access token 만료 시 Axios 인터셉터에서 토큰을 재발급한 뒤 기존 요청을 재시도하도록 구현했습니다.

## 🔗 관련 이슈

closes #71

## 📋 작업 내용

- 로그인 응답의 access token과 refresh token 유효성 검증
- 자동 로그인 체크 시 `localStorage`, 미체크 시 `sessionStorage`에 두 토큰 저장 
  - 토큰 저장 위치는 서버 정책에 따름
- refresh token 저장 위치를 기준으로 자동 로그인 유지 여부 판단
- 401 응답 시 refresh token으로 토큰 재발급 후 기존 요청 재시도
  - 동시 401 응답 발생 시 하나의 재발급 요청을 공유하도록 처리 
  - 재발급 실패 또는 재시도 후 다시 401이 발생하면 인증 정보와 쿼리 캐시 초기화 
- 로그아웃 시 access token과 refresh token 모두 제거 

## 🔍 To Reviewer

- 자동 로그인 체크 유무에 따라 새 창을 통해 테스트 했고, 자동 로그인에 체크한 경우에만 로그인된 화면이 보여지는 것을 확인했습니다.
- 재발급 API에서 refresh token이 회전되므로 응답으로 받은 두 토큰을 모두 교체하도록 처리했습니다.
- 재발급에 실패하거나 재시도한 요청이 다시 401을 반환하면 로그인 페이지로 이동하도록 처리했습니다. 

## 📸 스크린샷

UI 변경 사항이 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료