### PR TITLE
[feat] CCTV 삭제 API 연동 및 최근 훈련 기록 갱신

### DIFF
--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2077,6 +2077,7 @@ const FloorPlansDetailPage = () => {
     setSelectedItem(null);
     setSelectedZoneRef(null);
     setSelectedEdgeId(null);
+    setDeleteConfirmTarget(null);
     setEditingItemId(null);
     setEditingStructureId(null);
     setEditingZoneId(null);
@@ -2641,6 +2642,7 @@ const FloorPlansDetailPage = () => {
   const handleFloorChange = (newId: string) => {
     setSelectedFloorId(newId);
     setSelectedItem(null);
+    setDeleteConfirmTarget(null);
     setNodeAddOpen(false);
     setZoneAddOpen(false);
     void navigate(`/floorPlans/${selectedBuildingId}/${newId}`);
@@ -3922,6 +3924,14 @@ const FloorPlansDetailPage = () => {
   const handleDeleteConfirm = () => {
     const item = deleteConfirmTarget;
     if (!item || isDeletingItem) return;
+    if (
+      item.source === 'added' &&
+      item.type === 'cctv' &&
+      !realCctvs.some((cctv) => cctv.id === item.id && cctv.floorId === floorId)
+    ) {
+      setDeleteConfirmTarget(null);
+      return;
+    }
     if (editingItemId === item.id) setEditingItemId(null);
     if (item.source === 'added') {
       if (item.type === 'cctv') {

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import clsx from 'clsx';
 import { useNavigate, useParams } from 'react-router';
 
 import { ApiError } from '@apis/errors/apiError';
+import { floorQueryKeys } from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
 import CheckIcon from '@assets/icons/ic-check.svg?react';
@@ -33,6 +35,7 @@ import { formatAreaM2 } from '@utils/format';
 import {
   configureCctvGridCells,
   createCctv,
+  deleteCctv,
   disableCctv,
   enableCctv,
   getFloorCctvs,
@@ -2005,6 +2008,7 @@ const FloorCanvas = ({
 /* ── 메인 페이지 ── */
 const FloorPlansDetailPage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { buildingId, floorId } = useParams<{ buildingId: string; floorId: string }>();
   const { show } = useToast();
 
@@ -3920,6 +3924,26 @@ const FloorPlansDetailPage = () => {
     if (!item || isDeletingItem) return;
     if (editingItemId === item.id) setEditingItemId(null);
     if (item.source === 'added') {
+      if (item.type === 'cctv') {
+        setIsDeletingItem(true);
+        deleteCctv(item.id)
+          .then(() => {
+            handleAddedDeviceDelete(item.id);
+            setRealCctvs((prev) => prev.filter((cctv) => cctv.id !== item.id));
+            setSelectedItem((prev) =>
+              prev?.kind === 'device' && prev.data.id === item.id ? null : prev,
+            );
+            if (editingCctvId === item.id) handleCancelEditCctvCells();
+            setDeleteConfirmTarget(null);
+            void queryClient.invalidateQueries({ queryKey: floorQueryKeys.cctv(floorId) });
+          })
+          .catch((error: unknown) => {
+            const { message } = extractServerError(error);
+            show({ title: message || 'CCTV 삭제에 실패했습니다.', variant: 'error' });
+          })
+          .finally(() => setIsDeletingItem(false));
+        return;
+      }
       if (item.type === 'light') {
         // 서버에서 이 유도등이 붙어있던 노드·엣지까지 cascade로 함께 삭제됨
         setIsDeletingItem(true);

--- a/src/pages/floorPlans/api/cctvApi.ts
+++ b/src/pages/floorPlans/api/cctvApi.ts
@@ -43,6 +43,13 @@ export async function updateCctv(cctvId: string, body: UpdateCctvRequest): Promi
   return toCctv(cctv);
 }
 
+export async function deleteCctv(cctvId: string): Promise<void> {
+  await apiRequest<void>({
+    method: HTTP_METHOD.DELETE,
+    url: API_ENDPOINTS.CCTV.DETAIL(cctvId),
+  });
+}
+
 export async function enableCctv(cctvId: string): Promise<Cctv> {
   const cctv = await apiRequest<CctvResponse>({
     method: HTTP_METHOD.PATCH,

--- a/src/shared/apis/__generated__/data-contracts.ts
+++ b/src/shared/apis/__generated__/data-contracts.ts
@@ -765,6 +765,8 @@ export type DeactivateBuildingData = ApiResponseVoid;
 
 export type DeleteBuildingData = ApiResponseVoid;
 
+export type DeleteCctvData = ApiResponseVoid;
+
 export type DeleteEdgeData = ApiResponseVoid;
 
 export type DeleteFloorData = ApiResponseVoid;

--- a/src/shared/apis/reports/useReports.ts
+++ b/src/shared/apis/reports/useReports.ts
@@ -22,8 +22,9 @@ export const useGenerateTrainingReportMutation = () => {
   return useMutation({
     mutationFn: postTrainingReport,
     onSuccess: (report) => {
-      if (!report.reportId) return;
-      queryClient.setQueryData(reportQueryKeys.detail(report.reportId), report);
+      if (report.reportId) {
+        queryClient.setQueryData(reportQueryKeys.detail(report.reportId), report);
+      }
       void queryClient.invalidateQueries({ queryKey: scenarioQueryKeys.all });
       void queryClient.invalidateQueries({
         queryKey: dashboardQueryKeys.recentTrainings(),

--- a/src/shared/apis/reports/useReports.ts
+++ b/src/shared/apis/reports/useReports.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { dashboardQueryKeys } from '@apis/dashboard/dashboardQueryKeys';
 import { scenarioQueryKeys } from '@apis/scenarios/scenarioQueryKeys';
 
 import { reportQueryKeys } from './reportQueryKeys';
@@ -24,6 +25,11 @@ export const useGenerateTrainingReportMutation = () => {
       if (!report.reportId) return;
       queryClient.setQueryData(reportQueryKeys.detail(report.reportId), report);
       void queryClient.invalidateQueries({ queryKey: scenarioQueryKeys.all });
+      void queryClient.invalidateQueries({
+        queryKey: dashboardQueryKeys.recentTrainings(),
+        refetchType: 'all',
+      });
+      void queryClient.invalidateQueries({ queryKey: dashboardQueryKeys.stats() });
     },
   });
 };


### PR DESCRIPTION
## 📌 Summary

도면 관리의 CCTV 삭제 API를 연동하고, 훈련 종료 후 홈의 최근 훈련 기록이 즉시 갱신되도록 쿼리 캐시를 처리했습니다.

## 🔗 관련 이슈

closes #87 
closes #88

## 📋 작업 내용

- CCTV 삭제 API 연동
  - `DELETE /api/v1/cctvs/{cctvId}` 요청 함수 추가
  - 삭제 성공 시 CCTV 카드, 도면 마커, 선택 및 편집 상태 제거
  - 삭제된 CCTV가 다른 화면에 남지 않도록 층별 CCTV 쿼리 캐시 무효화
  - 삭제 실패 시 서버 오류 메시지 표시 및 확인 모달 유지

- 최근 훈련 기록 갱신
  > 훈련 종료 후 홈으로 이동했을 때 최근 훈련 기록에 바로 업데이트되지 않는 문제 
  - 분석 보고서 생성 성공 시 최근 훈련 기록 쿼리 무효화
  - 비활성 상태의 최근 훈련 쿼리도 백그라운드에서 재조회
  - 홈 대시보드 통계 쿼리 무효화

## 🔍 To Reviewer
- 훈련 종료 후 홈 바로가기 및 보고서 확인 후 홈 이동 시 최근 훈련 기록이 갱신되는지 확인 부탁드립니다.

## 📸 스크린샷

- UI 변경 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료