### PR TITLE
[fix] 도면관리·건물관리 QA - UI/버그 개선, 코드 fix

### DIFF
--- a/src/pages/buildings/BuildingsPage.tsx
+++ b/src/pages/buildings/BuildingsPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 
 import type {
   CreateBuildingRequest,
@@ -10,8 +9,7 @@ import type {
 import { buildingQueryKeys } from '@apis/buildings/buildingQueryKeys';
 import type { Building } from '@apis/buildings/buildingTypes';
 import { useGetBuildingsQuery } from '@apis/buildings/useBuildingsQuery';
-import { ApiError } from '@apis/errors/apiError';
-import type { BaseResponse } from '@apis/types/baseResponse';
+import { extractApiError } from '@apis/errors/apiError';
 import { useMyProfileQuery } from '@apis/users/useMyProfileQuery';
 
 import BuildingIcon from '@assets/icons/ic-building.svg?react';
@@ -44,14 +42,10 @@ type ModalState =
 
 // 실패 원인을 토스트에도 보여줘서, 재현했을 때 개발자도구 없이도 바로 원인을 알 수 있게 함
 // (request.ts는 HTTP 에러 상태코드가 오면 실제 서버 메시지 대신 고정 문구로 덮어써서 콘솔에도 안 남으므로,
-// 여기서는 axios 에러의 원본 응답 바디를 직접 읽어서 진짜 서버 메시지를 보여줌)
+// 여기서는 서버 응답의 원본 code·message를 공용 헬퍼로 직접 꺼내 진짜 서버 메시지를 보여줌)
 const describeError = (error: unknown): string => {
-  if (error instanceof ApiError) return `${error.message} (${error.code})`;
-  if (isAxiosError<BaseResponse<unknown>>(error)) {
-    const serverMessage = error.response?.data?.message;
-    if (serverMessage) return `${serverMessage} (HTTP ${error.response?.status})`;
-  }
-  return '알 수 없는 오류';
+  const { code, message } = extractApiError(error);
+  return message ? `${message}${code ? ` (${code})` : ''}` : '알 수 없는 오류';
 };
 
 interface FloorSyncTarget {

--- a/src/pages/buildings/BuildingsPage.tsx
+++ b/src/pages/buildings/BuildingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 
 import type {
   CreateBuildingRequest,
@@ -45,7 +46,12 @@ type ModalState =
 // 여기서는 서버 응답의 원본 code·message를 공용 헬퍼로 직접 꺼내 진짜 서버 메시지를 보여줌)
 const describeError = (error: unknown): string => {
   const { code, message } = extractApiError(error);
-  return message ? `${message}${code ? ` (${code})` : ''}` : '알 수 없는 오류';
+  if (message) return `${message}${code ? ` (${code})` : ''}`;
+  // 서버 응답 바디가 없는 4xx/5xx는 extractApiError가 code/message를 둘 다 빈 문자열로
+  // 돌려주므로, 그때만 HTTP 상태코드라도 보여줘서 "알 수 없는 오류"보다 단서를 남김
+  if (isAxiosError(error) && error.response?.status)
+    return `알 수 없는 오류 (HTTP ${error.response.status})`;
+  return '알 수 없는 오류';
 };
 
 interface FloorSyncTarget {

--- a/src/pages/buildings/components/BuildingCard/BuildingCard.tsx
+++ b/src/pages/buildings/components/BuildingCard/BuildingCard.tsx
@@ -32,8 +32,13 @@ const BuildingCard = ({ building, onEdit, onDelete }: BuildingCardProps) => {
   const deviceStats = useBuildingDeviceStatsQuery(building.id);
   const { cctvTotal, cctvOnline, iotTotal, iotOnline } = deviceStats;
   const isIotWarning = iotOnline < iotTotal;
-  const formatCount = (online: number, total: number) =>
-    deviceStats.isLoading ? '–' : `${online}/${total}`;
+  // 등록된 장비가 없는 층/건물에서 "0/0"이 마치 오류값처럼 보인다는 피드백 — 등록 대수가
+  // 아예 없을 땐 "없음"을 뜻하는 "-"로 보여줌(같은 카드의 최근 훈련일 미기록 표기와 통일)
+  const formatCount = (online: number, total: number) => {
+    if (deviceStats.isLoading) return '–';
+    if (total === 0) return '-';
+    return `${online}/${total}`;
+  };
 
   useEffect(() => {
     if (!menuOpen) return;

--- a/src/pages/buildings/components/BuildingCard/BuildingCard.tsx
+++ b/src/pages/buildings/components/BuildingCard/BuildingCard.tsx
@@ -6,6 +6,8 @@ import CameraIcon from '@assets/icons/ic-camera.svg?react';
 import LayersIcon from '@assets/icons/ic-layers.svg?react';
 import WifiIcon from '@assets/icons/ic-wifi.svg?react';
 
+import Skeleton from '@components/skeleton/Skeleton';
+
 import * as styles from './BuildingCard.css';
 import { useBuildingDeviceStatsQuery } from '../../api/useBuildingDeviceStatsQuery';
 
@@ -33,12 +35,10 @@ const BuildingCard = ({ building, onEdit, onDelete }: BuildingCardProps) => {
   const { cctvTotal, cctvOnline, iotTotal, iotOnline } = deviceStats;
   const isIotWarning = iotOnline < iotTotal;
   // 등록된 장비가 없는 층/건물에서 "0/0"이 마치 오류값처럼 보인다는 피드백 — 등록 대수가
-  // 아예 없을 땐 "없음"을 뜻하는 "-"로 보여줌(같은 카드의 최근 훈련일 미기록 표기와 통일)
-  const formatCount = (online: number, total: number) => {
-    if (deviceStats.isLoading) return '–';
-    if (total === 0) return '-';
-    return `${online}/${total}`;
-  };
+  // 아예 없을 땐 "없음"을 뜻하는 "-"로 보여줌(같은 카드의 최근 훈련일 미기록 표기와 통일).
+  // 로딩 중엔 formatCount가 아니라 Skeleton으로 따로 표시함(건물 카드마다 조회가 따로 돌아
+  // 완료 시점이 제각각이라, 텍스트가 카드별로 들쭉날쭉 팝업되는 것보다 자리표시자가 나음)
+  const formatCount = (online: number, total: number) => (total === 0 ? '-' : `${online}/${total}`);
 
   useEffect(() => {
     if (!menuOpen) return;
@@ -115,14 +115,20 @@ const BuildingCard = ({ building, onEdit, onDelete }: BuildingCardProps) => {
             <CameraIcon className={styles.cctvIcon} width={14} height={14} />
             CCTV
           </span>
-          <span className={styles.statValue}>{formatCount(cctvOnline, cctvTotal)}</span>
+          {deviceStats.isLoading ? (
+            <Skeleton width="3.2rem" height="1.4rem" />
+          ) : (
+            <span className={styles.statValue}>{formatCount(cctvOnline, cctvTotal)}</span>
+          )}
         </div>
         <div className={styles.statItem}>
           <span className={styles.statLabel}>
             <WifiIcon className={styles.iotIcon} width={14} height={14} />
             IoT 유도등
           </span>
-          {isIotWarning ? (
+          {deviceStats.isLoading ? (
+            <Skeleton width="3.2rem" height="1.4rem" />
+          ) : isIotWarning ? (
             <span className={styles.statValueWarning}>
               {formatCount(iotOnline, iotTotal)}
               <span role="img" aria-label="경고">

--- a/src/pages/buildings/modals/BuildingAddModal.tsx
+++ b/src/pages/buildings/modals/BuildingAddModal.tsx
@@ -41,6 +41,23 @@ const INITIAL_FORM: FormState = {
   belowFloors: '0',
 };
 
+// 필드별 통과 여부와 에러 문구를 한 곳에서 판정 — isFormValid(버튼 활성화 조건)와 화면에 보여줄
+// 에러 문구가 서로 다른 기준으로 갈라지지 않게 함
+const computeFieldErrors = (form: FormState): Partial<Record<keyof FormState, string>> => {
+  const next: Partial<Record<keyof FormState, string>> = {};
+  if (!form.name.trim()) next.name = '건물명을 입력해 주세요';
+  else if (form.name.trim().length < 2 || form.name.trim().length > 20)
+    next.name = '건물명은 2~20자로 입력해 주세요';
+  if (!form.address.trim()) next.address = '주소를 입력해 주세요';
+  else if (form.address.trim().length < 8 || form.address.trim().length > 100)
+    next.address = '주소는 8~100자로 입력해 주세요';
+  if (!form.aboveFloors.trim()) next.aboveFloors = '지상 층수를 입력해 주세요';
+  else if (!isPositiveInt(form.aboveFloors)) next.aboveFloors = '올바른 층수를 입력해 주세요';
+  if (form.belowFloors.trim() && !isNonNegativeInt(form.belowFloors))
+    next.belowFloors = '올바른 층수를 입력해 주세요';
+  return next;
+};
+
 const BuildingAddModal = ({
   open,
   onClose,
@@ -48,11 +65,20 @@ const BuildingAddModal = ({
   isSubmitting = false,
 }: BuildingAddModalProps) => {
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
-  const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
+  // "추가" 버튼이 비활성 상태라 handleConfirm(및 그 안의 validate)이 아예 호출되지 않아, 값을
+  // 잘못 입력해도 왜 버튼이 안 눌리는지 안내 문구가 하나도 안 뜨던 문제 — 필드를 직접 건드린
+  // 뒤부터는 실시간으로 에러를 보여주도록 touched를 따로 추적함(건드리기 전엔 빈 폼에도
+  // 에러가 먼저 뜨지 않게)
+  const [touched, setTouched] = useState<Partial<Record<keyof FormState, true>>>({});
+  const fieldErrors = computeFieldErrors(form);
+  const errors: Partial<Record<keyof FormState, string>> = {};
+  (Object.keys(fieldErrors) as (keyof FormState)[]).forEach((key) => {
+    if (touched[key]) errors[key] = fieldErrors[key];
+  });
 
   const handleChange = (field: 'name' | 'address') => (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm((prev) => ({ ...prev, [field]: e.target.value }));
-    setErrors((prev) => ({ ...prev, [field]: '' }));
+    setTouched((prev) => ({ ...prev, [field]: true }));
   };
 
   const handleBuildingTypeChange = (value: BuildingType) => {
@@ -61,37 +87,14 @@ const BuildingAddModal = ({
 
   const handleFloorChange = (field: 'aboveFloors' | 'belowFloors') => (value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
-    setErrors((prev) => ({ ...prev, [field]: '' }));
+    setTouched((prev) => ({ ...prev, [field]: true }));
   };
 
-  // validate()와 판정 기준을 그대로 따름(에러 문구를 만들지 않고 통과 여부만 봄) —
-  // 두 곳이 서로 다른 기준으로 갈라지면 "추가" 버튼은 켜졌는데 제출은 막히는 등 어긋날 수 있음
-  const isFormValid =
-    form.name.trim().length >= 2 &&
-    form.name.trim().length <= 20 &&
-    form.address.trim().length >= 8 &&
-    form.address.trim().length <= 100 &&
-    isPositiveInt(form.aboveFloors) &&
-    (!form.belowFloors.trim() || isNonNegativeInt(form.belowFloors));
-
-  const validate = () => {
-    const next: Partial<Record<keyof FormState, string>> = {};
-    if (!form.name.trim()) next.name = '건물명을 입력해 주세요';
-    else if (form.name.trim().length < 2 || form.name.trim().length > 20)
-      next.name = '건물명은 2~20자로 입력해 주세요';
-    if (!form.address.trim()) next.address = '주소를 입력해 주세요';
-    else if (form.address.trim().length < 8 || form.address.trim().length > 100)
-      next.address = '주소는 8~100자로 입력해 주세요';
-    if (!form.aboveFloors.trim()) next.aboveFloors = '지상 층수를 입력해 주세요';
-    else if (!isPositiveInt(form.aboveFloors)) next.aboveFloors = '올바른 층수를 입력해 주세요';
-    if (form.belowFloors.trim() && !isNonNegativeInt(form.belowFloors))
-      next.belowFloors = '올바른 층수를 입력해 주세요';
-    setErrors(next);
-    return Object.keys(next).length === 0;
-  };
+  // isFormValid(버튼 활성화 조건)는 computeFieldErrors와 같은 기준을 그대로 따름
+  const isFormValid = Object.keys(fieldErrors).length === 0;
 
   const handleConfirm = () => {
-    if (!validate()) return;
+    if (!isFormValid) return;
     onConfirm(
       {
         name: form.name.trim(),
@@ -109,7 +112,7 @@ const BuildingAddModal = ({
 
   const handleClose = () => {
     setForm(INITIAL_FORM);
-    setErrors({});
+    setTouched({});
     onClose();
   };
 

--- a/src/pages/buildings/modals/BuildingAddModal.tsx
+++ b/src/pages/buildings/modals/BuildingAddModal.tsx
@@ -64,6 +64,16 @@ const BuildingAddModal = ({
     setErrors((prev) => ({ ...prev, [field]: '' }));
   };
 
+  // validate()와 판정 기준을 그대로 따름(에러 문구를 만들지 않고 통과 여부만 봄) —
+  // 두 곳이 서로 다른 기준으로 갈라지면 "추가" 버튼은 켜졌는데 제출은 막히는 등 어긋날 수 있음
+  const isFormValid =
+    form.name.trim().length >= 2 &&
+    form.name.trim().length <= 20 &&
+    form.address.trim().length >= 8 &&
+    form.address.trim().length <= 100 &&
+    isPositiveInt(form.aboveFloors) &&
+    (!form.belowFloors.trim() || isNonNegativeInt(form.belowFloors));
+
   const validate = () => {
     const next: Partial<Record<keyof FormState, string>> = {};
     if (!form.name.trim()) next.name = '건물명을 입력해 주세요';
@@ -114,8 +124,8 @@ const BuildingAddModal = ({
           <Button variant="ghost" onClick={handleClose} disabled={isSubmitting}>
             취소
           </Button>
-          <Button onClick={handleConfirm} isLoading={isSubmitting}>
-            추가 완료
+          <Button onClick={handleConfirm} isLoading={isSubmitting} disabled={!isFormValid}>
+            추가
           </Button>
         </>
       }

--- a/src/pages/buildings/modals/BuildingEditModal.tsx
+++ b/src/pages/buildings/modals/BuildingEditModal.tsx
@@ -42,6 +42,14 @@ const toFormState = (building: Building): FormState => ({
   belowFloors: String(building.basementFloorCount),
 });
 
+// 원래 값과 하나라도 다른 게 있어야 수정할 내용이 있는 것 — 앞뒤 공백만 다른 건 무시함
+const isFormDirty = (form: FormState, original: FormState): boolean =>
+  form.name.trim() !== original.name.trim() ||
+  form.address.trim() !== original.address.trim() ||
+  form.buildingType !== original.buildingType ||
+  form.aboveFloors.trim() !== original.aboveFloors.trim() ||
+  form.belowFloors.trim() !== original.belowFloors.trim();
+
 const BuildingEditModal = ({
   open,
   onClose,
@@ -51,6 +59,7 @@ const BuildingEditModal = ({
 }: BuildingEditModalProps) => {
   const [form, setForm] = useState<FormState>(toFormState(building));
   const [errors, setErrors] = useState<Partial<Record<keyof FormState, string>>>({});
+  const isDirty = isFormDirty(form, toFormState(building));
 
   useEffect(() => {
     if (open) {
@@ -115,8 +124,8 @@ const BuildingEditModal = ({
           <Button variant="ghost" onClick={onClose} disabled={isSubmitting}>
             취소
           </Button>
-          <Button onClick={handleConfirm} isLoading={isSubmitting}>
-            수정 완료
+          <Button onClick={handleConfirm} isLoading={isSubmitting} disabled={!isDirty}>
+            수정
           </Button>
         </>
       }

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -12,7 +12,7 @@ const zoneHallwayColor = '#0891B2';
 /* ── 전체 레이아웃 ── */
 // 폭 상한을 뒀었는데 그러면 큰 화면에서 좌우로 회색 여백만 생기고 정작 캔버스는 안 넓어짐
 // (되돌림) — 범례·팝업이 도면과 동떨어져 보이는 문제는 그 둘을 각각 접을 수 있게 하거나
-// 캔버스 밖으로 옮기는 쪽으로 해결함(nodeTypeLegend 접기, 팝업을 좌측 사이드바로 이동)
+// 캔버스 밖으로 옮기는 쪽으로 해결함(범례는 인포 아이콘 팝오버로, 팝업은 좌측 사이드바로 이동)
 export const layout = style({
   display: 'flex',
   flex: 1,
@@ -100,13 +100,14 @@ export const floorNavItemActive = style({
 // (코드래빗 리뷰 반영 — 컴포넌트 스타일을 페이지 스타일 파일에 두면 컴포넌트를 다른 위치로
 // 옮길 때 스타일이 따라오지 않음)
 
-/* ── 장비/구역 추가 ── */
-export const canvasActionFloat = style({
+/* ── 캔버스 우상단(범례 + 장비/구역 추가) ── */
+export const canvasTopRightRow = style({
   position: 'absolute',
   zIndex: 10,
   top: vars.space.s6,
   right: vars.space.s6,
   display: 'flex',
+  alignItems: 'flex-start',
   gap: vars.space.s2,
 });
 
@@ -386,33 +387,56 @@ export const zoneLegendLabel = style({
   ...vars.typography.caption,
 });
 
-/* ── 마크 설명(노드/구역 종류) 범례 ── */
-export const nodeTypeLegend = style({
+/* ── 마크 설명(노드/구역 종류) 안내 — 인포 아이콘을 누르면 팝오버로 뜨고 바깥을 클릭하면
+   닫힘(지도 툴에서 흔한 on-demand 패턴). "+ 추가" 메뉴(addMenuContainer/Panel)와 같은
+   click-outside 구조를 그대로 따름 ── */
+export const legendInfoContainer = style({
+  position: 'relative',
+});
+
+export const legendInfoButton = style({
+  display: 'flex',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  boxShadow: vars.shadow.sm,
+  backgroundColor: vars.color.white,
+  cursor: 'pointer',
+  width: '3.4rem',
+  height: '3.4rem',
+  color: vars.color.textMid,
+  selectors: {
+    '&:hover': { backgroundColor: vars.color.gray25 },
+    '&[aria-expanded="true"]': {
+      borderColor: vars.color.primary,
+      color: vars.color.primary,
+    },
+  },
+});
+
+const legendPopoverIn = keyframes({
+  from: { transform: 'translateY(-0.4rem)', opacity: 0 },
+  to: { transform: 'translateY(0)', opacity: 1 },
+});
+
+export const legendPopover = style({
   position: 'absolute',
-  zIndex: 10,
-  right: vars.space.s6,
-  bottom: '7.6rem',
+  zIndex: 20,
+  top: 'calc(100% + 0.4rem)',
+  left: 0,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s4,
+  transformOrigin: 'top left',
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.lg,
-  boxShadow: vars.shadow.md,
+  boxShadow: vars.shadow.lg,
   backgroundColor: vars.color.white,
   padding: vars.space.s5,
   width: '16rem',
-});
-
-export const nodeTypeLegendHeader = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: vars.space.s3,
-  border: 'none',
-  backgroundColor: 'transparent',
-  cursor: 'pointer',
-  padding: 0,
-  color: vars.color.textMid,
+  animation: `${legendPopoverIn} 0.15s ease`,
 });
 
 export const nodeTypeLegendSection = style({
@@ -441,7 +465,9 @@ export const nodeTypeDotLight = style({ backgroundColor: '#d97706' });
 export const nodeTypeAreaSwatch = style({
   flexShrink: 0,
   border: '1px solid',
-  borderRadius: vars.radius.sm,
+  // vars.radius.sm(6px)은 1.2rem(12px) 박스에서 정확히 50%라 원으로 보였음 — 모서리만
+  // 둥근 사각형이 되도록 더 작은 값으로 낮춤(테두리·채운색 규칙은 그대로 유지)
+  borderRadius: '0.3rem',
   width: '1.2rem',
   height: '1.2rem',
 });

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -284,6 +284,70 @@ export const nodeAddLabel = style({
   ...vars.typography.caption,
 });
 
+// 갈림길 위치·좌우 통로 라벨 옆에 "캔버스에서 선택" 버튼을 나란히 두기 위함 — 드롭다운에서
+// 같은 이름 노드가 많아 고르기 혼란스럽다는 피드백으로, 도면에서 직접 클릭해 고르는 대안 제공
+export const nodeAddLabelRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s2,
+});
+
+export const nodeAddPickBtn = style({
+  flexShrink: 0,
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  color: vars.color.primary,
+  ...vars.typography.caption,
+  selectors: {
+    '&:hover': { textDecoration: 'underline' },
+    '&:disabled': { cursor: 'not-allowed', color: vars.color.gray300 },
+  },
+});
+
+// 갈림길 위치·좌우 통로는 드롭다운을 없애고 캔버스 클릭으로만 고르게 함(같은 이름의 노드가
+// 많아 드롭다운으로는 뭐가 뭔지 구분이 안 된다는 피드백) — 이 박스는 클릭 대상이 아니라
+// 현재 고른 값을 보여주기만 하는 정적 표시 영역
+export const nodeAddPickDisplay = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s2,
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.color.white,
+  padding: `${vars.space.s2} ${vars.space.s3} ${vars.space.s2} ${vars.space.s4}`,
+  color: vars.color.textHigh,
+  ...vars.typography.body14Medium,
+});
+
+export const nodeAddPickDisplayEmpty = style({
+  color: vars.color.textLow,
+});
+
+// 지금 이 필드가 "캔버스에서 선택" 중임을 표시 — 드롭다운의 aria-expanded 강조 테두리와 같은 색
+export const nodeAddPickDisplayActive = style({
+  borderColor: vars.color.primary,
+});
+
+export const nodeAddPickClearBtn = style({
+  display: 'inline-flex',
+  flexShrink: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 'none',
+  borderRadius: vars.radius.pill,
+  background: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  color: vars.color.textMid,
+  selectors: {
+    '&:hover': { backgroundColor: vars.color.gray50, color: vars.color.textHigh },
+  },
+});
+
 export const edgeBidirectionalField = style({
   display: 'flex',
   alignItems: 'center',
@@ -793,7 +857,17 @@ export const cctvEnableSwitchThumb = style({
   },
 });
 
+// 기기명(입력창 또는 텍스트) + 삭제 아이콘 버튼을 한 줄에 나란히 둠 — 삭제가 하단 버튼 행에
+// 있던 걸 여기로 옮겨서, 아래는 취소/완료(또는 수정)만 남게 함
+export const deviceCardNameRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
 export const deviceCardName = style({
+  flex: 1,
+  minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
@@ -802,12 +876,12 @@ export const deviceCardName = style({
 });
 
 export const deviceCardNameInput = style({
+  flex: 1,
   outline: 'none',
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.sm,
   backgroundColor: vars.color.white,
   padding: `${vars.space.s1} ${vars.space.s2}`,
-  width: '100%',
   minWidth: 0,
   color: vars.color.textHigh,
   ...vars.typography.body14Medium,
@@ -857,41 +931,6 @@ export const lightFieldGroup = style({
   gap: vars.space.s2,
 });
 
-// 카드 폭에 맞춰 버튼 3개가 한 줄에 다 들어가도록 폭 전체를 씀 — deviceCardRow의
-// space-between 안에 끼워 넣으면 "방향"라벨에 밀려 좁아져서 글자가 줄바꿈되던 문제가 있었음
-export const lightDirectionRow = style({
-  display: 'flex',
-  gap: vars.space.s1,
-});
-
-export const lightDirectionBtn = style({
-  flex: 1,
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.sm,
-  backgroundColor: vars.color.white,
-  cursor: 'pointer',
-  padding: `${vars.space.s1} 0`,
-  whiteSpace: 'nowrap',
-  color: vars.color.textMid,
-  ...vars.typography.caption,
-  selectors: {
-    '&:hover': { backgroundColor: vars.color.gray25 },
-    '&:disabled': {
-      opacity: 0.4,
-      backgroundColor: vars.color.white,
-      cursor: 'not-allowed',
-    },
-  },
-});
-
-// 방향은 서버가 현재 상태를 내려주지 않아 "지금 이 방향임"을 표시할 수 없음 — 대신 "방금 이걸
-// 눌렀다"는 클릭 자체를 눈에 보이게 남겨서, 눌렀는지 안 눌렀는지 헷갈리지 않게 함
-export const lightDirectionBtnActive = style({
-  borderColor: vars.color.primary,
-  backgroundColor: vars.color.primaryLight2,
-  color: vars.color.primary,
-});
-
 export const deviceCardActions = style({
   display: 'flex',
   gap: vars.space.s2,
@@ -927,20 +966,6 @@ export const deviceCardDoneBtn = style({
       backgroundColor: vars.color.primaryHover,
     },
     '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
-  },
-});
-
-export const deviceCardDeleteBtn = style({
-  flex: 1,
-  border: `1px solid ${vars.color.dangerLight}`,
-  borderRadius: vars.radius.md,
-  backgroundColor: vars.color.white,
-  cursor: 'pointer',
-  padding: vars.space.s2,
-  color: vars.color.danger,
-  ...vars.typography.caption,
-  selectors: {
-    '&:hover': { backgroundColor: '#FFF5F5' },
   },
 });
 
@@ -1139,15 +1164,33 @@ export const mapImage = style({
 });
 
 /* ── 마커 공통 ── */
+// 마커 위치의 기준점(0,0)만 잡음 — 크기가 없는 점이라 자식(원 아이콘·라벨)이 뭘 보여주든
+// 이 기준점 자체는 흔들리지 않음
 export const markerWrap = style({
   position: 'absolute',
   zIndex: 1,
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  gap: '0.3rem',
-  transform: 'translate(-50%, -50%)',
   cursor: 'pointer',
+});
+
+// 원 아이콘은 markerWrap의 (0,0)을 기준으로 항상 자기 자신의 고정 크기(2.4rem)만으로
+// -50%/-50% 이동해 중앙 정렬함 — 라벨(선택 시에만 나타남)과 같은 flex 박스에 있지 않아서,
+// 수정 모드 진입으로 라벨이 나타나거나 사라져도 원 아이콘 위치는 안 바뀜(전엔 라벨 유무로
+// markerWrap 전체 높이가 바뀌어 translate(-50%,-50%) 기준도 같이 바뀌면서 수정 시작하자마자
+// 마커가 위로 튀어 보이던 버그의 원인이었음)
+export const markerPin = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  transform: 'translate(-50%, -50%)',
+});
+
+// 라벨도 markerWrap의 (0,0) 기준으로 원 아이콘 반지름(1.2rem) + 기존 간격(0.3rem)만큼
+// 아래로 고정 오프셋 — 원 아이콘 쪽 레이아웃과 완전히 분리돼 있어 서로 영향을 안 줌
+export const markerLabelPin = style({
+  position: 'absolute',
+  top: '1.5rem',
+  left: 0,
+  transform: 'translateX(-50%)',
 });
 
 export const markerCircle = style({

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -10,9 +10,15 @@ const zoneStartColor = '#DB2777';
 const zoneHallwayColor = '#0891B2';
 
 /* ── 전체 레이아웃 ── */
+// 좌우 패널은 폭 고정인데 가운데 캔버스만 flex: 1로 남는 공간을 다 먹다 보니, 큰 화면에선
+// 도면(고정 크기 SVG) 주변에 빈 공간만 늘어나고 그 여백 구석에 앉은 범례·팝업이 도면과
+// 동떨어져 보이며 화면이 커질수록 상대적으로 작아 보이던 문제 — 전체 폭에 상한을 둬서 방지
 export const layout = style({
   display: 'flex',
   flex: 1,
+  margin: '0 auto',
+  width: '100%',
+  maxWidth: '144rem',
   minHeight: 0,
   overflow: 'hidden',
 });

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -31,6 +31,12 @@ export const sidebar = style({
   backgroundColor: vars.color.white,
   width: '28rem',
   overflowY: 'auto',
+  // 스크롤은 그대로 되지만 막대는 안 보이게(우측 장비 목록 패널과 동일한 처리)
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+  selectors: {
+    '&::-webkit-scrollbar': { display: 'none' },
+  },
 });
 
 export const sidebarInner = style({
@@ -285,6 +291,66 @@ export const edgeBidirectionalField = style({
   ...vars.typography.body14,
 });
 
+// 순서대로 클릭해 쌓은 경로를 "A → B → C"로 미리 보여주는 텍스트
+export const edgeChainPath = style({
+  wordBreak: 'break-word',
+  color: vars.color.textMid,
+  ...vars.typography.caption,
+});
+
+// 엣지 체인 검토 화면 — 구간이 많아질 수 있어 스크롤 가능한 목록으로 둠
+export const edgeChainList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: vars.space.s2,
+  maxHeight: '24rem',
+  overflowY: 'auto',
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+  selectors: {
+    '&::-webkit-scrollbar': { display: 'none' },
+  },
+});
+
+export const edgeChainRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.space.s2,
+});
+
+export const edgeChainRowLabel = style({
+  flex: 1,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  color: vars.color.textHigh,
+  ...vars.typography.body14,
+});
+
+export const edgeChainDistanceInput = style({
+  flexShrink: 0,
+  outline: 'none',
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.md,
+  padding: `${vars.space.s2} ${vars.space.s3}`,
+  width: '6.4rem',
+  color: vars.color.textHigh,
+  ...vars.typography.body14,
+  selectors: {
+    '&:focus': { borderColor: vars.color.primary },
+  },
+});
+
+// 다른 경로와 겹쳐 이미 존재하는 구간 표시 — 입력창 대신 이 태그만 보여줌
+export const edgeChainExistingTag = style({
+  flexShrink: 0,
+  borderRadius: vars.radius.pill,
+  backgroundColor: vars.color.gray50,
+  padding: `0.2rem ${vars.space.s2}`,
+  color: vars.color.textLow,
+  ...vars.typography.caption,
+});
+
 export const deviceTypeChips = style({
   display: 'flex',
   flexWrap: 'wrap',
@@ -350,6 +416,10 @@ export const nodeAddCancelBtn = style({
   backgroundColor: vars.color.white,
   cursor: 'pointer',
   padding: vars.space.s2,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
   color: vars.color.textMid,
   ...vars.typography.body14,
   selectors: {
@@ -364,6 +434,10 @@ export const nodeAddSubmitBtn = style({
   backgroundColor: vars.color.primary,
   cursor: 'pointer',
   padding: vars.space.s2,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
   color: vars.color.white,
   ...vars.typography.body14,
   selectors: {
@@ -1023,6 +1097,11 @@ export const canvasBody = style({
   backgroundColor: vars.color.white,
   padding: vars.space.s6,
   overflow: 'auto',
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+  selectors: {
+    '&::-webkit-scrollbar': { display: 'none' },
+  },
 });
 
 export const canvasBodyWithActions = style({

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -482,7 +482,7 @@ export const legendInfoButton = style({
   cursor: 'pointer',
   width: '3.4rem',
   height: '3.4rem',
-  color: vars.color.textMid,
+  color: vars.color.textLow,
   selectors: {
     '&:hover': { color: vars.color.primary },
     '&[aria-expanded="true"]': {
@@ -997,12 +997,12 @@ export const zoneCardIconBtnDelete = style([
 export const canvasBottomRightColumn = style({
   position: 'absolute',
   zIndex: 10,
-  right: '2.4rem',
-  bottom: '2.4rem',
+  right: vars.space.s8,
+  bottom: vars.space.s8,
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-end',
-  gap: vars.space.s2,
+  gap: vars.space.s1,
 });
 
 export const canvasZoomFloat = style({

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -8,6 +8,8 @@ const zoneDoorColor = '#2563EB';
 const zoneStairColor = '#F97316';
 const zoneStartColor = '#DB2777';
 const zoneHallwayColor = '#0891B2';
+// 계단(zoneStairColor)과 같은 주황 계열이라 구분이 안 된다는 피드백 — 노란색으로 분리
+const zoneLightColor = '#EAB308';
 
 /* ── 전체 레이아웃 ── */
 // 폭 상한을 뒀었는데 그러면 큰 화면에서 좌우로 회색 여백만 생기고 정작 캔버스는 안 넓어짐
@@ -460,7 +462,7 @@ export const nodeTypeDotDoor = style({ backgroundColor: zoneDoorColor });
 export const nodeTypeDotStair = style({ backgroundColor: zoneStairColor });
 export const nodeTypeDotHallway = style({ backgroundColor: zoneHallwayColor });
 export const nodeTypeDotStart = style({ backgroundColor: zoneStartColor });
-export const nodeTypeDotLight = style({ backgroundColor: '#d97706' });
+export const nodeTypeDotLight = style({ backgroundColor: zoneLightColor });
 
 export const nodeTypeAreaSwatch = style({
   flexShrink: 0,

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -2,14 +2,16 @@ import { keyframes, style } from '@vanilla-extract/css';
 
 import { vars } from '@styles/global.css';
 
-/* 도면 상 구역 의미 색상 — 문·출입구/계단/시작 후보 표시에서 반복 사용되므로 한 곳에서만 정의
-   (코드래빗 리뷰 반영 — 시작 후보 색상도 하드코딩 대신 이 파일 안에서 단일 소스로 관리) */
-const zoneDoorColor = '#2563EB';
-const zoneStairColor = '#F97316';
-const zoneStartColor = '#DB2777';
-const zoneHallwayColor = '#0891B2';
-// 계단(zoneStairColor)과 같은 주황 계열이라 구분이 안 된다는 피드백 — 노란색으로 분리
-const zoneLightColor = '#EAB308';
+import { DEVICE_COLOR } from './constants/deviceColors';
+
+/* 도면 상 구역 의미 색상 — 문·출입구/계단/시작 후보 표시에서 반복 사용되므로 한 곳에서만 정의.
+   FloorPlansDetailPage.tsx의 DEVICE_PLACE_CONFIG/STRUCTURE_NODE_COLOR와 값이 어긋나지 않도록
+   같은 공용 상수(deviceColors.ts)를 가져다 씀(코드래빗 리뷰 반영 — 값 중복 제거) */
+const zoneDoorColor = DEVICE_COLOR.door;
+const zoneStairColor = DEVICE_COLOR.stair;
+const zoneStartColor = DEVICE_COLOR.start;
+const zoneHallwayColor = DEVICE_COLOR.hallway;
+const zoneLightColor = DEVICE_COLOR.light;
 
 /* ── 전체 레이아웃 ── */
 // 폭 상한을 뒀었는데 그러면 큰 화면에서 좌우로 회색 여백만 생기고 정작 캔버스는 안 넓어짐

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -108,14 +108,14 @@ export const floorNavItemActive = style({
 // (코드래빗 리뷰 반영 — 컴포넌트 스타일을 페이지 스타일 파일에 두면 컴포넌트를 다른 위치로
 // 옮길 때 스타일이 따라오지 않음)
 
-/* ── 캔버스 우상단(범례 + 장비/구역 추가) ── */
+/* ── 캔버스 우상단(장비/구역 추가) ── */
 export const canvasTopRightRow = style({
   position: 'absolute',
   zIndex: 10,
   top: vars.space.s6,
   right: vars.space.s6,
   display: 'flex',
-  alignItems: 'flex-start',
+  alignItems: 'center',
   gap: vars.space.s2,
 });
 
@@ -470,42 +470,46 @@ export const legendInfoContainer = style({
   position: 'relative',
 });
 
+// 테두리 없이 동그란 i 아이콘만 보이게 — 아이콘 자체가 이미 원형(ic-info.svg)이라 버튼은
+// 클릭 영역만 잡아주고 시각적으로는 드러나지 않음(hover/열림 상태는 아이콘 색으로만 표시)
 export const legendInfoButton = style({
   display: 'flex',
   flexShrink: 0,
   alignItems: 'center',
   justifyContent: 'center',
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.md,
-  boxShadow: vars.shadow.sm,
-  backgroundColor: vars.color.white,
+  border: 'none',
+  backgroundColor: 'transparent',
   cursor: 'pointer',
   width: '3.4rem',
   height: '3.4rem',
   color: vars.color.textMid,
   selectors: {
-    '&:hover': { backgroundColor: vars.color.gray25 },
+    '&:hover': { color: vars.color.primary },
     '&[aria-expanded="true"]': {
-      borderColor: vars.color.primary,
       color: vars.color.primary,
     },
   },
 });
 
+// 아이콘이 이제 캔버스 우하단(줌 컨트롤 바로 위)에 있어서, 아래로 펼치면 화면 밖으로
+// 잘려나감 — 위로 펼치게 함(translateY 방향도 아래→위로 뒤집음)
 const legendPopoverIn = keyframes({
-  from: { transform: 'translateY(-0.4rem)', opacity: 0 },
+  from: { transform: 'translateY(0.4rem)', opacity: 0 },
   to: { transform: 'translateY(0)', opacity: 1 },
 });
 
 export const legendPopover = style({
   position: 'absolute',
   zIndex: 20,
-  top: 'calc(100% + 0.4rem)',
-  left: 0,
+  right: 0,
+  // 아이콘이 캔버스 오른쪽 끝 가까이 있어서 왼쪽 기준(left:0)으로 오른쪽으로 펼치면
+  // 캔버스 밖으로 잘려나감 — "+ 추가" 드롭다운(addMenuPanel)과 같은 방식으로 오른쪽
+  // 기준으로 왼쪽으로 펼치게 함
+  bottom: 'calc(100% + 0.4rem)',
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s4,
-  transformOrigin: 'top left',
+  transformOrigin: 'bottom right',
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.lg,
   boxShadow: vars.shadow.lg,
@@ -989,12 +993,19 @@ export const zoneCardIconBtnDelete = style([
   },
 ]);
 
-/* ── 플로팅 줌 컨트롤 ── */
-export const canvasZoomFloat = style({
+/* ── 캔버스 우하단(범례 정보 + 줌 컨트롤을 세로로 쌓음) ── */
+export const canvasBottomRightColumn = style({
   position: 'absolute',
   zIndex: 10,
   right: '2.4rem',
   bottom: '2.4rem',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'flex-end',
+  gap: vars.space.s2,
+});
+
+export const canvasZoomFloat = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.4rem',

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -701,21 +701,6 @@ export const deviceCardNameInput = style({
   },
 });
 
-export const deviceCardValueInput = style({
-  outline: 'none',
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.sm,
-  backgroundColor: vars.color.white,
-  padding: `0 ${vars.space.s2}`,
-  width: '14rem',
-  textAlign: 'right',
-  color: vars.color.textHigh,
-  ...vars.typography.caption,
-  selectors: {
-    '&:focus': { borderColor: vars.color.primary },
-  },
-});
-
 export const deviceCardRow = style({
   display: 'flex',
   alignItems: 'center',
@@ -747,23 +732,6 @@ export const deviceCardFieldEditBtn = style({
   ...vars.typography.caption,
   selectors: {
     '&:hover': { backgroundColor: vars.color.primaryLight2 },
-  },
-});
-
-// 유도등 카드 수정 중 필드(설치 위치 입력)를 담당 CCTV·가이던스 Dropdown과 같은 박스 모양으로
-// 맞춤 — 텍스트 입력과 Dropdown이 서로 다른 크기·정렬로 보이던 문제를 셋 다 "라벨 위,
-// 폭 전체 값" 한 가지 모양으로 통일해서 해결함(치수는 Dropdown의 rounded+fullWidth와 동일)
-export const lightFieldFull = style({
-  outline: 'none',
-  border: `1px solid ${vars.color.gray100}`,
-  borderRadius: vars.radius.md,
-  backgroundColor: vars.color.white,
-  padding: `${vars.space.s2} ${vars.space.s3} ${vars.space.s2} ${vars.space.s4}`,
-  width: '100%',
-  color: vars.color.textHigh,
-  ...vars.typography.body14Medium,
-  selectors: {
-    '&:focus': { borderColor: vars.color.primary },
   },
 });
 
@@ -839,10 +807,11 @@ export const deviceCardDoneBtn = style({
   color: vars.color.white,
   ...vars.typography.caption,
   selectors: {
-    '&:hover': {
+    '&:hover:not(:disabled)': {
       borderColor: vars.color.primaryHover,
       backgroundColor: vars.color.primaryHover,
     },
+    '&:disabled': { opacity: 0.5, cursor: 'not-allowed' },
   },
 });
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -10,15 +10,12 @@ const zoneStartColor = '#DB2777';
 const zoneHallwayColor = '#0891B2';
 
 /* ── 전체 레이아웃 ── */
-// 좌우 패널은 폭 고정인데 가운데 캔버스만 flex: 1로 남는 공간을 다 먹다 보니, 큰 화면에선
-// 도면(고정 크기 SVG) 주변에 빈 공간만 늘어나고 그 여백 구석에 앉은 범례·팝업이 도면과
-// 동떨어져 보이며 화면이 커질수록 상대적으로 작아 보이던 문제 — 전체 폭에 상한을 둬서 방지
+// 폭 상한을 뒀었는데 그러면 큰 화면에서 좌우로 회색 여백만 생기고 정작 캔버스는 안 넓어짐
+// (되돌림) — 범례·팝업이 도면과 동떨어져 보이는 문제는 그 둘을 각각 접을 수 있게 하거나
+// 캔버스 밖으로 옮기는 쪽으로 해결함(nodeTypeLegend 접기, 팝업을 좌측 사이드바로 이동)
 export const layout = style({
   display: 'flex',
   flex: 1,
-  margin: '0 auto',
-  width: '100%',
-  maxWidth: '144rem',
   minHeight: 0,
   overflow: 'hidden',
 });
@@ -207,38 +204,30 @@ export const gridSizeSlider = style({
   },
 });
 
+// 예전엔 캔버스 위에 절대 위치로 떠서 도면을 가려 그 밑을 클릭할 수 없었음 — 좌측 사이드바
+// 안 일반 흐름으로 옮겨서, 도면은 항상 그대로 보이고 클릭도 가능하게 함
 export const gridSetupPopup = style({
-  position: 'absolute',
-  zIndex: 15,
-  top: '5.6rem',
-  right: vars.space.s6,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s3,
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.lg,
-  boxShadow: vars.shadow.lg,
+  boxShadow: vars.shadow.md,
   backgroundColor: vars.color.white,
   padding: vars.space.s4,
-  width: '25rem',
 });
 
 /* ── 카메라 시야 구역 지정 안내 ── */
 /* ── 장비 추가 팝업 ── */
 export const nodeAddPopup = style({
-  position: 'absolute',
-  zIndex: 15,
-  top: '9.6rem',
-  right: vars.space.s6,
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s3,
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: vars.radius.lg,
-  boxShadow: vars.shadow.lg,
+  boxShadow: vars.shadow.md,
   backgroundColor: vars.color.white,
   padding: vars.space.s4,
-  width: '25rem',
 });
 
 export const nodeAddHeader = style({
@@ -412,6 +401,18 @@ export const nodeTypeLegend = style({
   backgroundColor: vars.color.white,
   padding: vars.space.s5,
   width: '16rem',
+});
+
+export const nodeTypeLegendHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.space.s3,
+  border: 'none',
+  backgroundColor: 'transparent',
+  cursor: 'pointer',
+  padding: 0,
+  color: vars.color.textMid,
 });
 
 export const nodeTypeLegendSection = style({

--- a/src/pages/floorPlans/FloorPlansDetailPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansDetailPage.css.ts
@@ -268,6 +268,12 @@ export const nodeAddHint = style({
   ...vars.typography.caption,
 });
 
+// 그냥 안내 문구가 아니라 "지금 이대로는 진행이 안 된다"는 경고(예: 연결된 엣지가 없음) — 색으로
+// 구분되게 함
+export const nodeAddHintWarning = style({
+  color: vars.color.danger,
+});
+
 export const nodeAddSubHint = style({
   color: vars.color.textLow,
   ...vars.typography.caption,
@@ -1122,28 +1128,38 @@ export const canvasHeaderFloor = style({
   ...vars.typography.body14Medium,
 });
 
+// "+ 추가" 버튼(canvasTopRightRow)이 이 박스 기준으로 절대 위치를 잡음 — 캔버스가 확대돼서
+// 스크롤이 생겨도 그 스크롤은 안쪽 canvasScrollArea에서만 일어나고, 이 박스 자체는 스크롤되지
+// 않아서 버튼이 항상 같은 자리에 고정됨(예전엔 이 박스 자체가 스크롤 컨테이너라 확대 후 스크롤하면
+// 버튼도 같이 밀려 화면 밖으로 나가던 문제가 있었음)
 export const canvasBody = style({
   position: 'relative',
-  display: 'flex',
   flex: 1,
-  alignItems: 'flex-start',
-  justifyContent: 'center',
   margin: vars.space.s4,
   marginTop: 0,
   border: `1px solid ${vars.color.gray100}`,
   borderRadius: `0 0 ${vars.radius.lg} ${vars.radius.lg}`,
   backgroundColor: vars.color.white,
   padding: vars.space.s6,
+});
+
+export const canvasBodyWithActions = style({
+  paddingTop: '8rem',
+});
+
+// 실제 스크롤이 일어나는 안쪽 영역 — canvasBody의 패딩 박스를 그대로 채움
+export const canvasScrollArea = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'center',
+  width: '100%',
+  height: '100%',
   overflow: 'auto',
   scrollbarWidth: 'none',
   msOverflowStyle: 'none',
   selectors: {
     '&::-webkit-scrollbar': { display: 'none' },
   },
-});
-
-export const canvasBodyWithActions = style({
-  paddingTop: '8rem',
 });
 
 export const mapWrap = style({

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2356,6 +2356,8 @@ const FloorPlansDetailPage = () => {
   const [selectedBuildingId] = useState(buildingId ?? '');
   const [selectedFloorId, setSelectedFloorId] = useState(floorId ?? '');
   const [zoom, setZoom] = useState(100);
+  // 노드/구역 범례가 캔버스 위에 고정으로 떠 있어 도면을 가린다는 피드백 — 접었다 펼 수 있게 함
+  const [isNodeLegendOpen, setIsNodeLegendOpen] = useState(true);
   const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
   const [selectedZoneRef, setSelectedZoneRef] = useState<ZoneRefSelection | null>(null);
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
@@ -4048,49 +4050,10 @@ const FloorPlansDetailPage = () => {
                 onConnectEdges={handleOpenEdgeAdd}
               />
             )}
-          </div>
-        </aside>
 
-        {/* ── 중앙 캔버스 ── */}
-        <div className={styles.canvasArea}>
-          {/* 모드 안내 토스트 */}
-          {toastMsg && (
-            <div className={clsx(styles.toast, toastFading && styles.toastFading)}>{toastMsg}</div>
-          )}
-
-          {currentFloor && (
-            <div className={styles.canvasHeader}>
-              <button
-                type="button"
-                className={styles.backButton}
-                onClick={() => navigate('/floorPlans')}
-                aria-label="도면 관리 목록으로"
-              >
-                <ChevronRightIcon width={16} height={16} className={styles.backButtonIcon} />
-              </button>
-              <span className={styles.canvasHeaderText}>{currentBuilding?.name ?? ''}</span>
-              <span className={styles.canvasHeaderFloor}>{formatFloor(currentFloor.floorNum)}</span>
-            </div>
-          )}
-
-          <div
-            className={clsx(
-              styles.canvasBody,
-              currentFloor?.segmentationStatus === 'DONE' && styles.canvasBodyWithActions,
-            )}
-          >
-            {/* 그리드는 이제 토글 없이 항상 표시함(아래 ensureFloorGridCells 자동 조회 효과 참고) —
-                추가(노드/구역/엣지) 메뉴만 남김 */}
-            {currentFloor?.segmentationStatus === 'DONE' && (
-              <div className={styles.canvasActionFloat}>
-                <AddActionMenu
-                  onAddNode={() => handleOpenNodeAdd()}
-                  onAddZone={handleToggleZoneAdd}
-                  onAddEdge={handleOpenEdgeAdd}
-                />
-              </div>
-            )}
-
+            {/* 노드/구역/엣지 추가 · 그리드 설정 · 감시영역 재선택 팝업 — 예전엔 캔버스 위에
+                떠 있어서 도면을 가려 그 밑을 클릭할 수 없었음. 도면을 보면서 동시에 입력할 수
+                있어야 하는 흐름이라, 캔버스와 겹치지 않는 이 사이드바로 옮김 */}
             {gridSetupPromptOpen && (
               <div className={styles.gridSetupPopup} onClick={(e) => e.stopPropagation()}>
                 <span className={styles.nodeAddTitle}>그리드 설정 필요</span>
@@ -4235,6 +4198,48 @@ const FloorPlansDetailPage = () => {
                 onSave={handleAddZone}
               />
             )}
+          </div>
+        </aside>
+
+        {/* ── 중앙 캔버스 ── */}
+        <div className={styles.canvasArea}>
+          {/* 모드 안내 토스트 */}
+          {toastMsg && (
+            <div className={clsx(styles.toast, toastFading && styles.toastFading)}>{toastMsg}</div>
+          )}
+
+          {currentFloor && (
+            <div className={styles.canvasHeader}>
+              <button
+                type="button"
+                className={styles.backButton}
+                onClick={() => navigate('/floorPlans')}
+                aria-label="도면 관리 목록으로"
+              >
+                <ChevronRightIcon width={16} height={16} className={styles.backButtonIcon} />
+              </button>
+              <span className={styles.canvasHeaderText}>{currentBuilding?.name ?? ''}</span>
+              <span className={styles.canvasHeaderFloor}>{formatFloor(currentFloor.floorNum)}</span>
+            </div>
+          )}
+
+          <div
+            className={clsx(
+              styles.canvasBody,
+              currentFloor?.segmentationStatus === 'DONE' && styles.canvasBodyWithActions,
+            )}
+          >
+            {/* 그리드는 이제 토글 없이 항상 표시함(아래 ensureFloorGridCells 자동 조회 효과 참고) —
+                추가(노드/구역/엣지) 메뉴만 남김 */}
+            {currentFloor?.segmentationStatus === 'DONE' && (
+              <div className={styles.canvasActionFloat}>
+                <AddActionMenu
+                  onAddNode={() => handleOpenNodeAdd()}
+                  onAddZone={handleToggleZoneAdd}
+                  onAddEdge={handleOpenEdgeAdd}
+                />
+              </div>
+            )}
 
             {loadingFloor ? (
               <LoadingState message="도면을 불러오는 중..." />
@@ -4305,51 +4310,72 @@ const FloorPlansDetailPage = () => {
 
           {currentFloor?.segmentationStatus === 'DONE' && (
             <div className={styles.nodeTypeLegend}>
-              <div className={styles.nodeTypeLegendSection}>
-                <span className={styles.zoneLegendTitle}>노드 종류</span>
-                <div className={styles.zoneLegendItem}>
-                  <span className={styles.nodeTypeCctvBadge}>CC</span>
-                  <span className={styles.zoneLegendLabel}>CCTV</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotLight)} />
-                  <span className={styles.zoneLegendLabel}>유도등</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotDoor)} />
-                  <span className={styles.zoneLegendLabel}>문 · 출입구</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStair)} />
-                  <span className={styles.zoneLegendLabel}>계단</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotHallway)} />
-                  <span className={styles.zoneLegendLabel}>복도</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStart)} />
-                  <span className={styles.zoneLegendLabel}>시작 후보</span>
-                </div>
-              </div>
+              <button
+                type="button"
+                className={styles.nodeTypeLegendHeader}
+                onClick={() => setIsNodeLegendOpen((prev) => !prev)}
+                aria-expanded={isNodeLegendOpen}
+              >
+                <span className={styles.zoneLegendTitle}>범례</span>
+                {isNodeLegendOpen ? (
+                  <ChevronDownIcon width={14} height={14} />
+                ) : (
+                  <ChevronRightIcon width={14} height={14} />
+                )}
+              </button>
 
-              <div className={styles.nodeTypeLegendDivider} />
+              {isNodeLegendOpen && (
+                <>
+                  <div className={styles.nodeTypeLegendSection}>
+                    <span className={styles.zoneLegendTitle}>노드 종류</span>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={styles.nodeTypeCctvBadge}>CC</span>
+                      <span className={styles.zoneLegendLabel}>CCTV</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotLight)} />
+                      <span className={styles.zoneLegendLabel}>유도등</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotDoor)} />
+                      <span className={styles.zoneLegendLabel}>문 · 출입구</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStair)} />
+                      <span className={styles.zoneLegendLabel}>계단</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotHallway)} />
+                      <span className={styles.zoneLegendLabel}>복도</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStart)} />
+                      <span className={styles.zoneLegendLabel}>시작 후보</span>
+                    </div>
+                  </div>
 
-              <div className={styles.nodeTypeLegendSection}>
-                <span className={styles.zoneLegendTitle}>구역 종류</span>
-                <div className={styles.zoneLegendItem}>
-                  <span
-                    className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchGeneral)}
-                  />
-                  <span className={styles.zoneLegendLabel}>일반 구역</span>
-                </div>
-                <div className={styles.zoneLegendItem}>
-                  <span
-                    className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchCamera)}
-                  />
-                  <span className={styles.zoneLegendLabel}>카메라 시야</span>
-                </div>
-              </div>
+                  <div className={styles.nodeTypeLegendDivider} />
+
+                  <div className={styles.nodeTypeLegendSection}>
+                    <span className={styles.zoneLegendTitle}>구역 종류</span>
+                    <div className={styles.zoneLegendItem}>
+                      <span
+                        className={clsx(
+                          styles.nodeTypeAreaSwatch,
+                          styles.nodeTypeAreaSwatchGeneral,
+                        )}
+                      />
+                      <span className={styles.zoneLegendLabel}>일반 구역</span>
+                    </div>
+                    <div className={styles.zoneLegendItem}>
+                      <span
+                        className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchCamera)}
+                      />
+                      <span className={styles.zoneLegendLabel}>카메라 시야</span>
+                    </div>
+                  </div>
+                </>
+              )}
             </div>
           )}
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -4470,8 +4470,6 @@ const FloorPlansDetailPage = () => {
             {/* 그리드는 이제 토글 없이 항상 표시함(아래 ensureFloorGridCells 자동 조회 효과 참고) */}
             {currentFloor?.segmentationStatus === 'DONE' && (
               <div className={styles.canvasTopRightRow}>
-                <NodeTypeLegendInfo />
-
                 <AddActionMenu
                   onAddNode={() => handleOpenNodeAdd()}
                   onAddZone={handleToggleZoneAdd}
@@ -4548,32 +4546,35 @@ const FloorPlansDetailPage = () => {
             )}
           </div>
 
-          {/* 플로팅 줌 컨트롤 */}
-          <div className={styles.canvasZoomFloat}>
-            <button
-              type="button"
-              className={styles.zoomButton}
-              onClick={() => setZoom((v) => Math.max(50, v - 10))}
-              disabled={zoom <= 50}
-            >
-              −
-            </button>
-            <button
-              type="button"
-              className={zoom !== 100 ? styles.zoomValueClickable : styles.zoomValue}
-              onClick={() => setZoom(100)}
-              title={zoom !== 100 ? '클릭해서 100% 리셋' : undefined}
-            >
-              {zoom}%
-            </button>
-            <button
-              type="button"
-              className={styles.zoomButton}
-              onClick={() => setZoom((v) => Math.min(200, v + 10))}
-              disabled={zoom >= 200}
-            >
-              +
-            </button>
+          {/* 캔버스 우하단 — 범례 정보 아이콘을 줌 컨트롤 바로 위에 세로로 쌓음 */}
+          <div className={styles.canvasBottomRightColumn}>
+            {currentFloor?.segmentationStatus === 'DONE' && <NodeTypeLegendInfo />}
+            <div className={styles.canvasZoomFloat}>
+              <button
+                type="button"
+                className={styles.zoomButton}
+                onClick={() => setZoom((v) => Math.max(50, v - 10))}
+                disabled={zoom <= 50}
+              >
+                −
+              </button>
+              <button
+                type="button"
+                className={zoom !== 100 ? styles.zoomValueClickable : styles.zoomValue}
+                onClick={() => setZoom(100)}
+                title={zoom !== 100 ? '클릭해서 100% 리셋' : undefined}
+              >
+                {zoom}%
+              </button>
+              <button
+                type="button"
+                className={styles.zoomButton}
+                onClick={() => setZoom((v) => Math.min(200, v + 10))}
+                disabled={zoom >= 200}
+              >
+                +
+              </button>
+            </div>
           </div>
         </div>
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -437,6 +437,7 @@ const MockFloorMap3F = ({
   zoneAddActive,
   onZoneDraftChange,
   onZoneDragEnd,
+  onZoneDraggingChange,
   savedZones,
   structureNodes,
   editingStructureId,
@@ -466,6 +467,7 @@ const MockFloorMap3F = ({
   zoneAddActive: boolean;
   onZoneDraftChange: (rect: ZoneRect | null) => void;
   onZoneDragEnd: () => void;
+  onZoneDraggingChange: (dragging: boolean) => void;
   savedZones: ZoneEntry[];
   structureNodes: StructureNode[];
   graphNodes: MapNode[];
@@ -492,6 +494,11 @@ const MockFloorMap3F = ({
 }) => {
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
   const structureDragMovedRef = useRef(false);
+  // 구역 드래그 중엔 포인터가 격자 셀·구조 노드 위를 지나가도 그 위에 걸린 개별 커서(pointer 등)로
+  // 안 바뀌고 항상 십자선(crosshair)으로 보여야 함 — 드래그가 아닐 땐 칸 클릭·노드 선택이 여전히
+  // 동작해야 하므로 zoneAddActive 내내가 아니라 실제 드래그 중(mousedown~mouseup)에만 그 레이어의
+  // 포인터 이벤트를 꺼서 아래 svg 배경의 crosshair가 그대로 보이게 함
+  const [isZoneDragging, setIsZoneDragging] = useState(false);
 
   // 엣지(선) 양 끝 좌표를 찾기 위한 노드 id → SVG 좌표 조회 (구조 노드 + 그 외 그래프 노드 통합)
   const nodePositionById = new Map<string, { x: number; y: number }>();
@@ -533,6 +540,8 @@ const MockFloorMap3F = ({
     const svgEl = e.currentTarget;
     const start = svgPoint(e.clientX, e.clientY, svgEl);
     dragStartRef.current = start;
+    setIsZoneDragging(true);
+    onZoneDraggingChange(true);
     onZoneDraftChange({ x: start.x, y: start.y, w: 0, h: 0 });
     let lastRect = { x: start.x, y: start.y, w: 0, h: 0 };
     const applyRect = rafThrottle((rect: typeof lastRect) => onZoneDraftChange(rect));
@@ -549,6 +558,8 @@ const MockFloorMap3F = ({
     };
     const onUp = () => {
       dragStartRef.current = null;
+      setIsZoneDragging(false);
+      onZoneDraggingChange(false);
       // onZoneDragEnd가 마지막으로 반영된 사각형을 기준으로 셀을 계산하므로, 대기 중인 갱신을
       // 취소하고 마지막 사각형을 먼저 동기 반영한 뒤에 종료 처리함
       applyRect.cancel();
@@ -772,7 +783,10 @@ const MockFloorMap3F = ({
               if (editingStructureId) return;
               onZoneRefSelect({ kind: 'node', id: n.id });
             }}
-            style={{ cursor: isEditingThis ? 'grab' : 'pointer' }}
+            style={{
+              cursor: isEditingThis ? 'grab' : 'pointer',
+              pointerEvents: isZoneDragging ? 'none' : 'auto',
+            }}
           >
             {/* 엣지 연결 모드에선 작은 점을 정확히 겨냥하기 어려워, 넓은 투명 히트영역을 겹쳐 둔다 */}
             {edgeAddActive && !isEditingThis && (
@@ -927,7 +941,10 @@ const MockFloorMap3F = ({
                 width={gridCellPxSize.w}
                 height={gridCellPxSize.h}
                 fill="transparent"
-                style={{ cursor: 'pointer', pointerEvents: 'auto' }}
+                style={{
+                  cursor: 'pointer',
+                  pointerEvents: isZoneDragging ? 'none' : 'auto',
+                }}
                 onClick={(e) => {
                   e.stopPropagation();
                   onGridCellToggle(cell.id);
@@ -2105,6 +2122,8 @@ const FloorCanvas = ({
   zoneAddActive,
   onZoneDraftChange,
   onZoneDragEnd,
+  isZoneDragging,
+  onZoneDraggingChange,
   savedZones,
   structureNodes,
   editingStructureId,
@@ -2146,6 +2165,8 @@ const FloorCanvas = ({
   zoneAddActive: boolean;
   onZoneDraftChange: (rect: ZoneRect | null) => void;
   onZoneDragEnd: () => void;
+  isZoneDragging: boolean;
+  onZoneDraggingChange: (dragging: boolean) => void;
   savedZones: ZoneEntry[];
   structureNodes: StructureNode[];
   editingStructureId: string | null;
@@ -2224,6 +2245,7 @@ const FloorCanvas = ({
         zoneAddActive={zoneAddActive}
         onZoneDraftChange={onZoneDraftChange}
         onZoneDragEnd={onZoneDragEnd}
+        onZoneDraggingChange={onZoneDraggingChange}
         savedZones={savedZones}
         structureNodes={structureNodes}
         editingStructureId={editingStructureId}
@@ -2253,39 +2275,45 @@ const FloorCanvas = ({
           style={{ left: `${stagedCameraPosition.x}%`, top: `${stagedCameraPosition.y}%` }}
         />
       )}
-      {floor.devices.map((device) => {
-        const pos = devicePositions[device.id] ?? { x: device.x, y: device.y };
-        return (
-          <DevicePin
-            key={device.id}
-            device={device}
-            posX={pos.x}
-            posY={pos.y}
-            selected={selected?.kind === 'device' && selected.data.id === device.id}
-            draggable={editingItemId === device.id}
-            onClick={() => onSelectDevice(device)}
-            onDragEnd={onDeviceMoved}
-          />
-        );
-      })}
+      {/* 구역 드래그 중엔 이 레이어(SVG 밖 HTML 마커)의 포인터 이벤트를 꺼서, 마커 위를
+          지나가도 각자의 cursor(grab/pointer)로 안 바뀌고 아래 SVG 배경의 crosshair가
+          그대로 보이게 함 — 이 wrapper는 position을 안 걸어서 자식들의 absolute 위치
+          기준(mapWrap)에는 영향이 없음 */}
+      <div style={{ pointerEvents: isZoneDragging ? 'none' : undefined }}>
+        {floor.devices.map((device) => {
+          const pos = devicePositions[device.id] ?? { x: device.x, y: device.y };
+          return (
+            <DevicePin
+              key={device.id}
+              device={device}
+              posX={pos.x}
+              posY={pos.y}
+              selected={selected?.kind === 'device' && selected.data.id === device.id}
+              draggable={editingItemId === device.id}
+              onClick={() => onSelectDevice(device)}
+              onDragEnd={onDeviceMoved}
+            />
+          );
+        })}
 
-      {/* 사용자가 추가한 장치 마커 */}
-      {addedDevices.map((d) => {
-        const pos = devicePositions[d.id] ?? { x: d.x, y: d.y };
-        return (
-          <AddedDevicePin
-            key={d.id}
-            device={d}
-            posX={pos.x}
-            posY={pos.y}
-            selected={selected?.kind === 'device' && selected.data.id === d.id}
-            draggable={editingItemId === d.id}
-            onClick={() => onSelectDevice(d as unknown as DeviceMarker)}
-            onDragEnd={onDeviceMoved}
-            onDragMoveEnd={onDeviceMoveEnd}
-          />
-        );
-      })}
+        {/* 사용자가 추가한 장치 마커 */}
+        {addedDevices.map((d) => {
+          const pos = devicePositions[d.id] ?? { x: d.x, y: d.y };
+          return (
+            <AddedDevicePin
+              key={d.id}
+              device={d}
+              posX={pos.x}
+              posY={pos.y}
+              selected={selected?.kind === 'device' && selected.data.id === d.id}
+              draggable={editingItemId === d.id}
+              onClick={() => onSelectDevice(d as unknown as DeviceMarker)}
+              onDragEnd={onDeviceMoved}
+              onDragMoveEnd={onDeviceMoveEnd}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 };
@@ -2677,6 +2705,11 @@ const FloorPlansDetailPage = () => {
     zoneDraftRectRef.current = rect;
     setZoneDraftRectState(rect);
   };
+  // 구역 드래그(사각형 선택) 중엔 캔버스 위 CCTV·유도등 마커(SVG 밖 별도 HTML 마커)와
+  // 격자 셀·구조 노드가 저마다 다른 커서를 걸고 있어도 항상 십자선(crosshair)으로 보이게 함 —
+  // MockFloorMap3F(SVG 내부)에서 드래그 시작/종료 시 이 값을 갱신하고, FloorCanvas가 SVG 밖
+  // 마커의 pointer-events를 같이 꺼서 호버가 아래 SVG 배경(crosshair)으로 그대로 넘어가게 함
+  const [isZoneDragging, setIsZoneDragging] = useState(false);
   const [topFilter, setTopFilter] = useState<'all' | 'device' | 'zone'>('all');
   // 여러 칩을 동시에 켤 수 있는 다중 선택 필터 — 빈 배열이면 "전체"와 같음
   const [deviceTypeFilter, setDeviceTypeFilter] = useState<
@@ -4643,6 +4676,8 @@ const FloorPlansDetailPage = () => {
                 }
                 onZoneDraftChange={setZoneDraftRect}
                 onZoneDragEnd={handleZoneDragEnd}
+                isZoneDragging={isZoneDragging}
+                onZoneDraggingChange={setIsZoneDragging}
                 savedZones={zones}
                 structureNodes={structureNodes}
                 editingStructureId={editingStructureId}

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -204,7 +204,8 @@ type PlacingEquipmentType = Exclude<PlacingDeviceType, 'door' | 'stair' | 'hallw
 
 const DEVICE_PLACE_CONFIG: Record<PlacingDeviceType, { label: string; color: string }> = {
   cctv: { label: 'CCTV', color: '#8b5cf6' },
-  light: { label: '유도등', color: '#d97706' },
+  // 계단(stair, #f97316)과 같은 주황 계열이라 구분이 안 된다는 피드백 — 노란색으로 분리
+  light: { label: '유도등', color: '#eab308' },
   door: { label: '문 · 출입구', color: '#2563eb' },
   stair: { label: '계단', color: '#f97316' },
   hallway: { label: '복도', color: '#0891b2' },

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -17,6 +17,7 @@ import InfoIcon from '@assets/icons/ic-info.svg?react';
 import PlusIcon from '@assets/icons/ic-plus.svg?react';
 import TrashIcon from '@assets/icons/ic-trash.svg?react';
 import WifiIcon from '@assets/icons/ic-wifi.svg?react';
+import XIcon from '@assets/icons/ic-x.svg?react';
 
 import { Button } from '@components/Button';
 import StatusBadge from '@components/chip/StatusBadge';
@@ -52,7 +53,6 @@ import {
 } from './api/floorPlansApi';
 import {
   assignLightCctv,
-  changeLightDirection,
   configureLightGuidance,
   createIoTLight,
   deleteIoTLight,
@@ -121,9 +121,9 @@ type PanelItem = {
 // 장비 카드의 "수정" 편집 폼 — CCTV는 label만 쓰고, 유도등은 설정 모달에 있던
 // 가이던스·담당 CCTV까지 전부 이 폼으로 흡수함(모달 없이 카드 안에서 편집). Pi 엔드포인트는
 // 스웨거상 "참고용 메타데이터일 뿐 실제 명령 전달 경로에는 안 쓰인다"고 명시되어 있어 뺐음.
-// "설치 위치"(zone)는 백엔드에 저장 필드가 없어(요청 스키마에 name/x/y뿐) 여기서 편집해도
-// 저장 API로 안 나가고, 새로고침하면 CCTV는 감시영역 문구로·유도등은 고정 문구로 다시
-// 덮어써지던 문제가 있어 편집 항목에서 뺌 — 카드엔 항상 읽기 전용으로만 보여줌
+// "설치 위치"(zone)는 백엔드에 저장 필드가 없어(요청 스키마에 name/x/y뿐) 텍스트로 입력받아도
+// 저장 API로 안 나가고 새로고침하면 사라지는 값이었음 — 편집 항목에서 아예 빼고, 카드엔 실제
+// 좌표(formatInstallLocation)를 읽기 전용으로 보여줌(CCTV는 감시영역 문구를 그대로 씀)
 interface DeviceEditForm {
   label: string;
   decisionNodeId: string;
@@ -153,6 +153,13 @@ type LightAddFields = {
 // 조립하면 한 줄이 100자를 넘기기 쉽고 표현도 어긋나기 쉬워 하나로 합침
 const formatMonitoredZone = (cctv: Pick<Cctv, 'monitoredGridCellCount' | 'monitoredAreaM2'>) =>
   `모니터링 ${cctv.monitoredGridCellCount}칸 · ${formatAreaM2(cctv.monitoredAreaM2)}㎡`;
+
+// "설치 위치" 카드 행 — CCTV는 감시 영역에서 계산한 실제 값(zone)이 있지만, 유도등은 그런
+// 백엔드 필드가 없어(등록 팝업의 "설치 위치" 입력은 저장 API로 나가지 않음) 새로고침하면
+// 사라지고 고정 문구로 되돌아가던 값이었음 — 대신 이미 갖고 있는 실제 좌표를 보여줘서
+// 최소한 의미 있는 값이 뜨게 함
+const formatInstallLocation = (type: PanelItem['type'], x: number, y: number, zone: string) =>
+  type === 'cctv' ? zone : `X ${Math.round(x)}% · Y ${Math.round(y)}%`;
 
 // 도면 마커의 DeviceType('cctv'|'iot'|'fire')을 패널 필터 체계(PanelItem.type)로 변환.
 // 두 군데(패널 목록 만들 때, 지도 클릭으로 필터 이동할 때)에서 각각 다시 구현하면 인식 못하는
@@ -447,6 +454,11 @@ const MockFloorMap3F = ({
   onGridCellToggle,
   onMapClick,
   onBackgroundClick,
+  lightPreviewNodeId,
+  lightPreviewLeftEdgeId,
+  lightPreviewRightEdgeId,
+  lightPickField,
+  onLightPick,
 }: {
   mapImageUrl: string | null;
   canvasH: number;
@@ -478,6 +490,15 @@ const MockFloorMap3F = ({
   onGridCellToggle: (cellId: string) => void;
   onMapClick: (x: number, y: number) => void;
   onBackgroundClick: () => void;
+  // 유도등 추가·수정 중 드롭다운으로 고른 갈림길 위치·왼쪽/오른쪽 통로를 캔버스에 바로
+  // 보여주기 위함 — "뭘 고른 건지 캔버스에서 안 보여서 불친절하다"는 피드백 반영
+  lightPreviewNodeId?: string;
+  lightPreviewLeftEdgeId?: string;
+  lightPreviewRightEdgeId?: string;
+  // "캔버스에서 선택" 모드 — 켜져 있으면 노드/엣지 클릭이 평소 동작(선택·삭제·엣지연결 등) 대신
+  // 유도등 갈림길 위치·좌우 통로 지정으로 대체됨
+  lightPickField?: 'decisionNode' | 'leftEdge' | 'rightEdge' | null;
+  onLightPick?: (id: string) => void;
 }) => {
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
   const structureDragMovedRef = useRef(false);
@@ -624,6 +645,20 @@ const MockFloorMap3F = ({
         const canSelect = !edgeAddActive && !placingActive && !zoneAddActive;
         const midX = (from.x + to.x) / 2;
         const midY = (from.y + to.y) / 2;
+        // 유도등 추가·수정 중 드롭다운으로 왼쪽/오른쪽 통로를 고르면 캔버스에서도 바로 어느
+        // 구간인지 보이게 함 — 색만으로는 헷갈릴 수 있어 라벨도 같이 띄움
+        const isLeftPreview = !!lightPreviewLeftEdgeId && edge.id === lightPreviewLeftEdgeId;
+        const isRightPreview = !!lightPreviewRightEdgeId && edge.id === lightPreviewRightEdgeId;
+        const previewColor = isLeftPreview ? '#0ea5e9' : isRightPreview ? '#f59e0b' : null;
+        // "캔버스에서 선택" 중엔 갈림길 위치에 실제로 연결된 엣지만 고를 수 있어야 함 — 드롭다운의
+        // 필터 기준(연결 여부 + 반대쪽이 이미 고른 엣지 제외)을 그대로 따름
+        const isEdgePickMode = lightPickField === 'leftEdge' || lightPickField === 'rightEdge';
+        const isPickableEdge =
+          isEdgePickMode &&
+          !!lightPreviewNodeId &&
+          (edge.fromNodeId === lightPreviewNodeId || edge.toNodeId === lightPreviewNodeId) &&
+          edge.id !==
+            (lightPickField === 'leftEdge' ? lightPreviewRightEdgeId : lightPreviewLeftEdgeId);
         return (
           <g key={edge.id}>
             <line
@@ -634,10 +669,15 @@ const MockFloorMap3F = ({
               stroke="transparent"
               strokeWidth="10"
               style={{
-                cursor: canSelect ? 'pointer' : 'default',
-                pointerEvents: canSelect ? 'stroke' : 'none',
+                cursor: canSelect || isPickableEdge ? 'pointer' : 'default',
+                pointerEvents: canSelect || isPickableEdge ? 'stroke' : 'none',
               }}
               onClick={(e) => {
+                if (isPickableEdge) {
+                  e.stopPropagation();
+                  onLightPick?.(edge.id);
+                  return;
+                }
                 if (!canSelect) return;
                 e.stopPropagation();
                 onEdgeSelect(edge.id);
@@ -648,11 +688,34 @@ const MockFloorMap3F = ({
               y1={from.y}
               x2={to.x}
               y2={to.y}
-              stroke={isSelected ? '#2563eb' : '#9ca3af'}
-              strokeWidth={isSelected ? '2.5' : '1.5'}
-              strokeDasharray="3 3"
+              stroke={previewColor ?? (isSelected ? '#2563eb' : '#9ca3af')}
+              strokeWidth={previewColor ? '3' : isSelected ? '2.5' : '1.5'}
+              strokeDasharray={previewColor ? undefined : '3 3'}
               style={{ pointerEvents: 'none' }}
             />
+            {previewColor && (
+              <g style={{ pointerEvents: 'none' }}>
+                <rect
+                  x={midX - 13}
+                  y={midY - 8}
+                  width={26}
+                  height={13}
+                  rx={3}
+                  fill={previewColor}
+                />
+                <text
+                  x={midX}
+                  y={midY + 2}
+                  textAnchor="middle"
+                  fontSize="8"
+                  fontWeight="700"
+                  fill="white"
+                  fontFamily="sans-serif"
+                >
+                  {isLeftPreview ? '왼쪽' : '오른쪽'}
+                </text>
+              </g>
+            )}
             {isSelected && (
               <g
                 style={{ cursor: 'pointer' }}
@@ -709,27 +772,59 @@ const MockFloorMap3F = ({
           평소엔 클릭도 안 되는데 캔버스만 지저분하게 만들어서 숨김. EXIT/CUSTOM은 정보성이라 항상 표시 */}
       {graphNodes.map((n) => {
         const isRoomOrHallway = n.type === 'ROOM' || n.type === 'HALLWAY';
-        if (isRoomOrHallway && !edgeAddActive) return null;
+        const isLightPreview = !!lightPreviewNodeId && n.id === lightPreviewNodeId;
+        // "캔버스에서 선택" 중엔 갈림길 위치로 아무 노드나 고를 수 있어야 해서, ROOM/HALLWAY도
+        // 엣지 연결 모드가 아니어도 이때는 보여줌(유도등의 갈림길 위치로 이미 고른 노드도 동일)
+        const isNodePickMode = lightPickField === 'decisionNode';
+        if (isRoomOrHallway && !edgeAddActive && !isLightPreview && !isNodePickMode) return null;
         const x = n.x * CANVAS_W;
         const y = n.y * canvasH;
         const color = GRAPH_NODE_COLOR[n.type as 'ROOM' | 'HALLWAY' | 'EXIT' | 'CUSTOM'];
         return (
           <g
             key={n.id}
-            style={{ pointerEvents: edgeAddActive ? 'auto' : 'none', cursor: 'pointer' }}
+            style={{
+              pointerEvents: edgeAddActive || isNodePickMode ? 'auto' : 'none',
+              cursor: 'pointer',
+            }}
             onClick={(e) => {
+              if (isNodePickMode) {
+                e.stopPropagation();
+                onLightPick?.(n.id);
+                return;
+              }
               if (!edgeAddActive) return;
               e.stopPropagation();
               onNodeClickForEdge(n.id);
             }}
           >
-            {/* 엣지 연결 모드에선 작은 점을 정확히 겨냥하기 어려워, 넓은 투명 히트영역을 겹쳐 둔다 */}
-            {edgeAddActive && <circle cx={x} cy={y} r={13} fill="transparent" />}
+            {/* 엣지 연결 모드·유도등 갈림길 선택 모드에선 작은 점을 정확히 겨냥하기 어려워,
+                넓은 투명 히트영역을 겹쳐 둔다 */}
+            {(edgeAddActive || isNodePickMode) && (
+              <circle cx={x} cy={y} r={13} fill="transparent" />
+            )}
             {/* 체인에 이미 골라둔 노드는 테두리로 강조해서 클릭했다는 걸 바로 알 수 있게 함 */}
             {edgeChainNodeIds.includes(n.id) && (
               <circle cx={x} cy={y} r={9} fill="none" stroke="#2563eb" strokeWidth="2" />
             )}
-            <circle cx={x} cy={y} r={n.type === 'EXIT' ? 6 : edgeAddActive ? 5 : 3} fill={color} />
+            {/* 유도등 갈림길 위치로 고른 노드 강조 — 노란 점선 링(유도등 색과 맞춤) */}
+            {isLightPreview && (
+              <circle
+                cx={x}
+                cy={y}
+                r={11}
+                fill="none"
+                stroke={DEVICE_COLOR.light}
+                strokeWidth="2"
+                strokeDasharray="3 2"
+              />
+            )}
+            <circle
+              cx={x}
+              cy={y}
+              r={n.type === 'EXIT' ? 6 : edgeAddActive || isLightPreview || isNodePickMode ? 5 : 3}
+              fill={color}
+            />
             {n.type === 'EXIT' && (
               <text
                 x={x}
@@ -753,12 +848,18 @@ const MockFloorMap3F = ({
         const isSelected = selectedZoneRef?.kind === 'node' && selectedZoneRef.id === n.id;
         const isStair = n.type === 'stair';
         const baseColor = STRUCTURE_NODE_COLOR[n.type];
+        const isLightPreview = !!lightPreviewNodeId && n.id === lightPreviewNodeId;
+        const isNodePickMode = lightPickField === 'decisionNode';
         return (
           <g
             key={n.id}
             onMouseDown={(e) => handleStructureMouseDown(e, n.id)}
             onClick={(e) => {
               e.stopPropagation();
+              if (isNodePickMode) {
+                onLightPick?.(n.id);
+                return;
+              }
               if (edgeAddActive) {
                 onNodeClickForEdge(n.id);
                 return;
@@ -799,6 +900,18 @@ const MockFloorMap3F = ({
                 fill="none"
                 stroke="#2563eb"
                 strokeWidth="2"
+              />
+            )}
+            {/* 유도등 갈림길 위치로 고른 노드 강조 — 노란 점선 링(유도등 색과 맞춤) */}
+            {isLightPreview && (
+              <circle
+                cx={n.x}
+                cy={n.y}
+                r={(n.isFinalExit ? 7 : isStair ? 6 : 4) + 6}
+                fill="none"
+                stroke={DEVICE_COLOR.light}
+                strokeWidth="2"
+                strokeDasharray="3 2"
               />
             )}
             <circle
@@ -890,20 +1003,17 @@ const MockFloorMap3F = ({
         });
       })()}
 
-      {/* 그리드 표시 토글 — 도면 위에 얹는 균일한 모눈종이 격자선(선만, 채움 없음) */}
-      {cctvGridCellsMode === 'browsing' && (
-        <GridOverlayLines cells={floorGridCells} size={gridCellPxSize} canvasH={canvasH} />
-      )}
+      {/* 그리드 배경 — 도면 위에 얹는 균일한 모눈종이 격자선(선만, 채움 없음). 선택/조회 중이든
+          아니든(browsing/selecting/viewing 어느 모드든) 항상 그림 — CCTV 카드를 눌러서 보기만
+          해도(viewing) 배경 그리드가 사라지면 안 되는데, 예전엔 viewing이 이 조건에서 빠져있어서
+          CCTV 카드를 클릭할 때마다 그리드가 사라지던 버그였음 */}
+      <GridOverlayLines cells={floorGridCells} size={gridCellPxSize} canvasH={canvasH} />
 
       {/* 그리드 셀 선택 — CCTV 신규 등록 중(선택 가능) 또는 기존 CCTV 감시 영역(조회 전용).
           셀마다 테두리를 그리면 원고지처럼 보여서, 얇은 균일 격자선 위에 선택된 셀만
           하나의 면적(채움+외곽선)으로 표시하고, 클릭 판정은 투명 히트영역이 담당함 */}
       {(cctvGridCellsMode === 'selecting' || cctvGridCellsMode === 'viewing') && (
         <>
-          {cctvGridCellsMode === 'selecting' && (
-            <GridOverlayLines cells={floorGridCells} size={gridCellPxSize} canvasH={canvasH} />
-          )}
-
           {(() => {
             const selectedCells = floorGridCells.filter((c) => selectedGridCellIds.includes(c.id));
             if (selectedCells.length === 0) return null;
@@ -983,7 +1093,11 @@ const DevicePin = ({
     isDragging.current = true;
     didMove.current = false;
 
-    const container = (e.currentTarget as HTMLElement).parentElement;
+    // 마커의 바로 위 부모(구역 드래그 중 포인터 이벤트만 끄는 레이어)는 일부러 position을
+    // 안 걸어둬서 자식이 전부 absolute면 높이가 0으로 찌그러짐 — 그 부모 기준으로 %를 계산하면
+    // rect.height가 0이라 세로 좌표가 전부 위/아래 끝으로 튐(수정 중 위치를 옮기면 마커가
+    // 캔버스 맨 위로 튀던 버그의 원인). 실제 좌표 기준인 mapWrap(그 부모의 부모)을 써야 함
+    const container = (e.currentTarget as HTMLElement).parentElement?.parentElement;
     if (!container) return;
     let lastPoint: { x: number; y: number } | null = null;
     const applyMove = rafThrottle((x: number, y: number) => onDragEnd(device.id, x, y));
@@ -1036,14 +1150,18 @@ const DevicePin = ({
       }}
       onKeyDown={(e) => e.key === 'Enter' && onClick()}
     >
-      <div className={markerClass}>
-        {device.type === 'cctv' ? (
-          <CameraIcon width={12} height={12} aria-hidden="true" />
-        ) : (
-          <WifiIcon width={12} height={12} aria-hidden="true" />
-        )}
+      <div className={styles.markerPin}>
+        <div className={markerClass}>
+          {device.type === 'cctv' ? (
+            <CameraIcon width={12} height={12} aria-hidden="true" />
+          ) : (
+            <WifiIcon width={12} height={12} aria-hidden="true" />
+          )}
+        </div>
       </div>
-      {selected && <span className={styles.markerLabel}>{device.label}</span>}
+      {selected && (
+        <span className={clsx(styles.markerLabel, styles.markerLabelPin)}>{device.label}</span>
+      )}
     </div>
   );
 };
@@ -1057,7 +1175,6 @@ const AddedDevicePin = ({
   draggable,
   onClick,
   onDragEnd,
-  onDragMoveEnd,
 }: {
   device: AddedDevice;
   posX: number;
@@ -1066,7 +1183,6 @@ const AddedDevicePin = ({
   draggable: boolean;
   onClick: () => void;
   onDragEnd: (id: string, x: number, y: number) => void;
-  onDragMoveEnd: (id: string, x: number, y: number) => void;
 }) => {
   const isDragging = useRef(false);
   const didMove = useRef(false);
@@ -1079,7 +1195,11 @@ const AddedDevicePin = ({
     isDragging.current = true;
     didMove.current = false;
 
-    const container = (e.currentTarget as HTMLElement).parentElement;
+    // 마커의 바로 위 부모(구역 드래그 중 포인터 이벤트만 끄는 레이어)는 일부러 position을
+    // 안 걸어둬서 자식이 전부 absolute면 높이가 0으로 찌그러짐 — 그 부모 기준으로 %를 계산하면
+    // rect.height가 0이라 세로 좌표가 전부 위/아래 끝으로 튐(수정 중 위치를 옮기면 마커가
+    // 캔버스 맨 위로 튀던 버그의 원인). 실제 좌표 기준인 mapWrap(그 부모의 부모)을 써야 함
+    const container = (e.currentTarget as HTMLElement).parentElement?.parentElement;
     if (!container) return;
     let lastPoint: { x: number; y: number } | null = null;
     const applyMove = rafThrottle((x: number, y: number) => onDragEnd(device.id, x, y));
@@ -1099,10 +1219,7 @@ const AddedDevicePin = ({
       applyMove.cancel();
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
-      if (lastPoint) {
-        onDragEnd(device.id, lastPoint.x, lastPoint.y);
-        onDragMoveEnd(device.id, lastPoint.x, lastPoint.y);
-      }
+      if (lastPoint) onDragEnd(device.id, lastPoint.x, lastPoint.y);
     };
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
@@ -1123,20 +1240,111 @@ const AddedDevicePin = ({
       }}
       onKeyDown={(e) => e.key === 'Enter' && onClick()}
     >
-      <div
-        className={styles.markerCircle}
-        style={{ backgroundColor: color, border: '2px dashed white' }}
-        title={device.label}
-      >
-        {device.type === 'cctv' ? (
-          <CameraIcon width={12} height={12} aria-hidden="true" />
-        ) : (
-          <WifiIcon width={12} height={12} aria-hidden="true" />
-        )}
+      <div className={styles.markerPin}>
+        <div
+          className={styles.markerCircle}
+          style={{ backgroundColor: color, border: '2px dashed white' }}
+          title={device.label}
+        >
+          {device.type === 'cctv' ? (
+            <CameraIcon width={12} height={12} aria-hidden="true" />
+          ) : (
+            <WifiIcon width={12} height={12} aria-hidden="true" />
+          )}
+        </div>
       </div>
-      {selected && <span className={styles.markerLabel}>{device.label}</span>}
+      {selected && (
+        <span className={clsx(styles.markerLabel, styles.markerLabelPin)}>{device.label}</span>
+      )}
     </div>
   );
+};
+
+type LightPickFieldName = 'decisionNode' | 'leftEdge' | 'rightEdge';
+
+interface LightPickFieldProps {
+  label: string;
+  fieldName: LightPickFieldName;
+  pickField: LightPickFieldName | null;
+  disabled?: boolean;
+  // 옵션 목록에서 찾은 현재 값의 표시용 라벨 — undefined면 아직 선택 안 된 상태
+  displayLabel?: string;
+  emptyText: string;
+  onStartPick: () => void;
+  onClear: () => void;
+}
+
+// 갈림길 위치·왼쪽 통로·오른쪽 통로 — 같은 이름 노드가 많아 드롭다운으로는 뭐가 뭔지 구분이
+// 안 된다는 QA 피드백으로 드롭다운 자체를 없애고 도면(캔버스) 클릭으로만 고르게 함. 이 컴포넌트는
+// 값을 고르는 UI가 아니라 "캔버스에서 선택" 버튼 + 현재 값 표시 + 지우기 버튼만 담당함
+const LightPickField = ({
+  label,
+  fieldName,
+  pickField,
+  disabled = false,
+  displayLabel,
+  emptyText,
+  onStartPick,
+  onClear,
+}: LightPickFieldProps) => {
+  const picking = pickField === fieldName;
+  return (
+    <div className={styles.nodeAddField}>
+      <div className={styles.nodeAddLabelRow}>
+        <span className={styles.nodeAddLabel}>{label}</span>
+        <button
+          type="button"
+          className={styles.nodeAddPickBtn}
+          disabled={disabled}
+          onClick={onStartPick}
+        >
+          {picking ? '선택 취소' : '캔버스에서 선택'}
+        </button>
+      </div>
+      <div
+        className={clsx(
+          styles.nodeAddPickDisplay,
+          !displayLabel && styles.nodeAddPickDisplayEmpty,
+          picking && styles.nodeAddPickDisplayActive,
+        )}
+      >
+        {displayLabel ?? emptyText}
+        {displayLabel && (
+          <button
+            type="button"
+            aria-label={`${label} 선택 해제`}
+            className={styles.nodeAddPickClearBtn}
+            onClick={onClear}
+          >
+            <XIcon width={14} height={14} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// 갈림길 위치에 이어진 엣지가 도면에 하나도 없으면 왼쪽/오른쪽 통로는 캔버스에서 클릭할 대상 자체가
+// 없어 아무것도 고를 수 없음(통로는 이 팝업이 아니라 별도의 "+ 추가 → 엣지 추가"로 미리 그려둬야
+// 하는 데이터라서) — 그 상태에서 그냥 "클릭해주세요"만 보여주면 왜 안 되는지 알 수 없어 안내를 바꿔줌
+const getLightPickHint = (
+  pickField: LightPickFieldName | null,
+  decisionNodeId: string,
+  edgeOptions: readonly { fromNodeId: string; toNodeId: string }[],
+): string => {
+  if (!pickField) {
+    return '이 유도등이 서 있는 갈림길 위치와, 화재 시 왼쪽·오른쪽 중 어느 통로로 안내할지 정해주세요';
+  }
+  if (pickField === 'decisionNode') return '도면에서 갈림길이 될 노드를 클릭해주세요';
+  const hasConnectedEdge = edgeOptions.some(
+    (e) => e.fromNodeId === decisionNodeId || e.toNodeId === decisionNodeId,
+  );
+  if (!hasConnectedEdge) {
+    return '이 갈림길에 연결된 통로(엣지)가 없어요. "+ 추가 → 엣지 추가"로 통로를 먼저 만들어주세요';
+  }
+  return pickField === 'leftEdge'
+    ? '도면에서 왼쪽 통로가 될 구간(선)을 클릭해주세요'
+    : '도면에서 오른쪽 통로가 될 구간(선)을 클릭해주세요';
 };
 
 /* ── 장비 추가 팝업 ──
@@ -1159,6 +1367,10 @@ const NodeAddPopup = ({
   lightNodeOptions,
   lightEdgeOptions,
   lightCctvOptions,
+  lightFields,
+  onLightFieldsChange,
+  lightPickField,
+  onStartLightPick,
 }: {
   containerRef: React.RefObject<HTMLDivElement>;
   type: PlacingDeviceType;
@@ -1168,26 +1380,34 @@ const NodeAddPopup = ({
   selectedCellCount: number;
   onCancel: () => void;
   onBack: () => void;
-  onSubmitEntry: (
-    type: PlacingDeviceType,
-    deviceId: string,
-    location: string,
-    lightFields: LightAddFields,
-  ) => void;
-  onFinalize: (deviceId: string, location: string) => void;
+  onSubmitEntry: (type: PlacingDeviceType, deviceId: string, lightFields: LightAddFields) => void;
+  onFinalize: (deviceId: string) => void;
   lightNodeOptions: { id: string; label: string }[];
   lightEdgeOptions: { id: string; label: string; fromNodeId: string; toNodeId: string }[];
   lightCctvOptions: { id: string; label: string }[];
+  // 갈림길 위치·좌우 통로 값은 부모가 갖고 있음(캔버스 클릭으로도 같은 값을 채울 수 있어야
+  // 해서 이 팝업 로컬 state로 두면 캔버스↔팝업 양방향 동기화가 번거로워짐 — DeviceCard의
+  // editForm과 같은 방식으로 통일). 담당 CCTV는 캔버스에서 고를 대상이 아니라 포함하지 않음
+  lightFields: { decisionNodeId: string; leftEdgeId: string; rightEdgeId: string };
+  onLightFieldsChange: (fields: {
+    decisionNodeId: string;
+    leftEdgeId: string;
+    rightEdgeId: string;
+  }) => void;
+  lightPickField: 'decisionNode' | 'leftEdge' | 'rightEdge' | null;
+  onStartLightPick: (field: 'decisionNode' | 'leftEdge' | 'rightEdge') => void;
 }) => {
   const [deviceId, setDeviceId] = useState('');
-  const [location, setLocation] = useState('');
-  // 유도등 추가 시 담당 CCTV·가이던스도 같이 받음 — 수정 카드(DeviceCard)와 채워야 하는 값이
-  // 서로 달라 등록 직후엔 "훈련 준비"에 필요한 guidanceConfigured/cctvId가 항상 비어있던 문제.
-  // 도면에 아직 판단 노드·엣지·CCTV가 없을 수도 있어 필수로 막지는 않음(비워두면 등록 후 카드에서 마저 채움)
+  // 담당 CCTV는 캔버스에서 고를 대상이 아니라(그래프 노드/엣지가 아님) 계속 이 팝업 로컬
+  // state로 둠 — 수정 카드(DeviceCard)와 채워야 하는 값이 서로 달라 등록 직후엔 "훈련 준비"에
+  // 필요한 guidanceConfigured/cctvId가 항상 비어있던 문제. 도면에 아직 판단 노드·엣지·CCTV가
+  // 없을 수도 있어 필수로 막지는 않음(비워두면 등록 후 카드에서 마저 채움)
   const [lightCctvId, setLightCctvId] = useState('');
-  const [lightDecisionNodeId, setLightDecisionNodeId] = useState('');
-  const [lightLeftEdgeId, setLightLeftEdgeId] = useState('');
-  const [lightRightEdgeId, setLightRightEdgeId] = useState('');
+  const {
+    decisionNodeId: lightDecisionNodeId,
+    leftEdgeId: lightLeftEdgeId,
+    rightEdgeId: lightRightEdgeId,
+  } = lightFields;
 
   const isStructureNode = isStructureNodeType(type);
   const isCctv = type === 'cctv';
@@ -1223,7 +1443,7 @@ const NodeAddPopup = ({
             type="button"
             className={styles.nodeAddSubmitBtn}
             disabled={selectedCellCount === 0}
-            onClick={() => onFinalize(deviceId, location)}
+            onClick={() => onFinalize(deviceId)}
           >
             추가
           </button>
@@ -1276,16 +1496,6 @@ const NodeAddPopup = ({
             />
           </div>
 
-          <div className={styles.nodeAddField}>
-            <span className={styles.nodeAddLabel}>설치 위치</span>
-            <input
-              className={styles.nodeAddInput}
-              value={location}
-              onChange={(e) => setLocation(e.target.value)}
-              placeholder="3층 · 복도 동측"
-            />
-          </div>
-
           {/* 담당 CCTV·가이던스(판단 노드/좌우 엣지) — 장비 카드 수정에서만 채울 수 있던 값이라
               등록 직후엔 항상 비어있던 문제(훈련 준비의 guidanceConfigured가 안 채워짐). 도면에
               아직 판단 노드·엣지·CCTV가 없을 수도 있어 필수는 아니고, 비워두면 등록 후 카드에서
@@ -1304,62 +1514,45 @@ const NodeAddPopup = ({
                   placeholder="미지정"
                 />
               </div>
-              <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>판단 노드</span>
-                <Dropdown
-                  shape="rounded"
-                  fullWidth
-                  ariaLabel="판단 노드"
-                  options={lightNodeOptions.map((n) => ({ value: n.id, label: n.label }))}
-                  value={lightDecisionNodeId}
-                  onChange={(v) => {
-                    setLightDecisionNodeId(v);
-                    setLightLeftEdgeId('');
-                    setLightRightEdgeId('');
-                  }}
-                  placeholder="판단 노드 선택"
-                />
-              </div>
-              <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>왼쪽 경로 엣지</span>
-                <Dropdown
-                  shape="rounded"
-                  fullWidth
-                  ariaLabel="왼쪽 경로 엣지"
-                  disabled={!lightDecisionNodeId}
-                  options={lightEdgeOptions
-                    .filter(
-                      (e) =>
-                        (e.fromNodeId === lightDecisionNodeId ||
-                          e.toNodeId === lightDecisionNodeId) &&
-                        e.id !== lightRightEdgeId,
-                    )
-                    .map((e) => ({ value: e.id, label: e.label }))}
-                  value={lightLeftEdgeId}
-                  onChange={setLightLeftEdgeId}
-                  placeholder={lightDecisionNodeId ? '왼쪽 엣지 선택' : '판단 노드를 먼저 선택'}
-                />
-              </div>
-              <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>오른쪽 경로 엣지</span>
-                <Dropdown
-                  shape="rounded"
-                  fullWidth
-                  ariaLabel="오른쪽 경로 엣지"
-                  disabled={!lightDecisionNodeId}
-                  options={lightEdgeOptions
-                    .filter(
-                      (e) =>
-                        (e.fromNodeId === lightDecisionNodeId ||
-                          e.toNodeId === lightDecisionNodeId) &&
-                        e.id !== lightLeftEdgeId,
-                    )
-                    .map((e) => ({ value: e.id, label: e.label }))}
-                  value={lightRightEdgeId}
-                  onChange={setLightRightEdgeId}
-                  placeholder={lightDecisionNodeId ? '오른쪽 엣지 선택' : '판단 노드를 먼저 선택'}
-                />
-              </div>
+              {/* "판단 노드"·"경로 엣지"란 용어와, 목록에 같은 종류(예: 복도) 노드가 여러 개일 때
+                  뭐가 뭔지 구분이 안 된다는 QA 피드백 — 무엇을 고르는 건지 문장으로 먼저 알려주고,
+                  옵션 라벨도 우측 패널 카드와 같은 번호("복도 1" 등, getGraphNodeLabel)를 쓰게 함.
+                  드롭다운이 여전히 헷갈리면 "캔버스에서 선택" 버튼으로 도면에서 직접 클릭해 고를
+                  수도 있게 함(이 경우 도면 위 강조·클릭은 부모가 처리하고 값만 내려받음) */}
+              <span className={styles.nodeAddHint}>
+                {getLightPickHint(lightPickField, lightDecisionNodeId, lightEdgeOptions)}
+              </span>
+              <LightPickField
+                label="갈림길 위치"
+                fieldName="decisionNode"
+                pickField={lightPickField}
+                displayLabel={lightNodeOptions.find((n) => n.id === lightDecisionNodeId)?.label}
+                emptyText="갈림길 위치 선택"
+                onStartPick={() => onStartLightPick('decisionNode')}
+                onClear={() =>
+                  onLightFieldsChange({ decisionNodeId: '', leftEdgeId: '', rightEdgeId: '' })
+                }
+              />
+              <LightPickField
+                label="왼쪽 통로"
+                fieldName="leftEdge"
+                pickField={lightPickField}
+                disabled={!lightDecisionNodeId}
+                displayLabel={lightEdgeOptions.find((e) => e.id === lightLeftEdgeId)?.label}
+                emptyText={lightDecisionNodeId ? '왼쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                onStartPick={() => onStartLightPick('leftEdge')}
+                onClear={() => onLightFieldsChange({ ...lightFields, leftEdgeId: '' })}
+              />
+              <LightPickField
+                label="오른쪽 통로"
+                fieldName="rightEdge"
+                pickField={lightPickField}
+                disabled={!lightDecisionNodeId}
+                displayLabel={lightEdgeOptions.find((e) => e.id === lightRightEdgeId)?.label}
+                emptyText={lightDecisionNodeId ? '오른쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                onStartPick={() => onStartLightPick('rightEdge')}
+                onClear={() => onLightFieldsChange({ ...lightFields, rightEdgeId: '' })}
+              />
             </>
           )}
         </>
@@ -1374,7 +1567,7 @@ const NodeAddPopup = ({
           className={styles.nodeAddSubmitBtn}
           disabled={!canSubmit}
           onClick={() =>
-            onSubmitEntry(type, deviceId.trim(), location.trim(), {
+            onSubmitEntry(type, deviceId.trim(), {
               cctvId: lightCctvId,
               decisionNodeId: lightDecisionNodeId,
               leftEdgeId: lightLeftEdgeId,
@@ -1749,13 +1942,15 @@ const DeviceCard = ({
   onSelect,
   onStartEdit,
   onSaveEdit,
+  onCancelEdit,
   onDelete,
   onToggleEnabled,
   onEditCctvCells,
-  onLightDirectionChange,
   lightNodeOptions,
   lightEdgeOptions,
   lightCctvOptions,
+  lightPickField,
+  onStartLightPick,
 }: {
   item: PanelItem;
   selected: boolean;
@@ -1767,23 +1962,20 @@ const DeviceCard = ({
   onSelect: (item: PanelItem) => void;
   onStartEdit: (item: PanelItem) => void;
   onSaveEdit: (item: PanelItem) => void;
+  onCancelEdit: (item: PanelItem) => void;
   onDelete: (item: PanelItem) => void;
   onToggleEnabled: (item: PanelItem) => void;
   onEditCctvCells: (item: PanelItem) => void;
-  onLightDirectionChange: (item: PanelItem, direction: 'LEFT' | 'RIGHT' | 'OFF') => void;
   lightNodeOptions: { id: string; label: string }[];
   lightEdgeOptions: { id: string; label: string; fromNodeId: string; toNodeId: string }[];
   lightCctvOptions: { id: string; label: string }[];
+  // "캔버스에서 선택" — 드롭다운 대신 도면에서 직접 클릭해 갈림길 위치·좌우 통로를 고르는 대안
+  lightPickField: 'decisionNode' | 'leftEdge' | 'rightEdge' | null;
+  onStartLightPick: (field: 'decisionNode' | 'leftEdge' | 'rightEdge') => void;
 }) => {
   // 가이던스·방향처럼 자주 안 건드리는 항목은 접어둬서, 수정 모드로 들어갈 때 카드가
   // 일반 모드보다 과하게 길어지는 걸 줄임
   const [detailsOpen, setDetailsOpen] = useState(false);
-  // 방향은 서버가 현재값을 안 내려줘서(즉시 명령이라 조회 불가) 버튼 자체엔 "지금 상태"를
-  // 표시할 수 없음 — 대신 "방금 이 버튼을 눌렀다"는 걸 보이게 해서 클릭이 씹혔는지 헷갈리지
-  // 않게 함(카드가 다시 열리면 초기화되는, 이번에 누른 것만 기억하는 값)
-  const [lastClickedDirection, setLastClickedDirection] = useState<'LEFT' | 'RIGHT' | 'OFF' | null>(
-    null,
-  );
 
   return (
     <div
@@ -1805,17 +1997,30 @@ const DeviceCard = ({
         if (!editing) onSelect(item);
       }}
     >
-      {editing ? (
-        <input
-          className={styles.deviceCardNameInput}
-          aria-label="장치 이름"
-          value={editForm.label}
-          onChange={(e) => onEditFormChange({ ...editForm, label: e.target.value })}
-          onClick={(e) => e.stopPropagation()}
-        />
-      ) : (
-        <span className={styles.deviceCardName}>{item.label}</span>
-      )}
+      <div className={styles.deviceCardNameRow}>
+        {editing ? (
+          <input
+            className={styles.deviceCardNameInput}
+            aria-label="장치 이름"
+            value={editForm.label}
+            onChange={(e) => onEditFormChange({ ...editForm, label: e.target.value })}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className={styles.deviceCardName}>{item.label}</span>
+        )}
+        <button
+          type="button"
+          aria-label="삭제"
+          className={styles.zoneCardIconBtnDelete}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(item);
+          }}
+        >
+          <TrashIcon width={14} height={14} />
+        </button>
+      </div>
       <div className={styles.deviceCardRow}>
         <span className={styles.deviceCardKey}>장치 코드</span>
         <span
@@ -1868,7 +2073,7 @@ const DeviceCard = ({
           title={
             item.type === 'cctv'
               ? '감시 영역에서 자동으로 계산돼요'
-              : '저장되는 값이 아니라 편집할 수 없어요'
+              : '도면 위 실제 좌표예요 — 캔버스에서 위치를 옮기면 여기도 함께 바뀌어요'
           }
         >
           {item.zone}
@@ -1897,7 +2102,7 @@ const DeviceCard = ({
           )}
           <div
             className={styles.deviceCardRow}
-            title="화재 시 이 유도등이 갈림길(판단 노드)에서 왼쪽/오른쪽 중 어느 통로로 사람들을 안내할지 정해요"
+            title="화재 시 이 유도등이 서 있는 갈림길에서 왼쪽/오른쪽 중 어느 통로로 사람들을 안내할지 정해요"
           >
             <span className={styles.deviceCardKey}>경로 · 방향</span>
             {editing ? (
@@ -1919,126 +2124,55 @@ const DeviceCard = ({
           </div>
           {editing && detailsOpen && (
             <div className={styles.lightFieldGroup} onClick={(e) => e.stopPropagation()}>
-              <Dropdown
-                shape="rounded"
-                fullWidth
-                ariaLabel="판단 노드"
-                options={lightNodeOptions.map((n) => ({ value: n.id, label: n.label }))}
-                value={editForm.decisionNodeId}
-                onChange={(v) =>
-                  // 판단 노드를 바꾸면 이전 노드에 연결돼 있던 좌/우 엣지 선택은 더 이상
-                  // 유효하지 않을 수 있어(연결 안 된 엣지를 저장 시점에야 서버가 거부하던 문제의
-                  // 원인이었음) 같이 비움
+              {/* "판단 노드"·"경로 엣지"란 용어가 무엇을 고르는 건지 안 와닿는다는 QA 피드백 —
+                  펼쳤을 때 항상 보이는 문장으로 먼저 설명함(hover에만 의존하던 title 문구를 대체).
+                  드롭다운에 같은 이름 노드가 많아 헷갈리면 "캔버스에서 선택"으로 도면에서 직접
+                  클릭해 고를 수도 있음 */}
+              <span className={styles.nodeAddHint}>
+                {getLightPickHint(lightPickField, editForm.decisionNodeId, lightEdgeOptions)}
+              </span>
+              <LightPickField
+                label="갈림길 위치"
+                fieldName="decisionNode"
+                pickField={lightPickField}
+                displayLabel={lightNodeOptions.find((n) => n.id === editForm.decisionNodeId)?.label}
+                emptyText="갈림길 위치 선택"
+                onStartPick={() => onStartLightPick('decisionNode')}
+                onClear={() =>
+                  // 갈림길 위치(판단 노드)를 바꾸면 이전 노드에 연결돼 있던 좌/우 통로 선택은
+                  // 더 이상 유효하지 않을 수 있어(연결 안 된 엣지를 저장 시점에야 서버가
+                  // 거부하던 문제의 원인이었음) 같이 비움
                   onEditFormChange({
                     ...editForm,
-                    decisionNodeId: v,
+                    decisionNodeId: '',
                     leftEdgeId: '',
                     rightEdgeId: '',
                   })
                 }
-                placeholder="판단 노드 선택"
               />
-              {/* 판단 노드에 실제로 연결된 엣지만 후보로 보여줌 — 그 외 엣지를 고르면 저장할 때
+              {/* 갈림길 위치에 실제로 연결된 통로(엣지)만 후보로 보여줌 — 그 외를 고르면 저장할 때
                   서버가 거부해서(leftEdgeId/rightEdgeId는 decisionNodeId에 연결돼 있어야 함)
-                  헷갈리던 문제를 아예 고를 수 없게 만들어 없앰. 좌/우도 서로 같은 엣지를
-                  고르지 못하게 상대가 고른 걸 후보에서 뺌 */}
-              <Dropdown
-                shape="rounded"
-                fullWidth
-                ariaLabel="왼쪽 경로 엣지"
+                  헷갈리던 문제를 아예 고를 수 없게 만들어 없앰 */}
+              <LightPickField
+                label="왼쪽 통로"
+                fieldName="leftEdge"
+                pickField={lightPickField}
                 disabled={!editForm.decisionNodeId}
-                options={lightEdgeOptions
-                  .filter(
-                    (e) =>
-                      (e.fromNodeId === editForm.decisionNodeId ||
-                        e.toNodeId === editForm.decisionNodeId) &&
-                      e.id !== editForm.rightEdgeId,
-                  )
-                  .map((e) => ({ value: e.id, label: e.label }))}
-                value={editForm.leftEdgeId}
-                onChange={(v) => onEditFormChange({ ...editForm, leftEdgeId: v })}
-                placeholder={editForm.decisionNodeId ? '왼쪽 엣지 선택' : '판단 노드를 먼저 선택'}
+                displayLabel={lightEdgeOptions.find((e) => e.id === editForm.leftEdgeId)?.label}
+                emptyText={editForm.decisionNodeId ? '왼쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                onStartPick={() => onStartLightPick('leftEdge')}
+                onClear={() => onEditFormChange({ ...editForm, leftEdgeId: '' })}
               />
-              <Dropdown
-                shape="rounded"
-                fullWidth
-                ariaLabel="오른쪽 경로 엣지"
+              <LightPickField
+                label="오른쪽 통로"
+                fieldName="rightEdge"
+                pickField={lightPickField}
                 disabled={!editForm.decisionNodeId}
-                options={lightEdgeOptions
-                  .filter(
-                    (e) =>
-                      (e.fromNodeId === editForm.decisionNodeId ||
-                        e.toNodeId === editForm.decisionNodeId) &&
-                      e.id !== editForm.leftEdgeId,
-                  )
-                  .map((e) => ({ value: e.id, label: e.label }))}
-                value={editForm.rightEdgeId}
-                onChange={(v) => onEditFormChange({ ...editForm, rightEdgeId: v })}
-                placeholder={editForm.decisionNodeId ? '오른쪽 엣지 선택' : '판단 노드를 먼저 선택'}
+                displayLabel={lightEdgeOptions.find((e) => e.id === editForm.rightEdgeId)?.label}
+                emptyText={editForm.decisionNodeId ? '오른쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                onStartPick={() => onStartLightPick('rightEdge')}
+                onClear={() => onEditFormChange({ ...editForm, rightEdgeId: '' })}
               />
-
-              <div className={styles.lightDirectionRow}>
-                <button
-                  type="button"
-                  className={clsx(
-                    styles.lightDirectionBtn,
-                    lastClickedDirection === 'LEFT' && styles.lightDirectionBtnActive,
-                  )}
-                  disabled={!item.cctvName}
-                  title={
-                    item.cctvName
-                      ? '저장 없이 누르면 바로 적용돼요'
-                      : '담당 CCTV를 먼저 지정해야 동작해요'
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLastClickedDirection('LEFT');
-                    onLightDirectionChange(item, 'LEFT');
-                  }}
-                >
-                  왼쪽
-                </button>
-                <button
-                  type="button"
-                  className={clsx(
-                    styles.lightDirectionBtn,
-                    lastClickedDirection === 'RIGHT' && styles.lightDirectionBtnActive,
-                  )}
-                  disabled={!item.cctvName}
-                  title={
-                    item.cctvName
-                      ? '저장 없이 누르면 바로 적용돼요'
-                      : '담당 CCTV를 먼저 지정해야 동작해요'
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLastClickedDirection('RIGHT');
-                    onLightDirectionChange(item, 'RIGHT');
-                  }}
-                >
-                  오른쪽
-                </button>
-                <button
-                  type="button"
-                  className={clsx(
-                    styles.lightDirectionBtn,
-                    lastClickedDirection === 'OFF' && styles.lightDirectionBtnActive,
-                  )}
-                  disabled={!item.cctvName}
-                  title={
-                    item.cctvName
-                      ? '저장 없이 누르면 바로 적용돼요'
-                      : '담당 CCTV를 먼저 지정해야 동작해요'
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLastClickedDirection('OFF');
-                    onLightDirectionChange(item, 'OFF');
-                  }}
-                >
-                  끄기
-                </button>
-              </div>
             </div>
           )}
         </>
@@ -2073,18 +2207,30 @@ const DeviceCard = ({
       )}
       <div className={styles.deviceCardActions}>
         {editing ? (
-          <button
-            type="button"
-            className={styles.deviceCardDoneBtn}
-            disabled={!hasChanges}
-            title={hasChanges ? undefined : '변경된 내용이 없어요'}
-            onClick={(e) => {
-              e.stopPropagation();
-              onSaveEdit(item);
-            }}
-          >
-            완료
-          </button>
+          <>
+            <button
+              type="button"
+              className={styles.deviceCardEditBtn}
+              onClick={(e) => {
+                e.stopPropagation();
+                onCancelEdit(item);
+              }}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              className={styles.deviceCardDoneBtn}
+              disabled={!hasChanges}
+              title={hasChanges ? undefined : '변경된 내용이 없어요'}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSaveEdit(item);
+              }}
+            >
+              완료
+            </button>
+          </>
         ) : (
           <button
             type="button"
@@ -2097,16 +2243,6 @@ const DeviceCard = ({
             수정
           </button>
         )}
-        <button
-          type="button"
-          className={styles.deviceCardDeleteBtn}
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete(item);
-          }}
-        >
-          삭제
-        </button>
       </div>
     </div>
   );
@@ -2153,9 +2289,13 @@ const FloorCanvas = ({
   onSelectDevice,
   onMapClick,
   onDeviceMoved,
-  onDeviceMoveEnd,
   onUpload,
   onBackgroundClick,
+  lightPreviewNodeId,
+  lightPreviewLeftEdgeId,
+  lightPreviewRightEdgeId,
+  lightPickField,
+  onLightPick,
 }: {
   mapWrapRef: React.RefObject<HTMLDivElement>;
   floor: Floor;
@@ -2196,9 +2336,13 @@ const FloorCanvas = ({
   onSelectDevice: (d: DeviceMarker) => void;
   onMapClick: (x: number, y: number) => void;
   onDeviceMoved: (id: string, x: number, y: number) => void;
-  onDeviceMoveEnd: (id: string, x: number, y: number) => void;
   onUpload: () => void;
   onBackgroundClick: () => void;
+  lightPreviewNodeId?: string;
+  lightPreviewLeftEdgeId?: string;
+  lightPreviewRightEdgeId?: string;
+  lightPickField?: 'decisionNode' | 'leftEdge' | 'rightEdge' | null;
+  onLightPick?: (id: string) => void;
 }) => {
   const hasFloorPlan = floor.segmentationStatus === 'DONE';
 
@@ -2271,6 +2415,11 @@ const FloorCanvas = ({
         onGridCellToggle={onGridCellToggle}
         onMapClick={onMapClick}
         onBackgroundClick={onBackgroundClick}
+        lightPreviewNodeId={lightPreviewNodeId}
+        lightPreviewLeftEdgeId={lightPreviewLeftEdgeId}
+        lightPreviewRightEdgeId={lightPreviewRightEdgeId}
+        lightPickField={lightPickField}
+        onLightPick={onLightPick}
       />
       {stagedCameraPosition && (
         <div
@@ -2284,7 +2433,12 @@ const FloorCanvas = ({
           기준(mapWrap)에는 영향이 없음 */}
       <div style={{ pointerEvents: isZoneDragging ? 'none' : undefined }}>
         {floor.devices.map((device) => {
-          const pos = devicePositions[device.id] ?? { x: device.x, y: device.y };
+          // devicePositions는 드래그 중 미리보기 오버레이 — 수정 모드를 벗어나면(완료든 취소든)
+          // 곧바로 원래 좌표로 되돌아가야 해서, 그 항목을 수정 중일 때만 오버레이를 반영함
+          const pos =
+            editingItemId === device.id && devicePositions[device.id]
+              ? devicePositions[device.id]
+              : { x: device.x, y: device.y };
           return (
             <DevicePin
               key={device.id}
@@ -2301,7 +2455,12 @@ const FloorCanvas = ({
 
         {/* 사용자가 추가한 장치 마커 */}
         {addedDevices.map((d) => {
-          const pos = devicePositions[d.id] ?? { x: d.x, y: d.y };
+          // devicePositions는 드래그 중 미리보기 오버레이 — 수정 모드를 벗어나면(완료든 취소든)
+          // 곧바로 원래 좌표로 되돌아가야 해서, 그 항목을 수정 중일 때만 오버레이를 반영함
+          const pos =
+            editingItemId === d.id && devicePositions[d.id]
+              ? devicePositions[d.id]
+              : { x: d.x, y: d.y };
           return (
             <AddedDevicePin
               key={d.id}
@@ -2312,7 +2471,6 @@ const FloorCanvas = ({
               draggable={editingItemId === d.id}
               onClick={() => onSelectDevice(d as unknown as DeviceMarker)}
               onDragEnd={onDeviceMoved}
-              onDragMoveEnd={onDeviceMoveEnd}
             />
           );
         })}
@@ -2723,6 +2881,20 @@ const FloorPlansDetailPage = () => {
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
   const [editForm, setEditForm] = useState<DeviceEditForm>(EMPTY_DEVICE_EDIT_FORM);
   const [nodeAddType, setNodeAddType] = useState<PlacingDeviceType>('cctv');
+  // 유도등 추가 팝업의 갈림길 위치·좌우 통로 값 — 드롭다운뿐 아니라 캔버스 클릭으로도 채울 수
+  // 있어야 해서(도면에서 직접 고르는 대안) 팝업 로컬 state가 아니라 여기서 관리함. 담당 CCTV는
+  // 캔버스에서 고를 대상이 아니라 계속 팝업 로컬 state(lightCctvId)로 남아있음
+  const [nodeAddLightFields, setNodeAddLightFields] = useState({
+    decisionNodeId: '',
+    leftEdgeId: '',
+    rightEdgeId: '',
+  });
+  // 지금 "캔버스에서 선택" 모드가 걸려있는 대상 — 추가 팝업/수정 카드 중 어느 쪽의 어느
+  // 필드인지 알아야 캔버스 클릭 결과를 올바른 곳에 반영할 수 있음
+  const [lightPickTarget, setLightPickTarget] = useState<{
+    source: 'add' | 'edit';
+    field: 'decisionNode' | 'leftEdge' | 'rightEdge';
+  } | null>(null);
   const [addedDevices, setAddedDevices] = useState<AddedDevice[]>([]);
   const [structureNodes, setStructureNodes] = useState<StructureNode[]>([]);
 
@@ -2772,31 +2944,11 @@ const FloorPlansDetailPage = () => {
     {},
   );
 
+  // devicePositions는 드래그 중 화면에 즉시 반영하기 위한 임시 오버레이 — 실제 저장은
+  // "완료"를 눌렀을 때(handleSaveEdit)만 일어나고, 그 전까지는 이 값만 갱신됨. 수정 모드를
+  // 벗어나면(완료든 취소든) 렌더링 쪽에서 이 오버레이를 무시하고 원래 좌표로 되돌아감
   const handleDeviceMoved = (id: string, x: number, y: number) => {
     setDevicePositions((prev) => ({ ...prev, [id]: { x, y } }));
-  };
-
-  // 드래그가 끝났을 때만 실제 위치를 저장. devicePositions는 드래그 중 화면에 즉시 반영하기 위한
-  // 임시 오버레이라, 서버에 커밋되면 addedDevices의 x/y도 같이 맞춰줌 — 그래야 이후 addedDevices가
-  // 다른 이유로 재구성되어도 devicePositions 없이 최신 위치를 그대로 유지함
-  const handleDeviceMoveEnd = (id: string, x: number, y: number) => {
-    const device = addedDevices.find((d) => d.id === id);
-    if (device?.placeType === 'light') {
-      updateIoTLight(id, { name: device.label, x: x / 100, y: y / 100 })
-        .then(() => {
-          setAddedDevices((prev) => prev.map((d) => (d.id === id ? { ...d, x, y } : d)));
-        })
-        .catch(() => {});
-      return;
-    }
-    if (device?.placeType === 'cctv') {
-      updateCctv(id, { name: device.label, x: x / 100, y: y / 100 })
-        .then((updated) => {
-          setRealCctvs((prev) => prev.map((c) => (c.id === id ? updated : c)));
-          setAddedDevices((prev) => prev.map((d) => (d.id === id ? { ...d, x, y } : d)));
-        })
-        .catch(() => {});
-    }
   };
 
   // CCTV/유도등 카드의 활성화 스위치 — 둘 다 enabled 필드와 활성화/비활성화 PATCH API 모양이
@@ -2875,16 +3027,6 @@ const FloorPlansDetailPage = () => {
       .catch(() => {});
   };
 
-  // 방향은 저장 개념이 없는 즉시 적용 명령이라(서버도 현재값을 GET에 내려주지 않음) 카드에서
-  // 누르면 바로 호출함 — "수정 → 완료"로 묶인 다른 필드들과 달리 그 자체가 액션임
-  const handleLightDirectionChange = (item: PanelItem, direction: 'LEFT' | 'RIGHT' | 'OFF') => {
-    changeLightDirection(item.id, direction)
-      .then(() => show({ title: '유도등 방향을 변경했습니다.', variant: 'success' }))
-      .catch((error: unknown) => {
-        const { message } = extractApiError(error);
-        show({ title: message || '유도등 방향 변경에 실패했습니다.', variant: 'error' });
-      });
-  };
   const [toastMsg] = useState<string | null>(null);
   const [toastFading] = useState(false);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -3028,7 +3170,6 @@ const FloorPlansDetailPage = () => {
   const finalizeNodePlacement = (
     type: PlacingDeviceType,
     deviceId: string,
-    location: string,
     position: { x: number; y: number },
     lightFields: LightAddFields,
   ) => {
@@ -3094,7 +3235,9 @@ const FloorPlansDetailPage = () => {
                 x: position.x,
                 y: position.y,
                 status: 'online',
-                zone: location || '사용자 등록',
+                // 유도등의 "설치 위치"는 실제 좌표(x/y)로 표시하므로(formatInstallLocation) 여기
+                // 값은 안 쓰임 — AddedDevice.zone 타입을 맞추기 위한 자리만 채움
+                zone: '',
               },
             ]);
 
@@ -3133,6 +3276,7 @@ const FloorPlansDetailPage = () => {
     setNodeStagedPosition(null);
     setZoneDraftRect(null);
     setNodeAddOpen(false);
+    setNodeAddLightFields({ decisionNodeId: '', leftEdgeId: '', rightEdgeId: '' });
   };
 
   // 그리드가 필요한 두 진입점(CCTV 등록, 그리드 표시 토글)이 공유하는 확인 로직 —
@@ -3165,7 +3309,6 @@ const FloorPlansDetailPage = () => {
   const handleSubmitNodeEntry = (
     type: PlacingDeviceType,
     deviceId: string,
-    location: string,
     lightFields: LightAddFields,
   ) => {
     if (!nodeStagedPosition) return;
@@ -3216,7 +3359,7 @@ const FloorPlansDetailPage = () => {
       });
       return;
     }
-    finalizeNodePlacement(type, deviceId, location, nodeStagedPosition, lightFields);
+    finalizeNodePlacement(type, deviceId, nodeStagedPosition, lightFields);
   };
 
   // 그리드설정/시야구역 단계에서 뒤로 — 입력 단계로 돌아가되 이미 지정한 위치는 유지
@@ -3227,10 +3370,13 @@ const FloorPlansDetailPage = () => {
     lastCctvDraftRectRef.current = null;
   };
 
-  // 팝업을 취소로 닫을 때도 다음 CCTV 등록 시도가 이전 드래그 영역을 이어받지 않게 비움
+  // 팝업을 취소로 닫을 때도 다음 CCTV 등록 시도가 이전 드래그 영역을 이어받지 않게 비움.
+  // 유도등 갈림길·좌우 통로 값과 캔버스 픽 모드도 다음 추가 시도에 남아있지 않게 같이 정리
   const handleCancelNodeAdd = () => {
     setNodeAddOpen(false);
     lastCctvDraftRectRef.current = null;
+    setNodeAddLightFields({ decisionNodeId: '', leftEdgeId: '', rightEdgeId: '' });
+    setLightPickTarget((prev) => (prev?.source === 'add' ? null : prev));
   };
 
   const handleGridSetupPromptCancel = () => {
@@ -3490,7 +3636,9 @@ const FloorPlansDetailPage = () => {
   };
 
   const handleStructureNodeMoveEnd = (id: string, x: number, y: number) => {
-    updateMapNodePosition(id, { x: x / CANVAS_W, y: y / canvasH }).catch(() => {});
+    updateMapNodePosition(id, { x: x / CANVAS_W, y: y / canvasH }).catch(() => {
+      show({ title: '위치 저장에 실패했습니다.', variant: 'error' });
+    });
   };
 
   const handleStructureNodeDelete = (id: string) => {
@@ -3513,10 +3661,18 @@ const FloorPlansDetailPage = () => {
       });
   };
 
-  // 노드 id로 표시용 라벨 조회 (구조 노드 + 그 외 그래프 노드 통합)
+  // 노드 id로 표시용 라벨 조회 (구조 노드 + 그 외 그래프 노드 통합) — 같은 종류(예: 복도)가
+  // 여러 개면 전부 "복도"로만 보여서 유도등 판단 노드·경로 엣지를 고를 때 뭐가 뭔지 구분이
+  // 안 되던 문제(QA 피드백) — 우측 패널 카드와 같은 규칙("복도 1", "복도 2"...)으로 번호를
+  // 붙여서, 패널에서 본 번호와 드롭다운 번호가 그대로 대응되게 함
   const getGraphNodeLabel = (id: string): string => {
     const structureNode = structureNodes.find((n) => n.id === id);
-    if (structureNode) return STRUCTURE_NODE_LABEL[structureNode.type];
+    if (structureNode) {
+      const sameTypeIndex = structureNodes
+        .filter((n) => n.type === structureNode.type)
+        .findIndex((n) => n.id === structureNode.id);
+      return `${STRUCTURE_NODE_LABEL[structureNode.type]} ${sameTypeIndex + 1}`;
+    }
     const graphNode = graphNodes.find((n) => n.id === id);
     return graphNode?.name ?? id;
   };
@@ -4102,7 +4258,7 @@ const FloorPlansDetailPage = () => {
         label: d.label,
         statusText: d.status === 'online' ? '실시간' : '오프라인',
         statusOnline: d.status === 'online',
-        zone: d.zone,
+        zone: formatInstallLocation(deviceTypeToPlaceType(d.type), d.x, d.y, d.zone),
         source: 'floor' as const,
       })),
       // 상태는 실제 CCTV/유도등의 enabled를 따라감 — 예전엔 '실시간'으로 고정돼 있어서
@@ -4118,7 +4274,7 @@ const FloorPlansDetailPage = () => {
           label: d.label,
           statusText: enabled ? '활성화' : '비활성화',
           statusOnline: enabled,
-          zone: d.zone,
+          zone: formatInstallLocation(d.placeType, d.x, d.y, d.zone),
           source: 'added' as const,
           monitoredArea: matchedCctv
             ? { cellCount: matchedCctv.monitoredGridCellCount, areaM2: matchedCctv.monitoredAreaM2 }
@@ -4150,12 +4306,16 @@ const FloorPlansDetailPage = () => {
     [structureNodes, deviceTypeFilter],
   );
 
-  // 유도등 설정 모달의 판단 노드/엣지 드롭다운 목록
+  // 유도등 설정 모달의 판단 노드/엣지 드롭다운 목록 — getGraphNodeLabel과 같은 번호 규칙을
+  // 쓰도록 그 함수를 그대로 재사용함(따로 STRUCTURE_NODE_LABEL만 가져다 쓰면 번호가 안 붙어
+  // 같은 종류 노드가 여러 개일 때 다시 구분이 안 되는 문제로 되돌아감)
   const lightNodeOptions = useMemo(
     () => [
-      ...structureNodes.map((n) => ({ id: n.id, label: STRUCTURE_NODE_LABEL[n.type] })),
+      ...structureNodes.map((n) => ({ id: n.id, label: getGraphNodeLabel(n.id) })),
       ...graphNodes.map((n) => ({ id: n.id, label: n.name })),
     ],
+    // getGraphNodeLabel은 structureNodes/graphNodes를 참조하는 클로저라 그 둘을 대신 의존성으로 둠
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [structureNodes, graphNodes],
   );
   // fromNodeId/toNodeId도 같이 내려줌 — 판단 노드에 실제로 연결된 엣지만 좌/우 후보로 걸러내는 데 씀
@@ -4190,8 +4350,72 @@ const FloorPlansDetailPage = () => {
       editForm.decisionNodeId !== (editingLight?.decisionNodeId ?? '') ||
       editForm.leftEdgeId !== (editingLight?.leftEdgeId ?? '') ||
       editForm.rightEdgeId !== (editingLight?.rightEdgeId ?? '') ||
-      editForm.cctvId !== (editingLight?.cctvId ?? '')
+      editForm.cctvId !== (editingLight?.cctvId ?? '') ||
+      // 위치 드래그도 완료를 눌러야 확정되므로, 옮긴 좌표가 스테이징돼 있으면 그것만으로도
+      // "바뀐 값이 있다"고 봄(devicePositions[id]는 handleStartEdit이 매 세션 시작마다 지움)
+      (!!editingItemId && editingItemId in devicePositions)
     : false;
+
+  // 캔버스에 비출 유도등 갈림길·좌우 통로 미리보기 — 추가 팝업이 열려있으면 그 값을, 유도등을
+  // 수정 중이면 수정 폼 값을 보여줌(둘 다 아니면 null이라 캔버스에 강조가 안 남음)
+  const lightPreviewSource =
+    nodeAddOpen && nodeAddType === 'light'
+      ? nodeAddLightFields
+      : editingPanelItem?.type === 'light'
+        ? editForm
+        : null;
+
+  // "캔버스에서 선택" — 드롭다운에 같은 이름 노드가 많아 고르기 혼란스럽다는 피드백으로,
+  // 도면에서 직접 클릭해 갈림길 위치·좌우 통로를 지정하는 대안 제공. 추가 팝업/수정 카드
+  // 중 어느 쪽이 지금 열려있는지에 따라 그쪽의 픽 모드만 캔버스에 반영함
+  const currentLightPickField =
+    nodeAddOpen && nodeAddType === 'light'
+      ? lightPickTarget?.source === 'add'
+        ? lightPickTarget.field
+        : null
+      : editingPanelItem?.type === 'light'
+        ? lightPickTarget?.source === 'edit'
+          ? lightPickTarget.field
+          : null
+        : null;
+
+  // 클릭 결과를 올바른 곳(추가 팝업 vs 수정 카드)에 반영하려면 시작한 소스를 같이 들고 있어야 함
+  const handleStartLightPick = (
+    source: 'add' | 'edit',
+    field: 'decisionNode' | 'leftEdge' | 'rightEdge',
+  ) => {
+    setLightPickTarget((prev) =>
+      prev?.source === source && prev.field === field ? null : { source, field },
+    );
+  };
+
+  // MockFloorMap3F가 픽 모드에서 유효한(연결된) 노드·엣지만 클릭 가능하게 걸러주므로, 여기서는
+  // 넘어온 id를 그대로 해당 대상의 값으로 반영하면 됨
+  const handleLightCanvasPick = (id: string) => {
+    if (!lightPickTarget) return;
+    const { source, field } = lightPickTarget;
+    if (source === 'add') {
+      setNodeAddLightFields((prev) =>
+        field === 'decisionNode'
+          ? { decisionNodeId: id, leftEdgeId: '', rightEdgeId: '' }
+          : field === 'leftEdge'
+            ? { ...prev, leftEdgeId: id }
+            : { ...prev, rightEdgeId: id },
+      );
+    } else {
+      setEditForm((prev) =>
+        field === 'decisionNode'
+          ? { ...prev, decisionNodeId: id, leftEdgeId: '', rightEdgeId: '' }
+          : field === 'leftEdge'
+            ? { ...prev, leftEdgeId: id }
+            : { ...prev, rightEdgeId: id },
+      );
+    }
+    setLightPickTarget(null);
+  };
+
+  const nodeAddLightPickField = lightPickTarget?.source === 'add' ? lightPickTarget.field : null;
+  const editLightPickField = lightPickTarget?.source === 'edit' ? lightPickTarget.field : null;
 
   const gridCellPxSize = useMemo(
     () => getGridCellPxSize(floorGridCells, canvasH),
@@ -4261,6 +4485,15 @@ const FloorPlansDetailPage = () => {
       rightEdgeId: light?.rightEdgeId ?? '',
       cctvId: light?.cctvId ?? '',
     });
+    // 이전에 드래그했다가 완료를 안 누르고 나간 세션의 스테이징 값이 남아있으면 이번에
+    // 새로 안 옮겨도 그 값이 그대로 보여서 위치가 잘못 표시될 수 있음 — 새 수정 세션은
+    // 항상 실제 저장된 좌표에서 다시 시작하게 정리함
+    setDevicePositions((prev) => {
+      if (!(item.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[item.id];
+      return next;
+    });
     setEditingItemId(item.id);
   };
 
@@ -4280,10 +4513,15 @@ const FloorPlansDetailPage = () => {
       );
     } else if (item.source === 'added') {
       const prevDevice = addedDevices.find((d) => d.id === item.id);
+      // 위치 드래그도 "완료"를 눌러야 확정되도록 함 — 이번 수정 세션에서 실제로 옮겼으면
+      // devicePositions에 그 좌표가 스테이징돼 있고(없으면 안 옮긴 것이므로 기존 좌표 그대로)
+      const stagedPos = devicePositions[item.id];
+      const finalX = stagedPos?.x ?? prevDevice?.x ?? 0;
+      const finalY = stagedPos?.y ?? prevDevice?.y ?? 0;
       setAddedDevices((prev) =>
-        prev.map((d) => (d.id === item.id ? { ...d, label: newLabel } : d)),
+        prev.map((d) => (d.id === item.id ? { ...d, label: newLabel, x: finalX, y: finalY } : d)),
       );
-      // 실패하면 방금 낙관적으로 바꾼 이름/구역을 원래대로 되돌림 — 안 그러면 저장 안 됐는데 화면엔 새 이름이 남음
+      // 실패하면 방금 낙관적으로 바꾼 이름·위치를 원래대로 되돌림 — 안 그러면 저장 안 됐는데 화면엔 새 값이 남음
       const rollback = () => {
         if (prevDevice)
           setAddedDevices((prev) => prev.map((d) => (d.id === item.id ? prevDevice : d)));
@@ -4292,8 +4530,8 @@ const FloorPlansDetailPage = () => {
         const prevLight = iotLights.find((l) => l.id === item.id);
         updateIoTLight(item.id, {
           name: newLabel,
-          x: prevDevice.x / 100,
-          y: prevDevice.y / 100,
+          x: finalX / 100,
+          y: finalY / 100,
         }).catch(() => {
           rollback();
           show({ title: '유도등 정보 수정에 실패했습니다.', variant: 'error' });
@@ -4331,7 +4569,7 @@ const FloorPlansDetailPage = () => {
             });
         }
       } else if (item.type === 'cctv' && prevDevice) {
-        updateCctv(item.id, { name: newLabel, x: prevDevice.x / 100, y: prevDevice.y / 100 })
+        updateCctv(item.id, { name: newLabel, x: finalX / 100, y: finalY / 100 })
           .then((updated) => {
             setRealCctvs((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
           })
@@ -4348,6 +4586,28 @@ const FloorPlansDetailPage = () => {
       });
     }
     setEditingItemId(null);
+    // 스테이징된 드래그 좌표는 이미 addedDevices에 커밋했으니 정리 — 다음 수정 세션은
+    // handleStartEdit이 다시 깨끗한 상태로 시작함
+    setDevicePositions((prev) => {
+      if (!(item.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[item.id];
+      return next;
+    });
+  };
+
+  // "취소" — 이름·가이던스 등 입력한 값은 그냥 버림. 위치도 저장 안 하고 나가면 렌더링
+  // 쪽에서 editingItemId가 이 항목이 아닐 때 devicePositions 오버레이를 무시하게 돼있어
+  // 자동으로 원래 좌표로 되돌아감(추가로 지워서 다음 수정 세션도 깨끗하게 시작하게 함)
+  const handleCancelEdit = (item: PanelItem) => {
+    if (editingCctvId === item.id) handleCancelEditCctvCells();
+    setEditingItemId(null);
+    setDevicePositions((prev) => {
+      if (!(item.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[item.id];
+      return next;
+    });
   };
 
   const handlePanelItemDelete = (item: PanelItem) => {
@@ -4616,6 +4876,10 @@ const FloorPlansDetailPage = () => {
                 lightNodeOptions={lightNodeOptions}
                 lightEdgeOptions={lightEdgeOptions}
                 lightCctvOptions={lightCctvOptions}
+                lightFields={nodeAddLightFields}
+                onLightFieldsChange={setNodeAddLightFields}
+                lightPickField={nodeAddLightPickField}
+                onStartLightPick={(field) => handleStartLightPick('add', field)}
               />
             )}
 
@@ -4713,6 +4977,11 @@ const FloorPlansDetailPage = () => {
                 selectedGridCellIds={selectedGridCellIds}
                 gridCellPxSize={gridCellPxSize}
                 onGridCellToggle={handleGridCellToggle}
+                lightPreviewNodeId={lightPreviewSource?.decisionNodeId}
+                lightPreviewLeftEdgeId={lightPreviewSource?.leftEdgeId}
+                lightPreviewRightEdgeId={lightPreviewSource?.rightEdgeId}
+                lightPickField={currentLightPickField}
+                onLightPick={handleLightCanvasPick}
                 stagedCameraPosition={nodeStagedPosition}
                 onSelectDevice={(d) => {
                   const isSame = selectedItem?.kind === 'device' && selectedItem.data.id === d.id;
@@ -4731,7 +5000,6 @@ const FloorPlansDetailPage = () => {
                 }}
                 devicePositions={devicePositions}
                 onDeviceMoved={handleDeviceMoved}
-                onDeviceMoveEnd={handleDeviceMoveEnd}
                 addedDevices={addedDevices}
                 onUpload={() => setUploadModalOpen(true)}
               />
@@ -4854,13 +5122,15 @@ const FloorPlansDetailPage = () => {
                       onSelect={handlePanelItemSelect}
                       onStartEdit={handleStartEdit}
                       onSaveEdit={handleSaveEdit}
+                      onCancelEdit={handleCancelEdit}
                       onDelete={handlePanelItemDelete}
                       onToggleEnabled={handleToggleEnabled}
                       onEditCctvCells={handleStartEditCctvCells}
-                      onLightDirectionChange={handleLightDirectionChange}
                       lightNodeOptions={lightNodeOptions}
                       lightEdgeOptions={lightEdgeOptions}
                       lightCctvOptions={lightCctvOptions}
+                      lightPickField={editingItemId === item.id ? editLightPickField : null}
+                      onStartLightPick={(field) => handleStartLightPick('edit', field)}
                     />
                   ))}
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -129,12 +129,14 @@ type PanelItem = {
   cctvName?: string;
 };
 
-// 장비 카드의 "수정" 편집 폼 — CCTV는 label/zone만 쓰고, 유도등은 설정 모달에 있던
+// 장비 카드의 "수정" 편집 폼 — CCTV는 label만 쓰고, 유도등은 설정 모달에 있던
 // 가이던스·담당 CCTV까지 전부 이 폼으로 흡수함(모달 없이 카드 안에서 편집). Pi 엔드포인트는
-// 스웨거상 "참고용 메타데이터일 뿐 실제 명령 전달 경로에는 안 쓰인다"고 명시되어 있어 뺐음
+// 스웨거상 "참고용 메타데이터일 뿐 실제 명령 전달 경로에는 안 쓰인다"고 명시되어 있어 뺐음.
+// "설치 위치"(zone)는 백엔드에 저장 필드가 없어(요청 스키마에 name/x/y뿐) 여기서 편집해도
+// 저장 API로 안 나가고, 새로고침하면 CCTV는 감시영역 문구로·유도등은 고정 문구로 다시
+// 덮어써지던 문제가 있어 편집 항목에서 뺌 — 카드엔 항상 읽기 전용으로만 보여줌
 interface DeviceEditForm {
   label: string;
-  zone: string;
   decisionNodeId: string;
   leftEdgeId: string;
   rightEdgeId: string;
@@ -143,7 +145,6 @@ interface DeviceEditForm {
 
 const EMPTY_DEVICE_EDIT_FORM: DeviceEditForm = {
   label: '',
-  zone: '',
   decisionNodeId: '',
   leftEdgeId: '',
   rightEdgeId: '',
@@ -1435,6 +1436,7 @@ const DeviceCard = ({
   selected,
   editing,
   editForm,
+  hasChanges,
   onEditFormChange,
   onSelect,
   onStartEdit,
@@ -1451,6 +1453,8 @@ const DeviceCard = ({
   selected: boolean;
   editing: boolean;
   editForm: DeviceEditForm;
+  // 폼이 원본과 달라졌는지 — "완료" 버튼을 실제로 바뀐 게 있을 때만 눌리게 하는 데 씀
+  hasChanges: boolean;
   onEditFormChange: (form: DeviceEditForm) => void;
   onSelect: (item: PanelItem) => void;
   onStartEdit: (item: PanelItem) => void;
@@ -1551,29 +1555,17 @@ const DeviceCard = ({
       </div>
       <div className={styles.deviceCardRow}>
         <span className={styles.deviceCardKey}>설치 위치</span>
-        {editing && item.type !== 'light' && (
-          <input
-            className={styles.deviceCardValueInput}
-            aria-label="설치 위치"
-            value={editForm.zone}
-            onChange={(e) => onEditFormChange({ ...editForm, zone: e.target.value })}
-            onClick={(e) => e.stopPropagation()}
-          />
-        )}
-        {!editing && <span className={styles.deviceCardValue}>{item.zone}</span>}
+        <span
+          className={styles.deviceCardValue}
+          title={
+            item.type === 'cctv'
+              ? '감시 영역에서 자동으로 계산돼요'
+              : '저장되는 값이 아니라 편집할 수 없어요'
+          }
+        >
+          {item.zone}
+        </span>
       </div>
-      {/* 유도등은 필드가 많아서(설치 위치·담당 CCTV·가이던스) 값 칸 크기가 텍스트 입력·
-          드롭다운마다 제각각으로 보이지 않도록, 수정 중엔 전부 "라벨 위 · 값 아래(폭 전체)"
-          한 가지 모양으로 통일함 */}
-      {editing && item.type === 'light' && (
-        <input
-          className={styles.lightFieldFull}
-          value={editForm.zone}
-          onChange={(e) => onEditFormChange({ ...editForm, zone: e.target.value })}
-          onClick={(e) => e.stopPropagation()}
-          placeholder="예: 3층 앞 복도"
-        />
-      )}
       {item.type === 'light' && (
         <>
           <div className={styles.deviceCardRow}>
@@ -1776,6 +1768,8 @@ const DeviceCard = ({
           <button
             type="button"
             className={styles.deviceCardDoneBtn}
+            disabled={!hasChanges}
+            title={hasChanges ? undefined : '변경된 내용이 없어요'}
             onClick={(e) => {
               e.stopPropagation();
               onSaveEdit(item);
@@ -3757,6 +3751,21 @@ const FloorPlansDetailPage = () => {
     [realCctvs],
   );
 
+  // 장비 카드 "완료" 버튼 — 실제로 바뀐 값이 있을 때만 눌리게. handleSaveEdit의
+  // guidanceChanged 판정과 같은 기준(원본 값과 폼 값 비교)을 여기서도 씀
+  const editingPanelItem = editingItemId
+    ? allPanelItems.find((item) => item.id === editingItemId)
+    : undefined;
+  const editingLight =
+    editingPanelItem?.type === 'light' ? iotLights.find((l) => l.id === editingItemId) : undefined;
+  const isDeviceEditFormDirty = editingPanelItem
+    ? editForm.label !== editingPanelItem.label ||
+      editForm.decisionNodeId !== (editingLight?.decisionNodeId ?? '') ||
+      editForm.leftEdgeId !== (editingLight?.leftEdgeId ?? '') ||
+      editForm.rightEdgeId !== (editingLight?.rightEdgeId ?? '') ||
+      editForm.cctvId !== (editingLight?.cctvId ?? '')
+    : false;
+
   const gridCellPxSize = useMemo(
     () => getGridCellPxSize(floorGridCells, canvasH),
     [floorGridCells, canvasH],
@@ -3820,7 +3829,6 @@ const FloorPlansDetailPage = () => {
     const light = item.type === 'light' ? iotLights.find((l) => l.id === item.id) : undefined;
     setEditForm({
       label: item.label,
-      zone: item.zone,
       decisionNodeId: light?.decisionNodeId ?? '',
       leftEdgeId: light?.leftEdgeId ?? '',
       rightEdgeId: light?.rightEdgeId ?? '',
@@ -3839,16 +3847,14 @@ const FloorPlansDetailPage = () => {
         prev
           ? {
               ...prev,
-              devices: prev.devices.map((d) =>
-                d.id === item.id ? { ...d, label: newLabel, zone: editForm.zone } : d,
-              ),
+              devices: prev.devices.map((d) => (d.id === item.id ? { ...d, label: newLabel } : d)),
             }
           : prev,
       );
     } else if (item.source === 'added') {
       const prevDevice = addedDevices.find((d) => d.id === item.id);
       setAddedDevices((prev) =>
-        prev.map((d) => (d.id === item.id ? { ...d, label: newLabel, zone: editForm.zone } : d)),
+        prev.map((d) => (d.id === item.id ? { ...d, label: newLabel } : d)),
       );
       // 실패하면 방금 낙관적으로 바꾼 이름/구역을 원래대로 되돌림 — 안 그러면 저장 안 됐는데 화면엔 새 이름이 남음
       const rollback = () => {
@@ -3911,7 +3917,7 @@ const FloorPlansDetailPage = () => {
     if (selectedItem?.kind === 'device' && selectedItem.data.id === item.id) {
       setSelectedItem({
         kind: 'device',
-        data: { ...selectedItem.data, label: newLabel, zone: editForm.zone },
+        data: { ...selectedItem.data, label: newLabel },
       });
     }
     setEditingItemId(null);
@@ -4440,6 +4446,7 @@ const FloorPlansDetailPage = () => {
                       selected={isPanelItemSelected(item)}
                       editing={editingItemId === item.id}
                       editForm={editForm}
+                      hasChanges={isDeviceEditFormDirty}
                       onEditFormChange={setEditForm}
                       onSelect={handlePanelItemSelect}
                       onStartEdit={handleStartEdit}

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -1301,19 +1301,23 @@ const EdgeAddPopup = ({
   // 두 노드 좌표 + 그리드 배율로 계산한 추정 거리(m). 없으면 수동 입력
   suggestedDistance: number | null;
   onCancel: () => void;
+  // distance는 m 단위(백엔드 저장 단위) — 입력창은 cm라 여기서 넘기기 전에 변환함
   onSave: (distance: number, bidirectional: boolean) => void;
 }) => {
-  const [distance, setDistance] = useState(
-    suggestedDistance !== null ? String(suggestedDistance) : '',
+  // 실내 노드 간 거리는 1m 미만도 흔해서 cm로 입력받음(정수로 편하게 입력, 저장은 m로 환산)
+  const [distanceCm, setDistanceCm] = useState(
+    suggestedDistance !== null ? String(Math.round(suggestedDistance * 100)) : '',
   );
   const [bidirectional, setBidirectional] = useState(true);
 
   const handleDistanceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const raw = e.target.value;
-    if (raw === '' || /^\d+(\.\d+)?$/.test(raw)) setDistance(raw);
+    // 완성된 숫자만 허용하면 "495"를 지우다 "4"처럼 될 때까지 중간 상태(끝자리 삭제 등)가
+    // 거부돼 편집이 막히던 문제 — 타이핑 도중 상태(끝에 점만 있거나 소수부가 빈 경우)도 허용
+    if (raw === '' || /^\d*\.?\d*$/.test(raw)) setDistanceCm(raw);
   };
 
-  const isValid = Number(distance) > 0;
+  const isValid = Number(distanceCm) > 0;
 
   return (
     <div ref={containerRef} className={styles.nodeAddPopup} onClick={(e) => e.stopPropagation()}>
@@ -1325,14 +1329,14 @@ const EdgeAddPopup = ({
       </span>
 
       <div className={styles.nodeAddField}>
-        <span className={styles.nodeAddLabel}>거리(m)</span>
+        <span className={styles.nodeAddLabel}>거리(cm)</span>
         <input
           className={styles.nodeAddInput}
           type="text"
           inputMode="decimal"
-          value={distance}
+          value={distanceCm}
           onChange={handleDistanceChange}
-          placeholder="3.5"
+          placeholder="350"
         />
         {suggestedDistance !== null && (
           <span className={styles.nodeAddSubHint}>좌표 기준 추정값 · 필요하면 수정하세요</span>
@@ -1356,7 +1360,7 @@ const EdgeAddPopup = ({
           type="button"
           className={styles.nodeAddSubmitBtn}
           disabled={!isValid}
-          onClick={() => onSave(Number(distance), bidirectional)}
+          onClick={() => onSave(Number(distanceCm) / 100, bidirectional)}
         >
           추가
         </button>
@@ -3258,7 +3262,12 @@ const FloorPlansDetailPage = () => {
       .then((newEdge) => {
         setGraphEdges((prev) => [...prev, newEdge]);
       })
-      .catch(() => {})
+      .catch((error: unknown) => {
+        // 실패해도 조용히 넘어가던 자리라 "노드가 너무 가까우면 연결이 안 되는" 것처럼 보이던
+        // 문제의 원인을 알 수 없었음 — 서버 메시지를 그대로 보여줌
+        const { message } = extractServerError(error);
+        show({ title: message || '엣지 연결에 실패했습니다.', variant: 'error' });
+      })
       .finally(() => {
         // 모드는 유지 — 연달아 엣지를 그리다가 "완료"로 끝낸다
         setEdgeDraftFromId(null);

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -152,6 +152,15 @@ const EMPTY_DEVICE_EDIT_FORM: DeviceEditForm = {
   cctvId: '',
 };
 
+// 유도등 추가 팝업에서 같이 받는 담당 CCTV·가이던스 값 — DeviceEditForm과 필드 구성은 같지만
+// label이 없고(장치 ID 입력이 대신함) 전부 빈 문자열이면 "아직 안 정함"으로 취급해 생략 가능함
+type LightAddFields = {
+  cctvId: string;
+  decisionNodeId: string;
+  leftEdgeId: string;
+  rightEdgeId: string;
+};
+
 // CCTV 등록·시야 재선택·수정 세 곳에서 카드에 보여줄 "모니터링 N칸 · M㎡" 문구를 각자 다시
 // 조립하면 한 줄이 100자를 넘기기 쉽고 표현도 어긋나기 쉬워 하나로 합침
 const formatMonitoredZone = (cctv: Pick<Cctv, 'monitoredGridCellCount' | 'monitoredAreaM2'>) =>
@@ -1143,6 +1152,9 @@ const NodeAddPopup = ({
   onBack,
   onSubmitEntry,
   onFinalize,
+  lightNodeOptions,
+  lightEdgeOptions,
+  lightCctvOptions,
 }: {
   containerRef: React.RefObject<HTMLDivElement>;
   type: PlacingDeviceType;
@@ -1152,14 +1164,30 @@ const NodeAddPopup = ({
   selectedCellCount: number;
   onCancel: () => void;
   onBack: () => void;
-  onSubmitEntry: (type: PlacingDeviceType, deviceId: string, location: string) => void;
+  onSubmitEntry: (
+    type: PlacingDeviceType,
+    deviceId: string,
+    location: string,
+    lightFields: LightAddFields,
+  ) => void;
   onFinalize: (deviceId: string, location: string) => void;
+  lightNodeOptions: { id: string; label: string }[];
+  lightEdgeOptions: { id: string; label: string; fromNodeId: string; toNodeId: string }[];
+  lightCctvOptions: { id: string; label: string }[];
 }) => {
   const [deviceId, setDeviceId] = useState('');
   const [location, setLocation] = useState('');
+  // 유도등 추가 시 담당 CCTV·가이던스도 같이 받음 — 수정 카드(DeviceCard)와 채워야 하는 값이
+  // 서로 달라 등록 직후엔 "훈련 준비"에 필요한 guidanceConfigured/cctvId가 항상 비어있던 문제.
+  // 도면에 아직 판단 노드·엣지·CCTV가 없을 수도 있어 필수로 막지는 않음(비워두면 등록 후 카드에서 마저 채움)
+  const [lightCctvId, setLightCctvId] = useState('');
+  const [lightDecisionNodeId, setLightDecisionNodeId] = useState('');
+  const [lightLeftEdgeId, setLightLeftEdgeId] = useState('');
+  const [lightRightEdgeId, setLightRightEdgeId] = useState('');
 
   const isStructureNode = isStructureNodeType(type);
   const isCctv = type === 'cctv';
+  const isLight = type === 'light';
   const totalSteps = isCctv ? 2 : 1;
   const stepNumber = stage === 'entry' ? 1 : totalSteps;
 
@@ -1253,6 +1281,83 @@ const NodeAddPopup = ({
               placeholder="3층 · 복도 동측"
             />
           </div>
+
+          {/* 담당 CCTV·가이던스(판단 노드/좌우 엣지) — 장비 카드 수정에서만 채울 수 있던 값이라
+              등록 직후엔 항상 비어있던 문제(훈련 준비의 guidanceConfigured가 안 채워짐). 도면에
+              아직 판단 노드·엣지·CCTV가 없을 수도 있어 필수는 아니고, 비워두면 등록 후 카드에서
+              마저 채울 수 있음 */}
+          {isLight && (
+            <>
+              <div className={styles.nodeAddField}>
+                <span className={styles.nodeAddLabel}>담당 CCTV</span>
+                <Dropdown
+                  shape="rounded"
+                  fullWidth
+                  ariaLabel="담당 CCTV"
+                  options={lightCctvOptions.map((c) => ({ value: c.id, label: c.label }))}
+                  value={lightCctvId}
+                  onChange={setLightCctvId}
+                  placeholder="미지정"
+                />
+              </div>
+              <div className={styles.nodeAddField}>
+                <span className={styles.nodeAddLabel}>판단 노드</span>
+                <Dropdown
+                  shape="rounded"
+                  fullWidth
+                  ariaLabel="판단 노드"
+                  options={lightNodeOptions.map((n) => ({ value: n.id, label: n.label }))}
+                  value={lightDecisionNodeId}
+                  onChange={(v) => {
+                    setLightDecisionNodeId(v);
+                    setLightLeftEdgeId('');
+                    setLightRightEdgeId('');
+                  }}
+                  placeholder="판단 노드 선택"
+                />
+              </div>
+              <div className={styles.nodeAddField}>
+                <span className={styles.nodeAddLabel}>왼쪽 가이던스 엣지</span>
+                <Dropdown
+                  shape="rounded"
+                  fullWidth
+                  ariaLabel="왼쪽 가이던스 엣지"
+                  disabled={!lightDecisionNodeId}
+                  options={lightEdgeOptions
+                    .filter(
+                      (e) =>
+                        (e.fromNodeId === lightDecisionNodeId ||
+                          e.toNodeId === lightDecisionNodeId) &&
+                        e.id !== lightRightEdgeId,
+                    )
+                    .map((e) => ({ value: e.id, label: e.label }))}
+                  value={lightLeftEdgeId}
+                  onChange={setLightLeftEdgeId}
+                  placeholder={lightDecisionNodeId ? '왼쪽 엣지 선택' : '판단 노드를 먼저 선택'}
+                />
+              </div>
+              <div className={styles.nodeAddField}>
+                <span className={styles.nodeAddLabel}>오른쪽 가이던스 엣지</span>
+                <Dropdown
+                  shape="rounded"
+                  fullWidth
+                  ariaLabel="오른쪽 가이던스 엣지"
+                  disabled={!lightDecisionNodeId}
+                  options={lightEdgeOptions
+                    .filter(
+                      (e) =>
+                        (e.fromNodeId === lightDecisionNodeId ||
+                          e.toNodeId === lightDecisionNodeId) &&
+                        e.id !== lightLeftEdgeId,
+                    )
+                    .map((e) => ({ value: e.id, label: e.label }))}
+                  value={lightRightEdgeId}
+                  onChange={setLightRightEdgeId}
+                  placeholder={lightDecisionNodeId ? '오른쪽 엣지 선택' : '판단 노드를 먼저 선택'}
+                />
+              </div>
+            </>
+          )}
         </>
       )}
 
@@ -1264,7 +1369,14 @@ const NodeAddPopup = ({
           type="button"
           className={styles.nodeAddSubmitBtn}
           disabled={!canSubmit}
-          onClick={() => onSubmitEntry(type, deviceId.trim(), location.trim())}
+          onClick={() =>
+            onSubmitEntry(type, deviceId.trim(), location.trim(), {
+              cctvId: lightCctvId,
+              decisionNodeId: lightDecisionNodeId,
+              leftEdgeId: lightLeftEdgeId,
+              rightEdgeId: lightRightEdgeId,
+            })
+          }
         >
           {isCctv ? '다음' : '추가'}
         </button>
@@ -2880,6 +2992,7 @@ const FloorPlansDetailPage = () => {
     deviceId: string,
     location: string,
     position: { x: number; y: number },
+    lightFields: LightAddFields,
   ) => {
     const cfg = DEVICE_PLACE_CONFIG[type];
 
@@ -2946,6 +3059,31 @@ const FloorPlansDetailPage = () => {
                 zone: location || '사용자 등록',
               },
             ]);
+
+            // 담당 CCTV·가이던스는 handleSaveEdit(카드 수정)과 같은 방식으로, 값이 채워졌을
+            // 때만 등록 직후 이어서 저장함 — 등록 시점에 판단 노드·엣지가 아직 없으면
+            // 비워둔 채로 넘어가고 나중에 카드에서 채워도 됨
+            const { decisionNodeId, leftEdgeId, rightEdgeId, cctvId } = lightFields;
+            if (decisionNodeId && leftEdgeId && rightEdgeId) {
+              configureLightGuidance(newLight.id, { decisionNodeId, leftEdgeId, rightEdgeId })
+                .then((updated) =>
+                  setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
+                )
+                .catch((error: unknown) => {
+                  const { message } = extractServerError(error);
+                  show({ title: message || '가이던스 저장에 실패했습니다.', variant: 'error' });
+                });
+            }
+            if (cctvId) {
+              assignLightCctv(newLight.id, cctvId)
+                .then((updated) =>
+                  setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
+                )
+                .catch((error: unknown) => {
+                  const { message } = extractServerError(error);
+                  show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
+                });
+            }
           })
           .catch(() => {
             show({ title: '유도등 등록에 실패했습니다. 다시 시도해주세요.', variant: 'error' });
@@ -2986,7 +3124,12 @@ const FloorPlansDetailPage = () => {
   // 입력 단계 제출 — CCTV는 서버가 배율(cellSizeMeter) 없이는 등록을 거부(CCTV006)하는데
   // 배율 조회 API가 없어서, 아는 값이 있으면 조용히 다시 적용하고 정말 모를 때만 사용자에게 묻는다.
   // (드래그를 다 끝낸 뒤에 실패하지 않도록 시야 선택 단계로 넘어가기 전에 처리)
-  const handleSubmitNodeEntry = (type: PlacingDeviceType, deviceId: string, location: string) => {
+  const handleSubmitNodeEntry = (
+    type: PlacingDeviceType,
+    deviceId: string,
+    location: string,
+    lightFields: LightAddFields,
+  ) => {
     if (!nodeStagedPosition) return;
     if (type === 'cctv') {
       // ensureFloorGridCells 호출 전 상태를 기억해둠 — 이미 이번 세션에서 그리드를 확인했다면
@@ -3035,7 +3178,7 @@ const FloorPlansDetailPage = () => {
       });
       return;
     }
-    finalizeNodePlacement(type, deviceId, location, nodeStagedPosition);
+    finalizeNodePlacement(type, deviceId, location, nodeStagedPosition, lightFields);
   };
 
   // 그리드설정/시야구역 단계에서 뒤로 — 입력 단계로 돌아가되 이미 지정한 위치는 유지
@@ -4422,6 +4565,9 @@ const FloorPlansDetailPage = () => {
                 onBack={handleNodeAddBack}
                 onSubmitEntry={handleSubmitNodeEntry}
                 onFinalize={handleFinalizeFov}
+                lightNodeOptions={lightNodeOptions}
+                lightEdgeOptions={lightEdgeOptions}
+                lightCctvOptions={lightCctvOptions}
               />
             )}
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -1334,11 +1334,11 @@ const NodeAddPopup = ({
                 />
               </div>
               <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>왼쪽 가이던스 엣지</span>
+                <span className={styles.nodeAddLabel}>왼쪽 경로 엣지</span>
                 <Dropdown
                   shape="rounded"
                   fullWidth
-                  ariaLabel="왼쪽 가이던스 엣지"
+                  ariaLabel="왼쪽 경로 엣지"
                   disabled={!lightDecisionNodeId}
                   options={lightEdgeOptions
                     .filter(
@@ -1354,11 +1354,11 @@ const NodeAddPopup = ({
                 />
               </div>
               <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>오른쪽 가이던스 엣지</span>
+                <span className={styles.nodeAddLabel}>오른쪽 경로 엣지</span>
                 <Dropdown
                   shape="rounded"
                   fullWidth
-                  ariaLabel="오른쪽 가이던스 엣지"
+                  ariaLabel="오른쪽 경로 엣지"
                   disabled={!lightDecisionNodeId}
                   options={lightEdgeOptions
                     .filter(
@@ -1896,7 +1896,7 @@ const DeviceCard = ({
             className={styles.deviceCardRow}
             title="화재 시 이 유도등이 갈림길(판단 노드)에서 왼쪽/오른쪽 중 어느 통로로 사람들을 안내할지 정해요"
           >
-            <span className={styles.deviceCardKey}>가이던스 · 방향</span>
+            <span className={styles.deviceCardKey}>경로 · 방향</span>
             {editing ? (
               <button
                 type="button"
@@ -1942,7 +1942,7 @@ const DeviceCard = ({
               <Dropdown
                 shape="rounded"
                 fullWidth
-                ariaLabel="왼쪽 가이던스 엣지"
+                ariaLabel="왼쪽 경로 엣지"
                 disabled={!editForm.decisionNodeId}
                 options={lightEdgeOptions
                   .filter(
@@ -1959,7 +1959,7 @@ const DeviceCard = ({
               <Dropdown
                 shape="rounded"
                 fullWidth
-                ariaLabel="오른쪽 가이던스 엣지"
+                ariaLabel="오른쪽 경로 엣지"
                 disabled={!editForm.decisionNodeId}
                 options={lightEdgeOptions
                   .filter(
@@ -3104,7 +3104,7 @@ const FloorPlansDetailPage = () => {
                 )
                 .catch((error: unknown) => {
                   const { message } = extractServerError(error);
-                  show({ title: message || '가이던스 저장에 실패했습니다.', variant: 'error' });
+                  show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
                 });
             }
             if (cctvId) {
@@ -4301,7 +4301,7 @@ const FloorPlansDetailPage = () => {
             )
             .catch((error: unknown) => {
               const { message } = extractServerError(error);
-              show({ title: message || '가이던스 저장에 실패했습니다.', variant: 'error' });
+              show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
             });
         }
 

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -76,6 +76,7 @@ import {
   getUserZoneDetail,
 } from './api/userZoneApi';
 import ReadinessChecklist from './components/ReadinessChecklist';
+import { DEVICE_COLOR } from './constants/deviceColors';
 import * as styles from './FloorPlansDetailPage.css';
 import EquipmentDeleteConfirmModal from './modals/EquipmentDeleteConfirmModal';
 import FloorUploadModal from './modals/FloorUploadModal';
@@ -199,14 +200,13 @@ type PlacingDeviceType = 'cctv' | 'light' | 'door' | 'stair' | 'hallway' | 'star
 type PlacingEquipmentType = Exclude<PlacingDeviceType, 'door' | 'stair' | 'hallway' | 'start'>;
 
 const DEVICE_PLACE_CONFIG: Record<PlacingDeviceType, { label: string; color: string }> = {
-  cctv: { label: 'CCTV', color: '#8b5cf6' },
-  // 계단(stair, #f97316)과 같은 주황 계열이라 구분이 안 된다는 피드백 — 노란색으로 분리
-  light: { label: '유도등', color: '#eab308' },
-  door: { label: '문 · 출입구', color: '#2563eb' },
-  stair: { label: '계단', color: '#f97316' },
-  hallway: { label: '복도', color: '#0891b2' },
+  cctv: { label: 'CCTV', color: DEVICE_COLOR.cctv },
+  light: { label: '유도등', color: DEVICE_COLOR.light },
+  door: { label: '문 · 출입구', color: DEVICE_COLOR.door },
+  stair: { label: '계단', color: DEVICE_COLOR.stair },
+  hallway: { label: '복도', color: DEVICE_COLOR.hallway },
   // "시작 노드"가 아니라 "시작 후보"로 부름 — 실제 훈련 시작점 확정은 시나리오설정에서 함
-  start: { label: '시작 후보', color: '#db2777' },
+  start: { label: '시작 후보', color: DEVICE_COLOR.start },
 };
 
 type AddedDevice = {
@@ -274,10 +274,10 @@ const API_TYPE_TO_STRUCTURE: Partial<Record<MapNodeType, StructureNodeType>> = {
 };
 
 const STRUCTURE_NODE_COLOR: Record<StructureNodeType, string> = {
-  door: '#2563eb',
-  stair: '#f97316',
-  hallway: '#0891b2',
-  start: '#db2777',
+  door: DEVICE_COLOR.door,
+  stair: DEVICE_COLOR.stair,
+  hallway: DEVICE_COLOR.hallway,
+  start: DEVICE_COLOR.start,
 };
 
 // 우측 패널 구조 노드 카드의 점 색상 클래스 — 위 색상표를 그대로 벡터-엑스트랙트 클래스로 옮긴 것
@@ -1477,7 +1477,14 @@ const EdgeChainReviewPopup = ({
   }[];
   onBack: () => void;
   onSubmit: (
-    rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[],
+    rows: {
+      fromId: string;
+      toId: string;
+      fromLabel: string;
+      toLabel: string;
+      distanceM: number;
+      bidirectional: boolean;
+    }[],
   ) => void;
 }) => {
   // 실내 노드 간 거리는 1m 미만도 흔해서 cm로 입력받음(정수로 편하게 입력, 저장은 m로 환산)
@@ -1500,12 +1507,21 @@ const EdgeChainReviewPopup = ({
     newSegmentCount > 0 && segments.every((s, i) => s.alreadyExists || Number(distancesCm[i]) > 0);
 
   const handleSubmit = () => {
-    const rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[] = [];
+    const rows: {
+      fromId: string;
+      toId: string;
+      fromLabel: string;
+      toLabel: string;
+      distanceM: number;
+      bidirectional: boolean;
+    }[] = [];
     segments.forEach((s, i) => {
       if (s.alreadyExists) return;
       rows.push({
         fromId: s.fromId,
         toId: s.toId,
+        fromLabel: s.fromLabel,
+        toLabel: s.toLabel,
         distanceM: Number(distancesCm[i]) / 100,
         bidirectional,
       });
@@ -2641,17 +2657,19 @@ const FloorPlansDetailPage = () => {
     };
   }, [floorId]);
 
-  // 층 그리드 셀 조회 — CCTV 시야구역 선택에 사용
+  // 층 그리드 셀 조회 — CCTV 시야구역 선택에 사용.
+  // 층을 빠르게 옮기거나 화면을 벗어나면(언마운트) 응답을 무시하는 것뿐 아니라 실제로 요청도
+  // 중단해야, 배율이 작아 페이지가 많은 층에서 안 쓸 응답까지 끝까지 받아오는 낭비가 없음
   useEffect(() => {
     if (!floorId) return;
-    let cancelled = false;
-    getFloorGridCells(floorId)
+    const controller = new AbortController();
+    getFloorGridCells(floorId, controller.signal)
       .then((cells) => {
-        if (!cancelled) setFloorGridCells(cells);
+        setFloorGridCells(cells);
       })
       .catch(() => {});
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [floorId]);
 
@@ -3577,7 +3595,14 @@ const FloorPlansDetailPage = () => {
   // 검토 화면에서 확정한 구간들을 한 번에 생성 — 일부만 실패해도 성공한 구간은 반영하고
   // 실패한 개수·사유만 토스트로 알림(하나 실패했다고 나머지까지 날아가면 안 됨)
   const handleSubmitEdgeChain = (
-    rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[],
+    rows: {
+      fromId: string;
+      toId: string;
+      fromLabel: string;
+      toLabel: string;
+      distanceM: number;
+      bidirectional: boolean;
+    }[],
   ) => {
     Promise.allSettled(
       rows.map((row) =>
@@ -3590,13 +3615,15 @@ const FloorPlansDetailPage = () => {
       ),
     ).then((results) => {
       const succeeded: MapEdge[] = [];
-      let failedCount = 0;
+      // 실패한 구간의 라벨을 같이 모아둠 — 전체 실패 개수만 알려주면 어느 구간이 안 됐는지
+      // 몰라서 성공한 구간까지 처음부터 다시 골라야 했던 문제
+      const failedLabels: string[] = [];
       let firstErrorMessage: string | undefined;
-      results.forEach((result) => {
+      results.forEach((result, i) => {
         if (result.status === 'fulfilled') {
           succeeded.push(result.value);
         } else {
-          failedCount += 1;
+          failedLabels.push(`${rows[i].fromLabel} → ${rows[i].toLabel}`);
           firstErrorMessage ??= extractApiError(result.reason).message;
         }
       });
@@ -3604,11 +3631,12 @@ const FloorPlansDetailPage = () => {
         setGraphEdges((prev) => [...prev, ...succeeded]);
         show({ title: `${succeeded.length}개 구간이 연결되었습니다.`, variant: 'success' });
       }
-      if (failedCount > 0) {
+      if (failedLabels.length > 0) {
         show({
-          title: `${failedCount}개 구간 연결에 실패했습니다.${
+          title: `${failedLabels.length}개 구간 연결에 실패했습니다.${
             firstErrorMessage ? ` (${firstErrorMessage})` : ''
           }`,
+          description: failedLabels.join(', '),
           variant: 'error',
         });
       }
@@ -4723,6 +4751,7 @@ const FloorPlansDetailPage = () => {
                 className={styles.zoomButton}
                 onClick={() => setZoom((v) => Math.max(50, v - 10))}
                 disabled={zoom <= 50}
+                aria-label="축소"
               >
                 −
               </button>
@@ -4739,6 +4768,7 @@ const FloorPlansDetailPage = () => {
                 className={styles.zoomButton}
                 onClick={() => setZoom((v) => Math.min(200, v + 10))}
                 disabled={zoom >= 200}
+                aria-label="확대"
               >
                 +
               </button>

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -5,7 +5,7 @@ import { isAxiosError } from 'axios';
 import clsx from 'clsx';
 import { useNavigate, useParams } from 'react-router';
 
-import { ApiError } from '@apis/errors/apiError';
+import { extractApiError } from '@apis/errors/apiError';
 import { floorQueryKeys } from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
@@ -93,19 +93,6 @@ import type { FloorGridCell } from './api/floorGridApi';
 import type { IoTLight } from './api/iotLightsApi';
 import type { MapEdge, MapNode, MapNodeType } from './api/mapGraphApi';
 import type { DeviceMarker, DeviceType, Floor, FloorBuilding } from './types/floorPlans';
-
-// 서버 에러 메시지 추출 — 200+isSuccess:false는 ApiError로, HTTP 4xx는 AxiosError로 서로 다르게
-// 올라오므로 한 곳에서 통일해서 꺼냄
-const extractServerError = (error: unknown): { code: string; message: string } => {
-  const responseData = isAxiosError(error) ? error.response?.data : undefined;
-  const body =
-    responseData && typeof responseData === 'object'
-      ? (responseData as { code?: unknown; message?: unknown })
-      : undefined;
-  const code = error instanceof ApiError ? error.code : String(body?.code ?? '');
-  const message = error instanceof ApiError ? error.message : String(body?.message ?? '');
-  return { code, message };
-};
 
 type SelectedItem = { kind: 'device'; data: DeviceMarker };
 
@@ -2876,7 +2863,7 @@ const FloorPlansDetailPage = () => {
     changeLightDirection(item.id, direction)
       .then(() => show({ title: '유도등 방향을 변경했습니다.', variant: 'success' }))
       .catch((error: unknown) => {
-        const { message } = extractServerError(error);
+        const { message } = extractApiError(error);
         show({ title: message || '유도등 방향 변경에 실패했습니다.', variant: 'error' });
       });
   };
@@ -3055,7 +3042,7 @@ const FloorPlansDetailPage = () => {
           .catch((error: unknown) => {
             // 지금까지 문/계단/복도가 실패한 적이 없어서 안 드러났을 뿐, 실패해도 조용히
             // 무시되던 자리라 원인을 알 수 있게 서버 메시지를 그대로 보여줌
-            const { code: serverCode, message: serverMessage } = extractServerError(error);
+            const { code: serverCode, message: serverMessage } = extractApiError(error);
             if (import.meta.env.DEV) {
               console.error(`[${cfg.label} 노드 추가 실패]`, serverCode, error);
             }
@@ -3103,7 +3090,7 @@ const FloorPlansDetailPage = () => {
                   setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
                 )
                 .catch((error: unknown) => {
-                  const { message } = extractServerError(error);
+                  const { message } = extractApiError(error);
                   show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
                 });
             }
@@ -3113,7 +3100,7 @@ const FloorPlansDetailPage = () => {
                   setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
                 )
                 .catch((error: unknown) => {
-                  const { message } = extractServerError(error);
+                  const { message } = extractApiError(error);
                   show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
                 });
             }
@@ -3328,7 +3315,7 @@ const FloorPlansDetailPage = () => {
       .then(handleCreated)
       .catch((error: unknown) => {
         // HTTP 4xx는 AxiosError로, 200 + isSuccess:false는 ApiError로 올라오므로 둘 다 본다
-        const { code: serverCode, message: serverMessage } = extractServerError(error);
+        const { code: serverCode, message: serverMessage } = extractApiError(error);
         if (import.meta.env.DEV) {
           console.error('[CCTV 등록 실패]', serverCode, error);
         }
@@ -3445,7 +3432,7 @@ const FloorPlansDetailPage = () => {
         prev.map((n) => (n.id === id ? { ...n, isFinalExit: !nextIsFinalExit } : n)),
       );
       // 마지막 남은 탈출구는 해제할 수 없는 등 서버가 이유를 message로 내려주므로 그대로 보여줌
-      const { message: serverMessage } = extractServerError(error);
+      const { message: serverMessage } = extractApiError(error);
       show({
         title: serverMessage || '최종 탈출구 지정에 실패했습니다.',
         variant: 'error',
@@ -3500,7 +3487,7 @@ const FloorPlansDetailPage = () => {
       })
       .catch((error: unknown) => {
         // 유도등 판단 노드로 참조 중이거나 마지막 탈출구인 경우 등 서버가 이유를 message로 내려줌
-        const { message: serverMessage } = extractServerError(error);
+        const { message: serverMessage } = extractApiError(error);
         show({
           title: serverMessage || '노드 삭제에 실패했습니다.',
           variant: 'error',
@@ -3610,7 +3597,7 @@ const FloorPlansDetailPage = () => {
           succeeded.push(result.value);
         } else {
           failedCount += 1;
-          firstErrorMessage ??= extractServerError(result.reason).message;
+          firstErrorMessage ??= extractApiError(result.reason).message;
         }
       });
       if (succeeded.length > 0) {
@@ -3748,7 +3735,7 @@ const FloorPlansDetailPage = () => {
         show({ title: '구역을 다시 설정했습니다.', variant: 'success' });
       })
       .catch((error: unknown) => {
-        const { message } = extractServerError(error);
+        const { message } = extractApiError(error);
         if (!deleted) {
           show({ title: message || '구역 재설정에 실패했습니다.', variant: 'error' });
           return;
@@ -4300,7 +4287,7 @@ const FloorPlansDetailPage = () => {
               setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
             )
             .catch((error: unknown) => {
-              const { message } = extractServerError(error);
+              const { message } = extractApiError(error);
               show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
             });
         }
@@ -4311,7 +4298,7 @@ const FloorPlansDetailPage = () => {
               setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
             )
             .catch((error: unknown) => {
-              const { message } = extractServerError(error);
+              const { message } = extractApiError(error);
               show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
             });
         }
@@ -4366,7 +4353,7 @@ const FloorPlansDetailPage = () => {
             void queryClient.invalidateQueries({ queryKey: floorQueryKeys.cctv(floorId) });
           })
           .catch((error: unknown) => {
-            const { message } = extractServerError(error);
+            const { message } = extractApiError(error);
             show({ title: message || 'CCTV 삭제에 실패했습니다.', variant: 'error' });
           })
           .finally(() => setIsDeletingItem(false));

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -300,6 +300,16 @@ const GRAPH_NODE_COLOR: Record<'ROOM' | 'HALLWAY' | 'EXIT' | 'CUSTOM', string> =
   CUSTOM: '#7c3aed',
 };
 
+// 두 노드 사이에 이미 엣지가 있는지 확인 — 방향은 상관없음(A-B가 있으면 B-A도 같은 구간으로 봄).
+// 체인으로 여러 경로를 잇다 보면 이전에 만든 경로와 구간이 겹칠 수 있는데, 그 구간만 생성에서
+// 자동으로 제외하기 위해 캔버스 미리보기와 검토 화면 양쪽에서 이 함수를 같이 씀
+const hasExistingEdge = (edges: MapEdge[], fromId: string, toId: string): boolean =>
+  edges.some(
+    (e) =>
+      (e.fromNodeId === fromId && e.toNodeId === toId) ||
+      (e.fromNodeId === toId && e.toNodeId === fromId),
+  );
+
 type ZoneRefSelection = { kind: 'node'; id: string } | { kind: 'zone'; id: string };
 
 // 그리드(PUT /floors/{id}/grid, GET /floors/{id}/grid/cells)는 두 가지 용도로만 존재함:
@@ -427,6 +437,7 @@ const MockFloorMap3F = ({
   graphEdges,
   edgeAddActive,
   onNodeClickForEdge,
+  edgeChainNodeIds,
   selectedEdgeId,
   onEdgeSelect,
   onEdgeDelete,
@@ -452,6 +463,8 @@ const MockFloorMap3F = ({
   graphEdges: MapEdge[];
   edgeAddActive: boolean;
   onNodeClickForEdge: (id: string) => void;
+  // 순서대로 클릭해 쌓은 엣지 체인 — 골라둔 노드 강조·구간 미리보기에 씀
+  edgeChainNodeIds: string[];
   selectedEdgeId: string | null;
   onEdgeSelect: (id: string) => void;
   onEdgeDelete: (id: string) => void;
@@ -660,6 +673,30 @@ const MockFloorMap3F = ({
         );
       })}
 
+      {/* 순서대로 클릭해 쌓는 중인 엣지 체인 미리보기 — 이미 있는 구간은 회색, 새로 만들 구간은
+          파란 점선으로 구분해서 검토 화면까지 안 가도 겹치는지 바로 알 수 있게 함 */}
+      {edgeChainNodeIds.length > 1 &&
+        edgeChainNodeIds.slice(0, -1).map((fromId, i) => {
+          const toId = edgeChainNodeIds[i + 1];
+          const from = nodePositionById.get(fromId);
+          const to = nodePositionById.get(toId);
+          if (!from || !to) return null;
+          const alreadyExists = hasExistingEdge(graphEdges, fromId, toId);
+          return (
+            <line
+              key={`edge-chain-preview-${fromId}-${toId}-${i}`}
+              x1={from.x}
+              y1={from.y}
+              x2={to.x}
+              y2={to.y}
+              stroke={alreadyExists ? '#9ca3af' : '#2563eb'}
+              strokeWidth="2"
+              strokeDasharray="4 3"
+              style={{ pointerEvents: 'none' }}
+            />
+          );
+        })}
+
       {/* 맵그래프 노드 중 ROOM/HALLWAY/EXIT/CUSTOM — 엣지 연결 모드에서만 클릭 가능.
           ROOM/HALLWAY는 경로 계산용 내부 포인트라 엣지 연결 모드일 때만 화면에 표시 —
           평소엔 클릭도 안 되는데 캔버스만 지저분하게 만들어서 숨김. EXIT/CUSTOM은 정보성이라 항상 표시 */}
@@ -681,6 +718,10 @@ const MockFloorMap3F = ({
           >
             {/* 엣지 연결 모드에선 작은 점을 정확히 겨냥하기 어려워, 넓은 투명 히트영역을 겹쳐 둔다 */}
             {edgeAddActive && <circle cx={x} cy={y} r={13} fill="transparent" />}
+            {/* 체인에 이미 골라둔 노드는 테두리로 강조해서 클릭했다는 걸 바로 알 수 있게 함 */}
+            {edgeChainNodeIds.includes(n.id) && (
+              <circle cx={x} cy={y} r={9} fill="none" stroke="#2563eb" strokeWidth="2" />
+            )}
             <circle cx={x} cy={y} r={n.type === 'EXIT' ? 6 : edgeAddActive ? 5 : 3} fill={color} />
             {n.type === 'EXIT' && (
               <text
@@ -737,6 +778,17 @@ const MockFloorMap3F = ({
                 stroke="#2563eb"
                 strokeWidth="2"
                 strokeDasharray="3 2"
+              />
+            )}
+            {/* 체인에 이미 골라둔 노드는 테두리로 강조 — isSelected 링과 헷갈리지 않게 실선으로 구분 */}
+            {edgeChainNodeIds.includes(n.id) && (
+              <circle
+                cx={n.x}
+                cy={n.y}
+                r={(n.isFinalExit ? 7 : isStair ? 6 : 4) + 4}
+                fill="none"
+                stroke="#2563eb"
+                strokeWidth="2"
               />
             )}
             <circle
@@ -1288,61 +1340,99 @@ const ZoneAddPopup = ({
   );
 };
 
-/* ── 엣지 연결 팝업 — 두 노드를 클릭해서 고른 뒤 거리·양방향 여부를 입력 ── */
-const EdgeAddPopup = ({
+/* ── 엣지 체인 검토 팝업 — 순서대로 고른 노드들 사이 구간을 한 번에 검토·확정.
+   구간이 1개(노드 2개)여도 같은 화면을 씀 — 별도 "한 쌍짜리" 경로를 둘 필요가 없음 ── */
+const EdgeChainReviewPopup = ({
   containerRef,
-  fromLabel,
-  toLabel,
-  suggestedDistance,
-  onCancel,
-  onSave,
+  segments,
+  onBack,
+  onSubmit,
 }: {
   containerRef: React.RefObject<HTMLDivElement>;
-  fromLabel: string;
-  toLabel: string;
-  // 두 노드 좌표 + 그리드 배율로 계산한 추정 거리(m). 없으면 수동 입력
-  suggestedDistance: number | null;
-  onCancel: () => void;
-  // distance는 m 단위(백엔드 저장 단위) — 입력창은 cm라 여기서 넘기기 전에 변환함
-  onSave: (distance: number, bidirectional: boolean) => void;
+  segments: {
+    fromId: string;
+    toId: string;
+    fromLabel: string;
+    toLabel: string;
+    // 두 노드 좌표 + 그리드 배율로 계산한 추정 거리(m). 없으면 수동 입력
+    suggestedDistanceM: number | null;
+    // 다른 경로와 겹쳐서 이미 존재하는 구간 — 입력 없이 생성 대상에서만 제외함
+    alreadyExists: boolean;
+  }[];
+  onBack: () => void;
+  onSubmit: (
+    rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[],
+  ) => void;
 }) => {
   // 실내 노드 간 거리는 1m 미만도 흔해서 cm로 입력받음(정수로 편하게 입력, 저장은 m로 환산)
-  const [distanceCm, setDistanceCm] = useState(
-    suggestedDistance !== null ? String(Math.round(suggestedDistance * 100)) : '',
+  const [distancesCm, setDistancesCm] = useState(() =>
+    segments.map((s) =>
+      s.suggestedDistanceM !== null ? String(Math.round(s.suggestedDistanceM * 100)) : '',
+    ),
   );
   const [bidirectional, setBidirectional] = useState(true);
 
-  const handleDistanceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.target.value;
-    // 완성된 숫자만 허용하면 "495"를 지우다 "4"처럼 될 때까지 중간 상태(끝자리 삭제 등)가
-    // 거부돼 편집이 막히던 문제 — 타이핑 도중 상태(끝에 점만 있거나 소수부가 빈 경우)도 허용
-    if (raw === '' || /^\d*\.?\d*$/.test(raw)) setDistanceCm(raw);
+  const handleDistanceChange = (index: number, raw: string) => {
+    // 완성된 숫자만 허용하면 편집 중간 상태(끝자리 삭제 등)가 거부돼 편집이 막히던 문제 —
+    // 타이핑 도중 상태(끝에 점만 있거나 소수부가 빈 경우)도 허용
+    if (raw !== '' && !/^\d*\.?\d*$/.test(raw)) return;
+    setDistancesCm((prev) => prev.map((v, i) => (i === index ? raw : v)));
   };
 
-  const isValid = Number(distanceCm) > 0;
+  const newSegmentCount = segments.filter((s) => !s.alreadyExists).length;
+  const allValid =
+    newSegmentCount > 0 && segments.every((s, i) => s.alreadyExists || Number(distancesCm[i]) > 0);
+
+  const handleSubmit = () => {
+    const rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[] = [];
+    segments.forEach((s, i) => {
+      if (s.alreadyExists) return;
+      rows.push({
+        fromId: s.fromId,
+        toId: s.toId,
+        distanceM: Number(distancesCm[i]) / 100,
+        bidirectional,
+      });
+    });
+    onSubmit(rows);
+  };
 
   return (
     <div ref={containerRef} className={styles.nodeAddPopup} onClick={(e) => e.stopPropagation()}>
       <div className={styles.nodeAddHeader}>
-        <span className={styles.nodeAddTitle}>엣지 연결</span>
+        <span className={styles.nodeAddTitle}>연결 구간 확인</span>
+        <span className={styles.nodeAddStepBadge}>
+          {newSegmentCount < segments.length
+            ? `신규 ${newSegmentCount}개 · 기존 ${segments.length - newSegmentCount}개`
+            : `${segments.length}개 구간`}
+        </span>
       </div>
       <span className={styles.nodeAddHint}>
-        {fromLabel} → {toLabel}
+        {newSegmentCount === 0
+          ? '선택한 구간이 모두 이미 연결되어 있어요'
+          : '새로 만들 구간의 거리(cm)를 확인하고, 필요하면 고쳐주세요'}
       </span>
 
-      <div className={styles.nodeAddField}>
-        <span className={styles.nodeAddLabel}>거리(cm)</span>
-        <input
-          className={styles.nodeAddInput}
-          type="text"
-          inputMode="decimal"
-          value={distanceCm}
-          onChange={handleDistanceChange}
-          placeholder="350"
-        />
-        {suggestedDistance !== null && (
-          <span className={styles.nodeAddSubHint}>좌표 기준 추정값 · 필요하면 수정하세요</span>
-        )}
+      <div className={styles.edgeChainList}>
+        {segments.map((s, i) => (
+          <div key={`${s.fromId}-${s.toId}`} className={styles.edgeChainRow}>
+            <span className={styles.edgeChainRowLabel}>
+              {s.fromLabel} → {s.toLabel}
+            </span>
+            {s.alreadyExists ? (
+              <span className={styles.edgeChainExistingTag}>이미 연결됨</span>
+            ) : (
+              <input
+                className={styles.edgeChainDistanceInput}
+                type="text"
+                inputMode="decimal"
+                value={distancesCm[i]}
+                onChange={(e) => handleDistanceChange(i, e.target.value)}
+                placeholder="350"
+              />
+            )}
+          </div>
+        ))}
       </div>
 
       <label className={styles.edgeBidirectionalField}>
@@ -1351,20 +1441,20 @@ const EdgeAddPopup = ({
           checked={bidirectional}
           onChange={(e) => setBidirectional(e.target.checked)}
         />
-        양방향 통행 가능
+        전체 양방향 통행 가능
       </label>
 
       <div className={styles.nodeAddActions}>
-        <button type="button" className={styles.nodeAddCancelBtn} onClick={onCancel}>
-          취소
+        <button type="button" className={styles.nodeAddCancelBtn} onClick={onBack}>
+          이전
         </button>
         <button
           type="button"
           className={styles.nodeAddSubmitBtn}
-          disabled={!isValid}
-          onClick={() => onSave(Number(distanceCm) / 100, bidirectional)}
+          disabled={!allValid}
+          onClick={handleSubmit}
         >
-          추가
+          {newSegmentCount}개 연결 추가
         </button>
       </div>
     </div>
@@ -1912,6 +2002,7 @@ const FloorCanvas = ({
   graphEdges,
   edgeAddActive,
   onNodeClickForEdge,
+  edgeChainNodeIds,
   selectedEdgeId,
   onEdgeSelect,
   onEdgeDelete,
@@ -1952,6 +2043,7 @@ const FloorCanvas = ({
   graphEdges: MapEdge[];
   edgeAddActive: boolean;
   onNodeClickForEdge: (id: string) => void;
+  edgeChainNodeIds: string[];
   selectedEdgeId: string | null;
   onEdgeSelect: (id: string) => void;
   onEdgeDelete: (id: string) => void;
@@ -2029,6 +2121,7 @@ const FloorCanvas = ({
         graphEdges={graphEdges}
         edgeAddActive={edgeAddActive}
         onNodeClickForEdge={onNodeClickForEdge}
+        edgeChainNodeIds={edgeChainNodeIds}
         selectedEdgeId={selectedEdgeId}
         onEdgeSelect={onEdgeSelect}
         onEdgeDelete={onEdgeDelete}
@@ -2457,11 +2550,10 @@ const FloorPlansDetailPage = () => {
   const [nodeAddOpen, setNodeAddOpen] = useState(false);
   const [zoneAddOpen, setZoneAddOpen] = useState(false);
   const [edgeAddOpen, setEdgeAddOpen] = useState(false);
-  const [edgeDraftFromId, setEdgeDraftFromId] = useState<string | null>(null);
-  const [edgeDraftToId, setEdgeDraftToId] = useState<string | null>(null);
-  // 엣지 연결 모드는 여러 개를 연달아 만들 수 있게 유지되는데, 그러다 보니 "완료"가 언제
-  // 끝나는지 감이 안 온다는 피드백 — 지금까지 몇 개 만들었는지 패널에 보여주기 위한 카운트
-  const [edgeCreatedCount, setEdgeCreatedCount] = useState(0);
+  // 노드를 한 쌍씩 고르던 방식 대신, 클릭한 순서대로 경로를 쌓아뒀다가 한 번에 구간별로
+  // 검토·확정함(A→B→C→D 클릭 시 A-B, B-C, C-D를 일괄 생성) — 매번 팝업을 반복하던 번거로움을 줄임
+  const [edgeChainNodeIds, setEdgeChainNodeIds] = useState<string[]>([]);
+  const [edgeChainReviewOpen, setEdgeChainReviewOpen] = useState(false);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [zones, setZones] = useState<ZoneEntry[]>([]);
   // 구역 재설정(재드래그) 중인 기존 구역 id — null이면 zoneAddOpen은 "새 구역 추가" 흐름.
@@ -3248,20 +3340,31 @@ const FloorPlansDetailPage = () => {
     return graphNode?.name ?? id;
   };
 
+  // 클릭한 순서대로 경로에 노드를 쌓음 — 같은 노드를 연속으로 눌러도 무시(실수로 두 번 클릭)
+  // 방금 고른 노드를 실수로 다시 클릭했을 수 있으니, 마지막 노드를 다시 누르면 추가하는 대신
+  // 선택을 취소함(경로 맨 끝을 한 단계 되돌리는 것과 같음)
   const handleEdgeNodeClick = (nodeId: string) => {
-    if (!edgeDraftFromId) {
-      setEdgeDraftFromId(nodeId);
-      return;
-    }
-    if (nodeId === edgeDraftFromId) return;
-    setEdgeDraftToId(nodeId);
+    setEdgeChainNodeIds((prev) =>
+      prev[prev.length - 1] === nodeId ? prev.slice(0, -1) : [...prev, nodeId],
+    );
   };
 
-  // 엣지 거리(m) 자동 추정 — 두 노드의 정규화 좌표(0~1) 차이를 칸 수로 환산한 뒤 그리드 배율(m/칸)을
+  const handleClearEdgeChain = () => {
+    setEdgeChainNodeIds([]);
+  };
+
+  // 엣지 연결 모드 종료
+  const handleExitEdgeMode = () => {
+    setEdgeChainNodeIds([]);
+    setEdgeChainReviewOpen(false);
+    setEdgeAddOpen(false);
+  };
+
+  // 두 노드 사이 거리(m) 추정 — 정규화 좌표(0~1) 차이를 칸 수로 환산한 뒤 그리드 배율(m/칸)을
   // 곱한다. 배율(GRID_SIZE_KEY→PENDING→등록된 CCTV 순으로 탐색)이나 그리드 정보가 없으면 null이라
-  // 팝업은 기존처럼 수동 입력으로 폴백한다.
-  const suggestedEdgeDistanceM = useMemo<number | null>(() => {
-    if (!edgeDraftFromId || !edgeDraftToId || !currentFloor) return null;
+  // 검토 화면에서 그 구간만 수동 입력으로 폴백한다.
+  const estimateEdgeDistanceM = (fromId: string, toId: string): number | null => {
+    if (!currentFloor) return null;
     const cellSizeMeter =
       readStoredNumber(GRID_SIZE_KEY(currentFloor.id)) ??
       readStoredNumber(PENDING_GRID_SIZE_KEY(currentFloor.id)) ??
@@ -3277,59 +3380,82 @@ const FloorPlansDetailPage = () => {
       const graphNode = graphNodes.find((n) => n.id === id);
       return graphNode ? { x: graphNode.x, y: graphNode.y } : null;
     };
-    const from = normalizedPos(edgeDraftFromId);
-    const to = normalizedPos(edgeDraftToId);
+    const from = normalizedPos(fromId);
+    const to = normalizedPos(toId);
     if (!from || !to) return null;
     const meters = Math.hypot((from.x - to.x) * cols, (from.y - to.y) * rows) * cellSizeMeter;
     return Math.max(0.1, Math.round(meters * 10) / 10);
-  }, [
-    edgeDraftFromId,
-    edgeDraftToId,
-    currentFloor,
-    floorGridCells,
-    structureNodes,
-    graphNodes,
-    realCctvs,
-    canvasH,
-  ]);
-
-  // 그리던 엣지 한 건만 취소 — 엣지 연결 모드는 유지해서 다음 쌍을 바로 이어 그릴 수 있게 함
-  const handleClearEdgeDraft = () => {
-    setEdgeDraftFromId(null);
-    setEdgeDraftToId(null);
   };
 
-  // 엣지 연결 모드 종료
-  const handleExitEdgeMode = () => {
-    setEdgeDraftFromId(null);
-    setEdgeDraftToId(null);
-    setEdgeAddOpen(false);
-    setEdgeCreatedCount(0);
+  // 클릭한 순서(A→B→C→D)를 연속 구간(A-B, B-C, C-D)으로 풀어 검토 화면에 넘길 목록을 만듦
+  const edgeChainSegments = edgeChainNodeIds.slice(0, -1).map((fromId, i) => {
+    const toId = edgeChainNodeIds[i + 1];
+    return {
+      fromId,
+      toId,
+      fromLabel: getGraphNodeLabel(fromId),
+      toLabel: getGraphNodeLabel(toId),
+      suggestedDistanceM: estimateEdgeDistanceM(fromId, toId),
+      // 다른 경로를 잇다 겹친 구간 — 이미 있는 엣지라 다시 만들 필요가 없어서 검토 화면에서
+      // 자동으로 제외함(사용자가 일일이 안 겹치게 클릭할 필요 없게)
+      alreadyExists: hasExistingEdge(graphEdges, fromId, toId),
+    };
+  });
+
+  const handleProceedToEdgeChainReview = () => {
+    if (edgeChainNodeIds.length < 2) return;
+    setEdgeChainReviewOpen(true);
   };
 
-  const handleCreateEdge = (distance: number, bidirectional: boolean) => {
-    if (!edgeDraftFromId || !edgeDraftToId) return;
-    createMapEdge({
-      fromNodeId: edgeDraftFromId,
-      toNodeId: edgeDraftToId,
-      distance,
-      bidirectional,
-    })
-      .then((newEdge) => {
-        setGraphEdges((prev) => [...prev, newEdge]);
-        setEdgeCreatedCount((prev) => prev + 1);
-      })
-      .catch((error: unknown) => {
-        // 실패해도 조용히 넘어가던 자리라 "노드가 너무 가까우면 연결이 안 되는" 것처럼 보이던
-        // 문제의 원인을 알 수 없었음 — 서버 메시지를 그대로 보여줌
-        const { message } = extractServerError(error);
-        show({ title: message || '엣지 연결에 실패했습니다.', variant: 'error' });
-      })
-      .finally(() => {
-        // 모드는 유지 — 연달아 엣지를 그리다가 "완료"로 끝낸다
-        setEdgeDraftFromId(null);
-        setEdgeDraftToId(null);
+  const handleBackFromEdgeChainReview = () => {
+    setEdgeChainReviewOpen(false);
+  };
+
+  // 검토 화면에서 확정한 구간들을 한 번에 생성 — 일부만 실패해도 성공한 구간은 반영하고
+  // 실패한 개수·사유만 토스트로 알림(하나 실패했다고 나머지까지 날아가면 안 됨)
+  const handleSubmitEdgeChain = (
+    rows: { fromId: string; toId: string; distanceM: number; bidirectional: boolean }[],
+  ) => {
+    Promise.allSettled(
+      rows.map((row) =>
+        createMapEdge({
+          fromNodeId: row.fromId,
+          toNodeId: row.toId,
+          distance: row.distanceM,
+          bidirectional: row.bidirectional,
+        }),
+      ),
+    ).then((results) => {
+      const succeeded: MapEdge[] = [];
+      let failedCount = 0;
+      let firstErrorMessage: string | undefined;
+      results.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          succeeded.push(result.value);
+        } else {
+          failedCount += 1;
+          firstErrorMessage ??= extractServerError(result.reason).message;
+        }
       });
+      if (succeeded.length > 0) {
+        setGraphEdges((prev) => [...prev, ...succeeded]);
+        show({ title: `${succeeded.length}개 구간이 연결되었습니다.`, variant: 'success' });
+      }
+      if (failedCount > 0) {
+        show({
+          title: `${failedCount}개 구간 연결에 실패했습니다.${
+            firstErrorMessage ? ` (${firstErrorMessage})` : ''
+          }`,
+          variant: 'error',
+        });
+      }
+      // 경로 하나를 확정하면 모드도 함께 종료 — 이어서 계속 뜨면 "안 끝난다"는 인상을 줌.
+      // 다른 경로를 더 잇고 싶으면 "엣지 연결"을 다시 열면 되고, 그때는 방금 만든 구간이
+      // graphEdges에 반영돼 있어 중복 클릭도 곧바로 감지됨
+      setEdgeChainNodeIds([]);
+      setEdgeChainReviewOpen(false);
+      setEdgeAddOpen(false);
+    });
   };
 
   const handleEdgeDelete = (edgeId: string) => {
@@ -3525,7 +3651,8 @@ const FloorPlansDetailPage = () => {
     setZoneAddOpen(false);
     setSelectedEdgeId(null);
     setEdgeAddOpen(true);
-    setEdgeCreatedCount(0);
+    setEdgeChainNodeIds([]);
+    setEdgeChainReviewOpen(false);
   };
 
   // 추가/편집 모드는 이제 바깥 클릭으로 안 닫히므로(캔버스가 아닌 다른 영역을 눌러도 진행
@@ -3547,6 +3674,9 @@ const FloorPlansDetailPage = () => {
         setGridSetupIntent(null);
       } else if (editingCctvId) {
         handleCancelEditCctvCells();
+      } else if (edgeChainReviewOpen) {
+        // 검토 화면에서는 모드 전체를 나가지 말고 경로 편집으로 한 단계만 되돌아감
+        setEdgeChainReviewOpen(false);
       } else if (edgeAddOpen) {
         handleExitEdgeMode();
       } else if (zoneAddOpen) {
@@ -3557,7 +3687,15 @@ const FloorPlansDetailPage = () => {
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [gridSetupPromptOpen, gridSetupIntent, editingCctvId, edgeAddOpen, zoneAddOpen, nodeAddOpen]);
+  }, [
+    gridSetupPromptOpen,
+    gridSetupIntent,
+    editingCctvId,
+    edgeChainReviewOpen,
+    edgeAddOpen,
+    zoneAddOpen,
+    nodeAddOpen,
+  ]);
 
   // 시작 후보 중 하나라도 엣지를 따라 최종 탈출구까지 이어지는지 (훈련 준비 체크리스트용).
   // 이 경로가 없으면 경로 탐색기가 EVAC005("도달 가능한 EXIT 노드가 없습니다")로 실패함 —
@@ -4184,54 +4322,60 @@ const FloorPlansDetailPage = () => {
               </div>
             )}
 
-            {/* 첫/두 번째 노드를 고르는 동안 계속 떠 있는 패널 — 엣지를 만들어도 모드가 닫히지
-                않으므로, 연달아 그리다가 "완료"로 끝낼 수 있게 종료 버튼을 항상 노출한다 */}
-            {edgeAddOpen && !edgeDraftToId && (
+            {/* 노드를 순서대로 계속 클릭해 경로를 쌓는 패널 — 경로 하나를 확정하면 모드도 같이
+                끝나므로(핸들러 쪽 주석 참고), 여기선 항상 "아직 아무 것도 안 만든 상태"만 보여줌 */}
+            {edgeAddOpen && !edgeChainReviewOpen && (
               <div className={styles.nodeAddPopup} onClick={(e) => e.stopPropagation()}>
                 <div className={styles.nodeAddHeader}>
                   <span className={styles.nodeAddTitle}>엣지 연결</span>
-                  {edgeCreatedCount > 0 && (
-                    <span className={styles.nodeAddStepBadge}>{edgeCreatedCount}개 연결됨</span>
-                  )}
                 </div>
                 <span className={styles.nodeAddHint}>
-                  {edgeDraftFromId
-                    ? '연결할 두 번째 노드를 클릭하세요'
-                    : '연결할 첫 번째 노드를 클릭하세요'}
+                  {edgeChainNodeIds.length === 0
+                    ? '연결할 노드를 순서대로 클릭하세요'
+                    : `계속 클릭해서 경로를 잇거나, 다음을 눌러 ${edgeChainNodeIds.length - 1}개 구간을 확정하세요`}
                 </span>
+                {edgeChainNodeIds.length > 0 && (
+                  <span className={styles.edgeChainPath}>
+                    {edgeChainNodeIds.map((id) => getGraphNodeLabel(id)).join(' → ')}
+                  </span>
+                )}
                 <div className={styles.nodeAddActions}>
-                  {edgeDraftFromId && (
+                  {edgeChainNodeIds.length > 0 && (
                     <button
                       type="button"
                       className={styles.nodeAddCancelBtn}
-                      onClick={handleClearEdgeDraft}
+                      onClick={handleClearEdgeChain}
                     >
                       다시 선택
                     </button>
                   )}
-                  <button
-                    type="button"
-                    // 아직 하나도 안 만들었으면 "완료"가 아니라 "취소"가 맞는 표현 — 지금까지
-                    // 만든 게 있어야 완료라는 말이 성립함
-                    className={
-                      edgeCreatedCount > 0 ? styles.nodeAddSubmitBtn : styles.nodeAddCancelBtn
-                    }
-                    onClick={handleExitEdgeMode}
-                  >
-                    {edgeCreatedCount > 0 ? '완료' : '취소'}
-                  </button>
+                  {edgeChainNodeIds.length >= 2 ? (
+                    <button
+                      type="button"
+                      className={styles.nodeAddSubmitBtn}
+                      onClick={handleProceedToEdgeChainReview}
+                    >
+                      다음
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className={styles.nodeAddCancelBtn}
+                      onClick={handleExitEdgeMode}
+                    >
+                      취소
+                    </button>
+                  )}
                 </div>
               </div>
             )}
 
-            {edgeAddOpen && edgeDraftFromId && edgeDraftToId && (
-              <EdgeAddPopup
+            {edgeAddOpen && edgeChainReviewOpen && (
+              <EdgeChainReviewPopup
                 containerRef={edgePopupRef}
-                fromLabel={getGraphNodeLabel(edgeDraftFromId)}
-                toLabel={getGraphNodeLabel(edgeDraftToId)}
-                suggestedDistance={suggestedEdgeDistanceM}
-                onCancel={handleClearEdgeDraft}
-                onSave={handleCreateEdge}
+                segments={edgeChainSegments}
+                onBack={handleBackFromEdgeChainReview}
+                onSubmit={handleSubmitEdgeChain}
               />
             )}
 
@@ -4362,8 +4506,9 @@ const FloorPlansDetailPage = () => {
                 onStructureNodeMoveEnd={handleStructureNodeMoveEnd}
                 graphNodes={graphNodes}
                 graphEdges={graphEdges}
-                edgeAddActive={edgeAddOpen}
+                edgeAddActive={edgeAddOpen && !edgeChainReviewOpen}
                 onNodeClickForEdge={handleEdgeNodeClick}
+                edgeChainNodeIds={edgeChainNodeIds}
                 selectedEdgeId={selectedEdgeId}
                 onEdgeSelect={setSelectedEdgeId}
                 onEdgeDelete={handleEdgeDelete}

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -850,6 +850,10 @@ const MockFloorMap3F = ({
         const baseColor = STRUCTURE_NODE_COLOR[n.type];
         const isLightPreview = !!lightPreviewNodeId && n.id === lightPreviewNodeId;
         const isNodePickMode = lightPickField === 'decisionNode';
+        // 왼쪽/오른쪽 통로(엣지)를 캔버스에서 고르는 중엔 노드는 고를 대상이 아닌데, 이 원이
+        // 계속 클릭을 가로채고 있었음 — 엣지가 노드 바로 옆에 붙어있으면 SVG 상 나중에 그려지는
+        // 이 노드 원이 클릭을 먼저 받아가서 엣지를 못 고르던 문제의 원인
+        const isEdgePickMode = lightPickField === 'leftEdge' || lightPickField === 'rightEdge';
         return (
           <g
             key={n.id}
@@ -873,7 +877,7 @@ const MockFloorMap3F = ({
             }}
             style={{
               cursor: isEditingThis ? 'grab' : 'pointer',
-              pointerEvents: isZoneDragging ? 'none' : 'auto',
+              pointerEvents: isZoneDragging || isEdgePickMode ? 'none' : 'auto',
             }}
           >
             {/* 엣지 연결 모드에선 작은 점을 정확히 겨냥하기 어려워, 넓은 투명 히트영역을 겹쳐 둔다 */}

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2459,6 +2459,9 @@ const FloorPlansDetailPage = () => {
   const [edgeAddOpen, setEdgeAddOpen] = useState(false);
   const [edgeDraftFromId, setEdgeDraftFromId] = useState<string | null>(null);
   const [edgeDraftToId, setEdgeDraftToId] = useState<string | null>(null);
+  // 엣지 연결 모드는 여러 개를 연달아 만들 수 있게 유지되는데, 그러다 보니 "완료"가 언제
+  // 끝나는지 감이 안 온다는 피드백 — 지금까지 몇 개 만들었는지 패널에 보여주기 위한 카운트
+  const [edgeCreatedCount, setEdgeCreatedCount] = useState(0);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
   const [zones, setZones] = useState<ZoneEntry[]>([]);
   // 구역 재설정(재드래그) 중인 기존 구역 id — null이면 zoneAddOpen은 "새 구역 추가" 흐름.
@@ -3301,6 +3304,7 @@ const FloorPlansDetailPage = () => {
     setEdgeDraftFromId(null);
     setEdgeDraftToId(null);
     setEdgeAddOpen(false);
+    setEdgeCreatedCount(0);
   };
 
   const handleCreateEdge = (distance: number, bidirectional: boolean) => {
@@ -3313,6 +3317,7 @@ const FloorPlansDetailPage = () => {
     })
       .then((newEdge) => {
         setGraphEdges((prev) => [...prev, newEdge]);
+        setEdgeCreatedCount((prev) => prev + 1);
       })
       .catch((error: unknown) => {
         // 실패해도 조용히 넘어가던 자리라 "노드가 너무 가까우면 연결이 안 되는" 것처럼 보이던
@@ -3520,6 +3525,7 @@ const FloorPlansDetailPage = () => {
     setZoneAddOpen(false);
     setSelectedEdgeId(null);
     setEdgeAddOpen(true);
+    setEdgeCreatedCount(0);
   };
 
   // 추가/편집 모드는 이제 바깥 클릭으로 안 닫히므로(캔버스가 아닌 다른 영역을 눌러도 진행
@@ -4184,6 +4190,9 @@ const FloorPlansDetailPage = () => {
               <div className={styles.nodeAddPopup} onClick={(e) => e.stopPropagation()}>
                 <div className={styles.nodeAddHeader}>
                   <span className={styles.nodeAddTitle}>엣지 연결</span>
+                  {edgeCreatedCount > 0 && (
+                    <span className={styles.nodeAddStepBadge}>{edgeCreatedCount}개 연결됨</span>
+                  )}
                 </div>
                 <span className={styles.nodeAddHint}>
                   {edgeDraftFromId
@@ -4202,10 +4211,14 @@ const FloorPlansDetailPage = () => {
                   )}
                   <button
                     type="button"
-                    className={styles.nodeAddSubmitBtn}
+                    // 아직 하나도 안 만들었으면 "완료"가 아니라 "취소"가 맞는 표현 — 지금까지
+                    // 만든 게 있어야 완료라는 말이 성립함
+                    className={
+                      edgeCreatedCount > 0 ? styles.nodeAddSubmitBtn : styles.nodeAddCancelBtn
+                    }
                     onClick={handleExitEdgeMode}
                   >
-                    완료
+                    {edgeCreatedCount > 0 ? '완료' : '취소'}
                   </button>
                 </div>
               </div>

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -1327,24 +1327,42 @@ const LightPickField = ({
 // 갈림길 위치에 이어진 엣지가 도면에 하나도 없으면 왼쪽/오른쪽 통로는 캔버스에서 클릭할 대상 자체가
 // 없어 아무것도 고를 수 없음(통로는 이 팝업이 아니라 별도의 "+ 추가 → 엣지 추가"로 미리 그려둬야
 // 하는 데이터라서) — 그 상태에서 그냥 "클릭해주세요"만 보여주면 왜 안 되는지 알 수 없어 안내를 바꿔줌
+interface LightPickHint {
+  text: string;
+  // 그냥 안내가 아니라 "지금 이대로는 진행이 안 된다"는 경고라 색으로도 구분되게 함
+  isWarning: boolean;
+}
+
 const getLightPickHint = (
   pickField: LightPickFieldName | null,
   decisionNodeId: string,
   edgeOptions: readonly { fromNodeId: string; toNodeId: string }[],
-): string => {
+): LightPickHint => {
   if (!pickField) {
-    return '이 유도등이 서 있는 갈림길 위치와, 화재 시 왼쪽·오른쪽 중 어느 통로로 안내할지 정해주세요';
+    return {
+      text: '이 유도등이 서 있는 갈림길 위치와, 화재 시 왼쪽·오른쪽 중 어느 통로로 안내할지 정해주세요',
+      isWarning: false,
+    };
   }
-  if (pickField === 'decisionNode') return '도면에서 갈림길이 될 노드를 클릭해주세요';
+  if (pickField === 'decisionNode') {
+    return { text: '도면에서 갈림길이 될 노드를 클릭해주세요', isWarning: false };
+  }
   const hasConnectedEdge = edgeOptions.some(
     (e) => e.fromNodeId === decisionNodeId || e.toNodeId === decisionNodeId,
   );
   if (!hasConnectedEdge) {
-    return '이 갈림길에 연결된 통로(엣지)가 없어요. "+ 추가 → 엣지 추가"로 통로를 먼저 만들어주세요';
+    return {
+      text: '이 갈림길에 연결된 통로(엣지)가 없어요. "+ 추가 → 엣지 추가"로 통로를 먼저 만들어주세요',
+      isWarning: true,
+    };
   }
-  return pickField === 'leftEdge'
-    ? '도면에서 왼쪽 통로가 될 구간(선)을 클릭해주세요'
-    : '도면에서 오른쪽 통로가 될 구간(선)을 클릭해주세요';
+  return {
+    text:
+      pickField === 'leftEdge'
+        ? '도면에서 왼쪽 통로가 될 구간(선)을 클릭해주세요'
+        : '도면에서 오른쪽 통로가 될 구간(선)을 클릭해주세요',
+    isWarning: false,
+  };
 };
 
 /* ── 장비 추가 팝업 ──
@@ -1500,61 +1518,74 @@ const NodeAddPopup = ({
               등록 직후엔 항상 비어있던 문제(훈련 준비의 guidanceConfigured가 안 채워짐). 도면에
               아직 판단 노드·엣지·CCTV가 없을 수도 있어 필수는 아니고, 비워두면 등록 후 카드에서
               마저 채울 수 있음 */}
-          {isLight && (
-            <>
-              <div className={styles.nodeAddField}>
-                <span className={styles.nodeAddLabel}>담당 CCTV</span>
-                <Dropdown
-                  shape="rounded"
-                  fullWidth
-                  ariaLabel="담당 CCTV"
-                  options={lightCctvOptions.map((c) => ({ value: c.id, label: c.label }))}
-                  value={lightCctvId}
-                  onChange={setLightCctvId}
-                  placeholder="미지정"
-                />
-              </div>
-              {/* "판단 노드"·"경로 엣지"란 용어와, 목록에 같은 종류(예: 복도) 노드가 여러 개일 때
-                  뭐가 뭔지 구분이 안 된다는 QA 피드백 — 무엇을 고르는 건지 문장으로 먼저 알려주고,
-                  옵션 라벨도 우측 패널 카드와 같은 번호("복도 1" 등, getGraphNodeLabel)를 쓰게 함.
-                  드롭다운이 여전히 헷갈리면 "캔버스에서 선택" 버튼으로 도면에서 직접 클릭해 고를
-                  수도 있게 함(이 경우 도면 위 강조·클릭은 부모가 처리하고 값만 내려받음) */}
-              <span className={styles.nodeAddHint}>
-                {getLightPickHint(lightPickField, lightDecisionNodeId, lightEdgeOptions)}
-              </span>
-              <LightPickField
-                label="갈림길 위치"
-                fieldName="decisionNode"
-                pickField={lightPickField}
-                displayLabel={lightNodeOptions.find((n) => n.id === lightDecisionNodeId)?.label}
-                emptyText="갈림길 위치 선택"
-                onStartPick={() => onStartLightPick('decisionNode')}
-                onClear={() =>
-                  onLightFieldsChange({ decisionNodeId: '', leftEdgeId: '', rightEdgeId: '' })
-                }
-              />
-              <LightPickField
-                label="왼쪽 통로"
-                fieldName="leftEdge"
-                pickField={lightPickField}
-                disabled={!lightDecisionNodeId}
-                displayLabel={lightEdgeOptions.find((e) => e.id === lightLeftEdgeId)?.label}
-                emptyText={lightDecisionNodeId ? '왼쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
-                onStartPick={() => onStartLightPick('leftEdge')}
-                onClear={() => onLightFieldsChange({ ...lightFields, leftEdgeId: '' })}
-              />
-              <LightPickField
-                label="오른쪽 통로"
-                fieldName="rightEdge"
-                pickField={lightPickField}
-                disabled={!lightDecisionNodeId}
-                displayLabel={lightEdgeOptions.find((e) => e.id === lightRightEdgeId)?.label}
-                emptyText={lightDecisionNodeId ? '오른쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
-                onStartPick={() => onStartLightPick('rightEdge')}
-                onClear={() => onLightFieldsChange({ ...lightFields, rightEdgeId: '' })}
-              />
-            </>
-          )}
+          {isLight &&
+            (() => {
+              const lightPickHint = getLightPickHint(
+                lightPickField,
+                lightDecisionNodeId,
+                lightEdgeOptions,
+              );
+              return (
+                <>
+                  <div className={styles.nodeAddField}>
+                    <span className={styles.nodeAddLabel}>담당 CCTV</span>
+                    <Dropdown
+                      shape="rounded"
+                      fullWidth
+                      ariaLabel="담당 CCTV"
+                      options={lightCctvOptions.map((c) => ({ value: c.id, label: c.label }))}
+                      value={lightCctvId}
+                      onChange={setLightCctvId}
+                      placeholder="미지정"
+                    />
+                  </div>
+                  {/* "판단 노드"·"경로 엣지"란 용어와, 목록에 같은 종류(예: 복도) 노드가 여러 개일 때
+                      뭐가 뭔지 구분이 안 된다는 QA 피드백 — 무엇을 고르는 건지 문장으로 먼저 알려주고,
+                      옵션 라벨도 우측 패널 카드와 같은 번호("복도 1" 등, getGraphNodeLabel)를 쓰게 함.
+                      드롭다운이 여전히 헷갈리면 "캔버스에서 선택" 버튼으로 도면에서 직접 클릭해 고를
+                      수도 있게 함(이 경우 도면 위 강조·클릭은 부모가 처리하고 값만 내려받음) */}
+                  <span
+                    className={clsx(
+                      styles.nodeAddHint,
+                      lightPickHint.isWarning && styles.nodeAddHintWarning,
+                    )}
+                  >
+                    {lightPickHint.text}
+                  </span>
+                  <LightPickField
+                    label="갈림길 위치"
+                    fieldName="decisionNode"
+                    pickField={lightPickField}
+                    displayLabel={lightNodeOptions.find((n) => n.id === lightDecisionNodeId)?.label}
+                    emptyText="갈림길 위치 선택"
+                    onStartPick={() => onStartLightPick('decisionNode')}
+                    onClear={() =>
+                      onLightFieldsChange({ decisionNodeId: '', leftEdgeId: '', rightEdgeId: '' })
+                    }
+                  />
+                  <LightPickField
+                    label="왼쪽 통로"
+                    fieldName="leftEdge"
+                    pickField={lightPickField}
+                    disabled={!lightDecisionNodeId}
+                    displayLabel={lightEdgeOptions.find((e) => e.id === lightLeftEdgeId)?.label}
+                    emptyText={lightDecisionNodeId ? '왼쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                    onStartPick={() => onStartLightPick('leftEdge')}
+                    onClear={() => onLightFieldsChange({ ...lightFields, leftEdgeId: '' })}
+                  />
+                  <LightPickField
+                    label="오른쪽 통로"
+                    fieldName="rightEdge"
+                    pickField={lightPickField}
+                    disabled={!lightDecisionNodeId}
+                    displayLabel={lightEdgeOptions.find((e) => e.id === lightRightEdgeId)?.label}
+                    emptyText={lightDecisionNodeId ? '오른쪽 통로 선택' : '갈림길 위치를 먼저 선택'}
+                    onStartPick={() => onStartLightPick('rightEdge')}
+                    onClear={() => onLightFieldsChange({ ...lightFields, rightEdgeId: '' })}
+                  />
+                </>
+              );
+            })()}
         </>
       )}
 
@@ -2128,9 +2159,23 @@ const DeviceCard = ({
                   펼쳤을 때 항상 보이는 문장으로 먼저 설명함(hover에만 의존하던 title 문구를 대체).
                   드롭다운에 같은 이름 노드가 많아 헷갈리면 "캔버스에서 선택"으로 도면에서 직접
                   클릭해 고를 수도 있음 */}
-              <span className={styles.nodeAddHint}>
-                {getLightPickHint(lightPickField, editForm.decisionNodeId, lightEdgeOptions)}
-              </span>
+              {(() => {
+                const lightPickHint = getLightPickHint(
+                  lightPickField,
+                  editForm.decisionNodeId,
+                  lightEdgeOptions,
+                );
+                return (
+                  <span
+                    className={clsx(
+                      styles.nodeAddHint,
+                      lightPickHint.isWarning && styles.nodeAddHintWarning,
+                    )}
+                  >
+                    {lightPickHint.text}
+                  </span>
+                );
+              })()}
               <LightPickField
                 label="갈림길 위치"
                 fieldName="decisionNode"
@@ -3611,6 +3656,9 @@ const FloorPlansDetailPage = () => {
   const handleZoneRefSelect = (ref: ZoneRefSelection) => {
     setSelectedItem(null);
     setEditingItemId(null);
+    // 엣지를 선택해둔 채로 다른 노드·구역을 고르면 엣지 강조가 그대로 남아있던 문제 —
+    // 포커스는 하나만 유지되게 함
+    setSelectedEdgeId(null);
     setSelectedZoneRef((prev) => (isSameZoneRef(prev, ref) ? null : ref));
   };
 
@@ -3636,8 +3684,9 @@ const FloorPlansDetailPage = () => {
   };
 
   const handleStructureNodeMoveEnd = (id: string, x: number, y: number) => {
-    updateMapNodePosition(id, { x: x / CANVAS_W, y: y / canvasH }).catch(() => {
-      show({ title: '위치 저장에 실패했습니다.', variant: 'error' });
+    updateMapNodePosition(id, { x: x / CANVAS_W, y: y / canvasH }).catch((error: unknown) => {
+      const { message } = extractApiError(error);
+      show({ title: message || '위치 저장에 실패했습니다.', variant: 'error' });
     });
   };
 
@@ -4656,8 +4705,11 @@ const FloorPlansDetailPage = () => {
             setIotLights((prev) => prev.filter((l) => l.id !== item.id));
             setDeleteConfirmTarget(null);
           })
-          .catch(() => {
-            show({ title: '유도등 삭제에 실패했습니다.', variant: 'error' });
+          .catch((error: unknown) => {
+            // CCTV/구조 노드 삭제와 달리 여기만 서버 메시지를 안 보여줘서, 실패해도 왜 실패했는지
+            // 알 수 없었음(예: 다른 곳에서 참조 중이라 서버가 거부하는 경우) — 실제 사유를 그대로 보여줌
+            const { message } = extractApiError(error);
+            show({ title: message || '유도등 삭제에 실패했습니다.', variant: 'error' });
           })
           .finally(() => setIsDeletingItem(false));
         return;
@@ -4936,78 +4988,84 @@ const FloorPlansDetailPage = () => {
               </div>
             )}
 
-            {loadingFloor ? (
-              <LoadingState message="도면을 불러오는 중..." />
-            ) : currentFloor ? (
-              <FloorCanvas
-                mapWrapRef={mapWrapRef}
-                floor={floor ?? currentFloor}
-                resolvedImageUrl={resolvedMapImageUrl}
-                canvasH={canvasH}
-                selected={selectedItem}
-                zoom={zoom}
-                editingItemId={editingItemId}
-                placingActive={nodeAddOpen}
-                zoneAddActive={
-                  zoneAddOpen ||
-                  (nodeAddType === 'cctv' && nodeAddStage === 'fov') ||
-                  !!editingCctvId
-                }
-                onZoneDraftChange={setZoneDraftRect}
-                onZoneDragEnd={handleZoneDragEnd}
-                isZoneDragging={isZoneDragging}
-                onZoneDraggingChange={setIsZoneDragging}
-                savedZones={zones}
-                structureNodes={structureNodes}
-                editingStructureId={editingStructureId}
-                onStructureNodeMove={handleStructureNodeMove}
-                onStructureNodeMoveEnd={handleStructureNodeMoveEnd}
-                graphNodes={graphNodes}
-                graphEdges={graphEdges}
-                edgeAddActive={edgeAddOpen && !edgeChainReviewOpen}
-                onNodeClickForEdge={handleEdgeNodeClick}
-                edgeChainNodeIds={edgeChainNodeIds}
-                selectedEdgeId={selectedEdgeId}
-                onEdgeSelect={setSelectedEdgeId}
-                onEdgeDelete={handleEdgeDelete}
-                selectedZoneRef={selectedZoneRef}
-                onZoneRefSelect={handleZoneRefSelectFromMap}
-                cctvGridCellsMode={cctvGridCellsMode}
-                floorGridCells={floorGridCells}
-                selectedGridCellIds={selectedGridCellIds}
-                gridCellPxSize={gridCellPxSize}
-                onGridCellToggle={handleGridCellToggle}
-                lightPreviewNodeId={lightPreviewSource?.decisionNodeId}
-                lightPreviewLeftEdgeId={lightPreviewSource?.leftEdgeId}
-                lightPreviewRightEdgeId={lightPreviewSource?.rightEdgeId}
-                lightPickField={currentLightPickField}
-                onLightPick={handleLightCanvasPick}
-                stagedCameraPosition={nodeStagedPosition}
-                onSelectDevice={(d) => {
-                  const isSame = selectedItem?.kind === 'device' && selectedItem.data.id === d.id;
-                  setSelectedItem(isSame ? null : { kind: 'device', data: d });
-                  setSelectedZoneRef(null);
-                  // 지금 하위 필터에 가려져 있어도 이 장비 카드가 패널에 드러나도록 그 종류로 이동
-                  // (다른 칩은 정리 — 안 그러면 이 종류가 아직 안 켜져 있을 때 여전히 숨어 있음)
-                  setTopFilter((prev) => (prev === 'zone' ? 'all' : prev));
-                  const chip = deviceTypeToFilterChip(d.type);
-                  setDeviceTypeFilter(chip ? [chip] : []);
-                }}
-                onMapClick={handleMapClick}
-                onBackgroundClick={() => {
-                  setSelectedItem(null);
-                  setSelectedZoneRef(null);
-                }}
-                devicePositions={devicePositions}
-                onDeviceMoved={handleDeviceMoved}
-                addedDevices={addedDevices}
-                onUpload={() => setUploadModalOpen(true)}
-              />
-            ) : (
-              <div className={styles.canvasPlaceholder}>
-                <span className={styles.canvasPlaceholderTitle}>층 정보를 찾을 수 없습니다</span>
-              </div>
-            )}
+            <div className={styles.canvasScrollArea}>
+              {loadingFloor ? (
+                <LoadingState message="도면을 불러오는 중..." />
+              ) : currentFloor ? (
+                <FloorCanvas
+                  mapWrapRef={mapWrapRef}
+                  floor={floor ?? currentFloor}
+                  resolvedImageUrl={resolvedMapImageUrl}
+                  canvasH={canvasH}
+                  selected={selectedItem}
+                  zoom={zoom}
+                  editingItemId={editingItemId}
+                  placingActive={nodeAddOpen}
+                  zoneAddActive={
+                    zoneAddOpen ||
+                    (nodeAddType === 'cctv' && nodeAddStage === 'fov') ||
+                    !!editingCctvId
+                  }
+                  onZoneDraftChange={setZoneDraftRect}
+                  onZoneDragEnd={handleZoneDragEnd}
+                  isZoneDragging={isZoneDragging}
+                  onZoneDraggingChange={setIsZoneDragging}
+                  savedZones={zones}
+                  structureNodes={structureNodes}
+                  editingStructureId={editingStructureId}
+                  onStructureNodeMove={handleStructureNodeMove}
+                  onStructureNodeMoveEnd={handleStructureNodeMoveEnd}
+                  graphNodes={graphNodes}
+                  graphEdges={graphEdges}
+                  edgeAddActive={edgeAddOpen && !edgeChainReviewOpen}
+                  onNodeClickForEdge={handleEdgeNodeClick}
+                  edgeChainNodeIds={edgeChainNodeIds}
+                  selectedEdgeId={selectedEdgeId}
+                  onEdgeSelect={setSelectedEdgeId}
+                  onEdgeDelete={handleEdgeDelete}
+                  selectedZoneRef={selectedZoneRef}
+                  onZoneRefSelect={handleZoneRefSelectFromMap}
+                  cctvGridCellsMode={cctvGridCellsMode}
+                  floorGridCells={floorGridCells}
+                  selectedGridCellIds={selectedGridCellIds}
+                  gridCellPxSize={gridCellPxSize}
+                  onGridCellToggle={handleGridCellToggle}
+                  lightPreviewNodeId={lightPreviewSource?.decisionNodeId}
+                  lightPreviewLeftEdgeId={lightPreviewSource?.leftEdgeId}
+                  lightPreviewRightEdgeId={lightPreviewSource?.rightEdgeId}
+                  lightPickField={currentLightPickField}
+                  onLightPick={handleLightCanvasPick}
+                  stagedCameraPosition={nodeStagedPosition}
+                  onSelectDevice={(d) => {
+                    const isSame = selectedItem?.kind === 'device' && selectedItem.data.id === d.id;
+                    setSelectedItem(isSame ? null : { kind: 'device', data: d });
+                    setSelectedZoneRef(null);
+                    // 엣지를 선택해둔 채로 장비를 고르면 엣지 강조가 그대로 남아있던 문제 —
+                    // 포커스는 하나만 유지되게 함
+                    setSelectedEdgeId(null);
+                    // 지금 하위 필터에 가려져 있어도 이 장비 카드가 패널에 드러나도록 그 종류로 이동
+                    // (다른 칩은 정리 — 안 그러면 이 종류가 아직 안 켜져 있을 때 여전히 숨어 있음)
+                    setTopFilter((prev) => (prev === 'zone' ? 'all' : prev));
+                    const chip = deviceTypeToFilterChip(d.type);
+                    setDeviceTypeFilter(chip ? [chip] : []);
+                  }}
+                  onMapClick={handleMapClick}
+                  onBackgroundClick={() => {
+                    setSelectedItem(null);
+                    setSelectedZoneRef(null);
+                    setSelectedEdgeId(null);
+                  }}
+                  devicePositions={devicePositions}
+                  onDeviceMoved={handleDeviceMoved}
+                  addedDevices={addedDevices}
+                  onUpload={() => setUploadModalOpen(true)}
+                />
+              ) : (
+                <div className={styles.canvasPlaceholder}>
+                  <span className={styles.canvasPlaceholderTitle}>층 정보를 찾을 수 없습니다</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* 캔버스 우하단 — 범례 정보 아이콘을 줌 컨트롤 바로 위에 세로로 쌓음 */}

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2668,20 +2668,6 @@ const FloorPlansDetailPage = () => {
     target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [focusedPanelId]);
 
-  // 장비 추가 팝업: 팝업 및 도면 영역 바깥 클릭 시 닫기 (도면 클릭은 배치로 처리)
-  // 위치를 한 번이라도 지정한 뒤에는 진행 상태를 실수로 잃지 않도록 바깥 클릭으로 닫히지 않게 함
-  useEffect(() => {
-    if (!nodeAddOpen || nodeStagedPosition) return;
-    const handleOutside = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (nodePopupRef.current?.contains(target)) return;
-      if (mapWrapRef.current?.contains(target)) return;
-      setNodeAddOpen(false);
-    };
-    document.addEventListener('mousedown', handleOutside);
-    return () => document.removeEventListener('mousedown', handleOutside);
-  }, [nodeAddOpen, nodeStagedPosition]);
-
   // 장비 추가 팝업이 닫히면 배치 진행 상태 초기화
   useEffect(() => {
     if (!nodeAddOpen) {
@@ -2690,22 +2676,6 @@ const FloorPlansDetailPage = () => {
       setZoneDraftRect(null);
     }
   }, [nodeAddOpen]);
-
-  // 구역 설정 팝업: 팝업 및 도면 영역 바깥 클릭 시 닫기 (도면 드래그는 구역 선택으로 처리)
-  // 셀을 이미 선택한 뒤에는 진행 상태를 실수로 잃지 않도록 바깥 클릭으로 닫히지 않게 함.
-  // 기존 구역을 수정 중(zoneResetTargetId)일 때도 마찬가지 — 카드의 완료를 눌러야만
-  // 끝나게 하고, 다른 곳을 잘못 눌러서 조용히 편집이 날아가지 않게 함
-  useEffect(() => {
-    if (!zoneAddOpen || zoneResetTargetId || zoneDraftCellIds.length > 0) return;
-    const handleOutside = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (zonePopupRef.current?.contains(target)) return;
-      if (mapWrapRef.current?.contains(target)) return;
-      setZoneAddOpen(false);
-    };
-    document.addEventListener('mousedown', handleOutside);
-    return () => document.removeEventListener('mousedown', handleOutside);
-  }, [zoneAddOpen, zoneResetTargetId, zoneDraftCellIds]);
 
   // 구역 설정 팝업이 닫히면 드래그로 선택한 임시 영역/셀과 재설정 대상도 함께 초기화
   useEffect(() => {
@@ -3551,6 +3521,37 @@ const FloorPlansDetailPage = () => {
     setSelectedEdgeId(null);
     setEdgeAddOpen(true);
   };
+
+  // 추가/편집 모드는 이제 바깥 클릭으로 안 닫히므로(캔버스가 아닌 다른 영역을 눌러도 진행
+  // 중인 폼이 사라지지 않게 하기 위함), 마우스 없이도 빠져나갈 수 있도록 Esc로 지금 열려 있는
+  // 모드 하나를 명시적으로 종료함. 이 모드들은 서로 배타적으로 열리므로 우선순위만 정해두면 됨
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (gridSetupPromptOpen) {
+        // handleGridSetupPromptCancel과 같은 동작 — 매 렌더마다 새로 만들어지는 함수라
+        // 의존성 배열에 넣으면 리스너가 렌더마다 재구독되므로 여기선 로직만 그대로 옮겨 씀
+        setGridSetupPromptOpen(false);
+        if (gridSetupIntent === 'cctv') {
+          setNodeAddStage('entry');
+          setZoneDraftRect(null);
+          setCctvDraftCellIds([]);
+          lastCctvDraftRectRef.current = null;
+        }
+        setGridSetupIntent(null);
+      } else if (editingCctvId) {
+        handleCancelEditCctvCells();
+      } else if (edgeAddOpen) {
+        handleExitEdgeMode();
+      } else if (zoneAddOpen) {
+        setZoneAddOpen(false);
+      } else if (nodeAddOpen) {
+        handleCancelNodeAdd();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [gridSetupPromptOpen, gridSetupIntent, editingCctvId, edgeAddOpen, zoneAddOpen, nodeAddOpen]);
 
   // 시작 후보 중 하나라도 엣지를 따라 최종 탈출구까지 이어지는지 (훈련 준비 체크리스트용).
   // 이 경로가 없으면 경로 탐색기가 EVAC005("도달 가능한 EXIT 노드가 없습니다")로 실패함 —

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -13,6 +13,7 @@ import CheckIcon from '@assets/icons/ic-check.svg?react';
 import ChevronDownIcon from '@assets/icons/ic-chevron-down.svg?react';
 import ChevronRightIcon from '@assets/icons/ic-chevron-right.svg?react';
 import EditIcon from '@assets/icons/ic-edit.svg?react';
+import InfoIcon from '@assets/icons/ic-info.svg?react';
 import PlusIcon from '@assets/icons/ic-plus.svg?react';
 import TrashIcon from '@assets/icons/ic-trash.svg?react';
 import WifiIcon from '@assets/icons/ic-wifi.svg?react';
@@ -1434,6 +1435,86 @@ const AddActionMenu = ({
   );
 };
 
+/* ── 노드/구역 종류 안내 — 인포 아이콘을 눌렀을 때만 팝오버로 보여주고 바깥을 클릭하면 닫힘
+   (항상 떠 있는 범례가 도면을 가린다는 피드백을 받아 지도 툴들에서 흔한 "on-demand 팝오버"
+   패턴으로 바꿈) ── */
+const NodeTypeLegendInfo = () => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className={styles.legendInfoContainer}>
+      <button
+        type="button"
+        className={styles.legendInfoButton}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label="노드·구역 표시 안내"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <InfoIcon width={18} height={18} />
+      </button>
+
+      {open && (
+        <div className={styles.legendPopover} role="dialog" aria-label="노드·구역 표시 안내">
+          <div className={styles.nodeTypeLegendSection}>
+            <span className={styles.zoneLegendTitle}>노드 종류</span>
+            <div className={styles.zoneLegendItem}>
+              <span className={styles.nodeTypeCctvBadge}>CC</span>
+              <span className={styles.zoneLegendLabel}>CCTV</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotLight)} />
+              <span className={styles.zoneLegendLabel}>유도등</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotDoor)} />
+              <span className={styles.zoneLegendLabel}>문 · 출입구</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStair)} />
+              <span className={styles.zoneLegendLabel}>계단</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotHallway)} />
+              <span className={styles.zoneLegendLabel}>복도</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStart)} />
+              <span className={styles.zoneLegendLabel}>시작 후보</span>
+            </div>
+          </div>
+
+          <div className={styles.nodeTypeLegendDivider} />
+
+          <div className={styles.nodeTypeLegendSection}>
+            <span className={styles.zoneLegendTitle}>구역 종류</span>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchGeneral)} />
+              <span className={styles.zoneLegendLabel}>일반 구역</span>
+            </div>
+            <div className={styles.zoneLegendItem}>
+              <span className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchCamera)} />
+              <span className={styles.zoneLegendLabel}>카메라 시야</span>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 /* ── 장비 카드 ── */
 const DeviceCard = ({
   item,
@@ -2356,8 +2437,6 @@ const FloorPlansDetailPage = () => {
   const [selectedBuildingId] = useState(buildingId ?? '');
   const [selectedFloorId, setSelectedFloorId] = useState(floorId ?? '');
   const [zoom, setZoom] = useState(100);
-  // 노드/구역 범례가 캔버스 위에 고정으로 떠 있어 도면을 가린다는 피드백 — 접었다 펼 수 있게 함
-  const [isNodeLegendOpen, setIsNodeLegendOpen] = useState(true);
   const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
   const [selectedZoneRef, setSelectedZoneRef] = useState<ZoneRefSelection | null>(null);
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
@@ -4229,10 +4308,11 @@ const FloorPlansDetailPage = () => {
               currentFloor?.segmentationStatus === 'DONE' && styles.canvasBodyWithActions,
             )}
           >
-            {/* 그리드는 이제 토글 없이 항상 표시함(아래 ensureFloorGridCells 자동 조회 효과 참고) —
-                추가(노드/구역/엣지) 메뉴만 남김 */}
+            {/* 그리드는 이제 토글 없이 항상 표시함(아래 ensureFloorGridCells 자동 조회 효과 참고) */}
             {currentFloor?.segmentationStatus === 'DONE' && (
-              <div className={styles.canvasActionFloat}>
+              <div className={styles.canvasTopRightRow}>
+                <NodeTypeLegendInfo />
+
                 <AddActionMenu
                   onAddNode={() => handleOpenNodeAdd()}
                   onAddZone={handleToggleZoneAdd}
@@ -4307,77 +4387,6 @@ const FloorPlansDetailPage = () => {
               </div>
             )}
           </div>
-
-          {currentFloor?.segmentationStatus === 'DONE' && (
-            <div className={styles.nodeTypeLegend}>
-              <button
-                type="button"
-                className={styles.nodeTypeLegendHeader}
-                onClick={() => setIsNodeLegendOpen((prev) => !prev)}
-                aria-expanded={isNodeLegendOpen}
-              >
-                <span className={styles.zoneLegendTitle}>범례</span>
-                {isNodeLegendOpen ? (
-                  <ChevronDownIcon width={14} height={14} />
-                ) : (
-                  <ChevronRightIcon width={14} height={14} />
-                )}
-              </button>
-
-              {isNodeLegendOpen && (
-                <>
-                  <div className={styles.nodeTypeLegendSection}>
-                    <span className={styles.zoneLegendTitle}>노드 종류</span>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={styles.nodeTypeCctvBadge}>CC</span>
-                      <span className={styles.zoneLegendLabel}>CCTV</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotLight)} />
-                      <span className={styles.zoneLegendLabel}>유도등</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotDoor)} />
-                      <span className={styles.zoneLegendLabel}>문 · 출입구</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStair)} />
-                      <span className={styles.zoneLegendLabel}>계단</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotHallway)} />
-                      <span className={styles.zoneLegendLabel}>복도</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span className={clsx(styles.nodeTypeDot, styles.nodeTypeDotStart)} />
-                      <span className={styles.zoneLegendLabel}>시작 후보</span>
-                    </div>
-                  </div>
-
-                  <div className={styles.nodeTypeLegendDivider} />
-
-                  <div className={styles.nodeTypeLegendSection}>
-                    <span className={styles.zoneLegendTitle}>구역 종류</span>
-                    <div className={styles.zoneLegendItem}>
-                      <span
-                        className={clsx(
-                          styles.nodeTypeAreaSwatch,
-                          styles.nodeTypeAreaSwatchGeneral,
-                        )}
-                      />
-                      <span className={styles.zoneLegendLabel}>일반 구역</span>
-                    </div>
-                    <div className={styles.zoneLegendItem}>
-                      <span
-                        className={clsx(styles.nodeTypeAreaSwatch, styles.nodeTypeAreaSwatchCamera)}
-                      />
-                      <span className={styles.zoneLegendLabel}>카메라 시야</span>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-          )}
 
           {/* 플로팅 줌 컨트롤 */}
           <div className={styles.canvasZoomFloat}>

--- a/src/pages/floorPlans/FloorPlansPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansPage.css.ts
@@ -10,6 +10,12 @@ export const container = style({
   padding: vars.space.s8,
   minHeight: '100%',
   overflowY: 'auto',
+  // 스크롤은 그대로 되지만 막대는 안 보이게(도면 관리 상세 페이지와 동일한 처리)
+  scrollbarWidth: 'none',
+  msOverflowStyle: 'none',
+  selectors: {
+    '&::-webkit-scrollbar': { display: 'none' },
+  },
 });
 
 export const stateMessage = style({

--- a/src/pages/floorPlans/FloorPlansPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansPage.css.ts
@@ -119,6 +119,8 @@ export const metaRow = style({
 });
 
 export const metaKey = style({
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
   color: vars.color.textLow,
   ...vars.typography.caption,
 });
@@ -143,9 +145,10 @@ export const metaValueFailed = style({
   ...vars.typography.caption,
 });
 
-// 등록 요건 진행바 — metaRow 안에서 값 자리만큼만 차지하게 폭을 좁게 고정
+// 등록 요건 진행바 — "등록 요건" 라벨이 잘리지 않을 만큼 폭을 더 좁게 고정
 export const readinessProgressBar = style({
-  width: '6.4rem',
+  flexShrink: 0,
+  width: '4rem',
 });
 
 export const uploadButton = style({

--- a/src/pages/floorPlans/FloorPlansPage.css.ts
+++ b/src/pages/floorPlans/FloorPlansPage.css.ts
@@ -143,6 +143,11 @@ export const metaValueFailed = style({
   ...vars.typography.caption,
 });
 
+// 등록 요건 진행바 — metaRow 안에서 값 자리만큼만 차지하게 폭을 좁게 고정
+export const readinessProgressBar = style({
+  width: '6.4rem',
+});
+
 export const uploadButton = style({
   border: `1px solid ${vars.color.primary}`,
   borderRadius: vars.radius.md,

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -13,6 +13,7 @@ import StatusBadge from '@components/chip/StatusBadge';
 import type { StatusBadgeColor } from '@components/chip/StatusBadge';
 import EmptyState from '@components/empty';
 import LoadingState from '@components/loadingState';
+import SegmentedProgressBar from '@components/progress/SegmentedProgressBar';
 import useToast from '@components/toast/useToast';
 
 import { ROUTES } from '@constants/path';
@@ -51,20 +52,26 @@ const AiStatusText = ({ status }: { status: SegmentationStatus | null }) => {
   return <span className={styles.metaValue}>—</span>;
 };
 
-// 항목별 내역(시작 노드·최종 탈출구·탈출 경로)은 상세보기에서 보여주고, 카드에서는 AI 분석과
-// 같은 한 줄 형태로 개수만 요약함 — 3/3이면 완료와 같은 초록, 일부만 됐으면 진행중과 같은
-// 주황, 하나도 안 됐으면 무채색
-const ReadinessCountText = ({ readiness }: { readiness: FloorReadiness }) => {
+// 항목별 내역(시작 노드·최종 탈출구·탈출 경로)은 상세보기에서 보여주고, 카드에서는 구간형
+// 진행바로 "3개 중 몇 개 완료"만 한눈에 보여줌 — 3/3이면 완료와 같은 초록, 일부만 됐으면
+// 진행중과 같은 주황, 하나도 안 됐으면 무채색(공용 컴포넌트: SegmentedProgressBar)
+const ReadinessProgress = ({ readiness }: { readiness: FloorReadiness }) => {
   if (readiness.isLoading) return <span className={styles.metaValue}>—</span>;
   const doneCount = [
     readiness.hasStartNode,
     readiness.hasFinalExit,
     readiness.hasRouteToExit,
   ].filter(Boolean).length;
-  const text = `${doneCount}/3`;
-  if (doneCount === 3) return <span className={styles.metaValueDone}>{text}</span>;
-  if (doneCount === 0) return <span className={styles.metaValue}>{text}</span>;
-  return <span className={styles.metaValuePending}>{text}</span>;
+  const tone = doneCount === 3 ? 'done' : doneCount === 0 ? 'neutral' : 'progress';
+  return (
+    <SegmentedProgressBar
+      total={3}
+      completed={doneCount}
+      tone={tone}
+      className={styles.readinessProgressBar}
+      aria-label={`등록 요건 ${doneCount}/3 완료`}
+    />
+  );
 };
 
 interface FloorSummary {
@@ -132,7 +139,7 @@ const FloorCard = ({ floor, buildingId, buildingName, onUpload, onReupload }: Fl
         {isDone && (
           <div className={styles.metaRow}>
             <span className={styles.metaKey}>등록 요건</span>
-            <ReadinessCountText readiness={readiness} />
+            <ReadinessProgress readiness={readiness} />
           </div>
         )}
       </div>

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -14,6 +14,7 @@ import type { StatusBadgeColor } from '@components/chip/StatusBadge';
 import EmptyState from '@components/empty';
 import LoadingState from '@components/loadingState';
 import SegmentedProgressBar from '@components/progress/SegmentedProgressBar';
+import Skeleton from '@components/skeleton/Skeleton';
 import useToast from '@components/toast/useToast';
 
 import { ROUTES } from '@constants/path';
@@ -56,7 +57,11 @@ const AiStatusText = ({ status }: { status: SegmentationStatus | null }) => {
 // 진행바로 "3개 중 몇 개 완료"만 한눈에 보여줌 — 3/3이면 완료와 같은 초록, 일부만 됐으면
 // 진행중과 같은 주황, 하나도 안 됐으면 무채색(공용 컴포넌트: SegmentedProgressBar)
 const ReadinessProgress = ({ readiness }: { readiness: FloorReadiness }) => {
-  if (readiness.isLoading) return <span className={styles.metaValue}>—</span>;
+  // 카드마다 조회가 따로 돌아 완료 시점이 제각각이라, 로딩 중엔 빈 값(—) 대신 자리표시자를
+  // 보여줘서 도착한 카드부터 하나씩 팝업하는 느낌 대신 "다 같이 준비 중"으로 보이게 함
+  if (readiness.isLoading) {
+    return <Skeleton width="4rem" height="0.5rem" className={styles.readinessProgressBar} />;
+  }
   const doneCount = [
     readiness.hasStartNode,
     readiness.hasFinalExit,

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -53,14 +53,27 @@ const AiStatusText = ({ status }: { status: SegmentationStatus | null }) => {
   return <span className={styles.metaValue}>—</span>;
 };
 
+interface ReadinessProgressProps {
+  readiness: FloorReadiness;
+}
+
 // 항목별 내역(시작 노드·최종 탈출구·탈출 경로)은 상세보기에서 보여주고, 카드에서는 구간형
 // 진행바로 "3개 중 몇 개 완료"만 한눈에 보여줌 — 3/3이면 완료와 같은 초록, 일부만 됐으면
 // 진행중과 같은 주황, 하나도 안 됐으면 무채색(공용 컴포넌트: SegmentedProgressBar)
-const ReadinessProgress = ({ readiness }: { readiness: FloorReadiness }) => {
+const ReadinessProgress = ({ readiness }: ReadinessProgressProps) => {
   // 카드마다 조회가 따로 돌아 완료 시점이 제각각이라, 로딩 중엔 빈 값(—) 대신 자리표시자를
   // 보여줘서 도착한 카드부터 하나씩 팝업하는 느낌 대신 "다 같이 준비 중"으로 보이게 함
   if (readiness.isLoading) {
     return <Skeleton width="4rem" height="0.5rem" className={styles.readinessProgressBar} />;
+  }
+  // 조회 자체가 실패한 경우 "0/3 미완료"처럼 보이면 실제로 요건이 하나도 없는 것과 헷갈림 —
+  // 별도로 실패를 알려주고 0/3으로 단정하지 않음
+  if (readiness.isError) {
+    return (
+      <span className={styles.metaValueFailed} title="등록 요건을 불러오지 못했어요">
+        조회 실패
+      </span>
+    );
   }
   const doneCount = [
     readiness.hasStartNode,

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -21,12 +21,14 @@ import { formatFloor, hasFloorPlan } from '@utils/floor';
 
 import { setFloorGrid } from './api/floorGridApi';
 import { analyzeFloor, getFloorBuildings, uploadFloor } from './api/floorPlansApi';
+import { useFloorReadinessQuery } from './api/useFloorReadinessQuery';
 import * as styles from './FloorPlansPage.css';
 import FloorReuploadConfirmModal from './modals/FloorReuploadConfirmModal';
 import FloorUploadModal from './modals/FloorUploadModal';
 import GridAreaSettingModal from './modals/GridAreaSettingModal';
 import { rememberPendingGridSize } from './utils/gridStorage';
 
+import type { FloorReadiness } from './api/useFloorReadinessQuery';
 import type { FloorBuilding, SegmentationStatus } from './types/floorPlans';
 
 const NONE_STATUS_BADGE: { label: string; color: StatusBadgeColor } = {
@@ -41,21 +43,28 @@ const STATUS_CONFIG: Record<SegmentationStatus, { label: string; color: StatusBa
   FAILED: { label: '실패', color: 'red' },
 };
 
-const formatDate = (iso: string | null) => {
-  if (!iso) return '—';
-  const date = new Date(iso);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
 const AiStatusText = ({ status }: { status: SegmentationStatus | null }) => {
   if (status === 'DONE') return <span className={styles.metaValueDone}>완료</span>;
   if (status === 'PENDING') return <span className={styles.metaValuePending}>대기중</span>;
   if (status === 'PROCESSING') return <span className={styles.metaValuePending}>처리중</span>;
   if (status === 'FAILED') return <span className={styles.metaValueFailed}>실패</span>;
   return <span className={styles.metaValue}>—</span>;
+};
+
+// 항목별 내역(시작 노드·최종 탈출구·탈출 경로)은 상세보기에서 보여주고, 카드에서는 AI 분석과
+// 같은 한 줄 형태로 개수만 요약함 — 3/3이면 완료와 같은 초록, 일부만 됐으면 진행중과 같은
+// 주황, 하나도 안 됐으면 무채색
+const ReadinessCountText = ({ readiness }: { readiness: FloorReadiness }) => {
+  if (readiness.isLoading) return <span className={styles.metaValue}>—</span>;
+  const doneCount = [
+    readiness.hasStartNode,
+    readiness.hasFinalExit,
+    readiness.hasRouteToExit,
+  ].filter(Boolean).length;
+  const text = `${doneCount}/3`;
+  if (doneCount === 3) return <span className={styles.metaValueDone}>{text}</span>;
+  if (doneCount === 0) return <span className={styles.metaValue}>{text}</span>;
+  return <span className={styles.metaValuePending}>{text}</span>;
 };
 
 interface FloorSummary {
@@ -99,6 +108,8 @@ const FloorCard = ({ floor, buildingId, buildingName, onUpload, onReupload }: Fl
   const isNone = !hasFloorPlan(floor);
   const { label, color } = isNone ? NONE_STATUS_BADGE : STATUS_CONFIG[floor.segmentationStatus];
   const isDone = floor.segmentationStatus === 'DONE';
+  // AI 분석이 끝나야 노드를 등록할 수 있어서, 그 전 층은 그래프를 조회할 필요가 없음
+  const readiness = useFloorReadinessQuery(floor.id, isDone);
 
   return (
     <div className={styles.floorCard}>
@@ -115,13 +126,15 @@ const FloorCard = ({ floor, buildingId, buildingName, onUpload, onReupload }: Fl
 
       <div className={styles.cardMeta}>
         <div className={styles.metaRow}>
-          <span className={styles.metaKey}>업로드</span>
-          <span className={styles.metaValue}>{formatDate(floor.processedAt)}</span>
-        </div>
-        <div className={styles.metaRow}>
           <span className={styles.metaKey}>AI 분석</span>
           <AiStatusText status={isNone ? null : floor.segmentationStatus} />
         </div>
+        {isDone && (
+          <div className={styles.metaRow}>
+            <span className={styles.metaKey}>등록 요건</span>
+            <ReadinessCountText readiness={readiness} />
+          </div>
+        )}
       </div>
 
       {isNone ? (

--- a/src/pages/floorPlans/api/floorPlansApi.ts
+++ b/src/pages/floorPlans/api/floorPlansApi.ts
@@ -9,7 +9,7 @@ import {
 
 import type { Floor, FloorBuilding } from '../types/floorPlans';
 
-// devices/pois는 CCTV·IoT·맵그래프 API 연동 전까지 빈 배열로 둠 (다음 단위에서 채울 예정)
+// devices는 CCTV·IoT·맵그래프 API 연동 전까지 빈 배열로 둠 (다음 단위에서 채울 예정)
 interface FloorSource {
   id?: string;
   floorNum?: number;
@@ -34,7 +34,6 @@ export const toFloor = (response: FloorSource, buildingId: string): Floor => {
     segmentationStatus,
     processedAt: processedAt ?? null,
     devices: [],
-    pois: [],
   };
 };
 
@@ -115,4 +114,3 @@ export async function analyzeFloor(floorId: string): Promise<void> {
 }
 
 export { getFloorImageUrl };
-export type { FloorImageUrl } from '@apis/floors/floorsApi';

--- a/src/pages/floorPlans/api/useFloorReadinessQuery.ts
+++ b/src/pages/floorPlans/api/useFloorReadinessQuery.ts
@@ -5,13 +5,16 @@ export interface FloorReadiness {
   hasFinalExit: boolean;
   hasRouteToExit: boolean;
   isLoading: boolean;
+  // 조회 실패 시 호출부가 "0/3 미완료"가 아니라 별도의 오류 상태로 구분해서 보여줄 수 있게 함 —
+  // 그래프가 비어서 진짜 0/3인지, 조회 자체가 실패해서 데이터를 모르는 건지는 다른 상황임
+  isError: boolean;
 }
 
 // 도면 상세의 훈련 준비 체크리스트와 같은 조건(시작 노드/최종 탈출구/그 사이 경로)을 목록
 // 카드에서도 보여주기 위해 재사용 — 경로가 없으면 경로 탐색기가 EVAC005("도달 가능한 EXIT
 // 노드가 없습니다")로 실패하므로, 시작 노드가 그래프에 연결만 안 돼 있어도 여기서 걸림
 export const useFloorReadinessQuery = (floorId: string, enabled = true): FloorReadiness => {
-  const { data, isLoading } = useFloorGraphQuery(floorId, enabled);
+  const { data, isLoading, isError } = useFloorGraphQuery(floorId, enabled);
   const nodes = data?.nodes ?? [];
   const edges = data?.edges ?? [];
 
@@ -52,5 +55,6 @@ export const useFloorReadinessQuery = (floorId: string, enabled = true): FloorRe
     hasFinalExit: exitIds.size > 0,
     hasRouteToExit,
     isLoading,
+    isError,
   };
 };

--- a/src/pages/floorPlans/api/useFloorReadinessQuery.ts
+++ b/src/pages/floorPlans/api/useFloorReadinessQuery.ts
@@ -1,0 +1,56 @@
+import { useFloorGraphQuery } from '@apis/floors/floorQueries';
+
+export interface FloorReadiness {
+  hasStartNode: boolean;
+  hasFinalExit: boolean;
+  hasRouteToExit: boolean;
+  isLoading: boolean;
+}
+
+// 도면 상세의 훈련 준비 체크리스트와 같은 조건(시작 노드/최종 탈출구/그 사이 경로)을 목록
+// 카드에서도 보여주기 위해 재사용 — 경로가 없으면 경로 탐색기가 EVAC005("도달 가능한 EXIT
+// 노드가 없습니다")로 실패하므로, 시작 노드가 그래프에 연결만 안 돼 있어도 여기서 걸림
+export const useFloorReadinessQuery = (floorId: string, enabled = true): FloorReadiness => {
+  const { data, isLoading } = useFloorGraphQuery(floorId, enabled);
+  const nodes = data?.nodes ?? [];
+  const edges = data?.edges ?? [];
+
+  const startNodes = nodes.filter((n) => n.type === 'START');
+  const exitIds = new Set(nodes.filter((n) => n.type === 'EXIT').map((n) => n.id));
+
+  const hasRouteToExit = (() => {
+    if (startNodes.length === 0 || exitIds.size === 0) return false;
+    const adjacency = new Map<string, string[]>();
+    const link = (from: string, to: string) => {
+      const list = adjacency.get(from);
+      if (list) list.push(to);
+      else adjacency.set(from, [to]);
+    };
+    for (const edge of edges) {
+      link(edge.fromNodeId, edge.toNodeId);
+      if (edge.bidirectional) link(edge.toNodeId, edge.fromNodeId);
+    }
+    return startNodes.some((start) => {
+      const visited = new Set([start.id]);
+      const queue = [start.id];
+      while (queue.length > 0) {
+        const current = queue.shift() as string;
+        if (exitIds.has(current)) return true;
+        for (const next of adjacency.get(current) ?? []) {
+          if (!visited.has(next)) {
+            visited.add(next);
+            queue.push(next);
+          }
+        }
+      }
+      return false;
+    });
+  })();
+
+  return {
+    hasStartNode: startNodes.length > 0,
+    hasFinalExit: exitIds.size > 0,
+    hasRouteToExit,
+    isLoading,
+  };
+};

--- a/src/pages/floorPlans/components/ReadinessChecklist.css.ts
+++ b/src/pages/floorPlans/components/ReadinessChecklist.css.ts
@@ -72,3 +72,16 @@ export const readinessActionBtn = style({
     '&:hover': { backgroundColor: vars.color.primaryLight2 },
   },
 });
+
+// 앞 단계(시작 노드·최종 탈출구)가 안 끝나 지금은 누를 수 없는 상태 — 항목 자체는 계속
+// 보여주되, 버튼을 회색으로 바꾸고 라벨에 뭘 먼저 해야 하는지 안내함
+export const readinessActionBtnDisabled = style({
+  flexShrink: 0,
+  border: `1px solid ${vars.color.gray100}`,
+  borderRadius: vars.radius.pill,
+  backgroundColor: vars.color.gray50,
+  cursor: 'not-allowed',
+  padding: `0.2rem ${vars.space.s3}`,
+  color: vars.color.textLow,
+  ...vars.typography.caption,
+});

--- a/src/pages/floorPlans/components/ReadinessChecklist.css.ts
+++ b/src/pages/floorPlans/components/ReadinessChecklist.css.ts
@@ -24,35 +24,6 @@ export const readinessHint = style({
   ...vars.typography.caption,
 });
 
-export const readinessItem = style({
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  gap: vars.space.s2,
-  borderTop: `1px solid ${vars.color.gray50}`,
-  paddingTop: vars.space.s2,
-});
-
-export const readinessItemLabel = style({
-  display: 'flex',
-  alignItems: 'center',
-  gap: vars.space.s2,
-  color: vars.color.textHigh,
-  ...vars.typography.body14,
-});
-
-export const readinessDot = style({
-  flexShrink: 0,
-  borderRadius: '50%',
-  backgroundColor: vars.color.gray300,
-  width: '0.7rem',
-  height: '0.7rem',
-});
-
-export const readinessDotDone = style({
-  backgroundColor: vars.color.success,
-});
-
 export const readinessDoneText = style({
   flexShrink: 0,
   color: vars.color.textLow,

--- a/src/pages/floorPlans/components/ReadinessChecklist.css.ts
+++ b/src/pages/floorPlans/components/ReadinessChecklist.css.ts
@@ -56,3 +56,15 @@ export const readinessActionBtnDisabled = style({
   color: vars.color.textLow,
   ...vars.typography.caption,
 });
+
+// 비활성 버튼이 왜 눌리지 않는지 설명하는 문구 — title 속성은 비활성 버튼에서 포커스를 못 받아
+// 스크린리더·키보드 사용자에게 일관되게 노출되지 않으므로, aria-describedby로 항상 연결되는
+// 화면에서만 숨긴(시각적으로는 안 보이는) 문구로 대신함
+export const readinessDisabledHint = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  clip: 'rect(0, 0, 0, 0)',
+});

--- a/src/pages/floorPlans/components/ReadinessChecklist.tsx
+++ b/src/pages/floorPlans/components/ReadinessChecklist.tsx
@@ -36,14 +36,9 @@ const ReadinessChecklist = ({
   onConnectEdges,
 }: ReadinessChecklistProps) => {
   // 시작/탈출구가 모두 준비돼야 엣지 연결 버튼을 누를 수 있음 — 그 전엔 항목은 보이되
-  // 버튼을 비활성화하고 뭘 먼저 해야 하는지 안내함
+  // 버튼을 비활성화함. 안내 문구는 "탈출 경로" 라벨과 한 줄에 나란히 있어 길면 라벨 쪽이
+  // 깨져 보이므로 짧게 고정된 문구만 씀(뭐가 부족한지는 위 두 항목에서 이미 보임)
   const canConnectRoute = hasStartNode && hasFinalExit;
-  const routeBlockedLabel =
-    !hasStartNode && !hasFinalExit
-      ? '시작 노드·최종 탈출구 먼저 설정'
-      : !hasStartNode
-        ? '시작 노드 먼저 설정'
-        : '최종 탈출구 먼저 설정';
 
   return (
     <div className={styles.readinessCard}>
@@ -97,7 +92,7 @@ const ReadinessChecklist = ({
           </button>
         ) : (
           <button type="button" className={styles.readinessActionBtnDisabled} disabled>
-            {routeBlockedLabel}
+            엣지 추가하기
           </button>
         )}
       </div>

--- a/src/pages/floorPlans/components/ReadinessChecklist.tsx
+++ b/src/pages/floorPlans/components/ReadinessChecklist.tsx
@@ -1,11 +1,13 @@
-import clsx from 'clsx';
+import StepProgress from '@components/progress/StepProgress';
+import type { ProgressStep } from '@components/progress/StepProgress';
 
 import * as styles from './ReadinessChecklist.css';
 
 // 훈련 준비 — 시나리오를 재생하려면 이 층에 ①시작 노드(후보) ②최종 탈출구(계단) ③시작
 // 지점에서 최종 탈출구까지 이어지는 엣지 경로가 있어야 함. 이 셋이 노드추가 팝업 안 칩,
 // 우측 패널 카드 토글, 엣지 연결 모드로 흩어져 있어 뭐가 필요한지 안 보이던 문제를 여기
-// 한 곳에 모아서 해결함.
+// 한 곳에 모아서 해결함. 순서가 있는 준비 단계라 공용 StepProgress(원형 마커 + 연결선)로
+// 표시하고, 각 단계 라벨 옆에는 실제로 그 단계를 처리할 수 있는 버튼을 그대로 붙임.
 //
 // 발화점 항목은 뺐음 — 팀 전달사항(2026-09-03)으로 발화점 등록 API(POST
 // /scenarios/{scenarioId}/fire-zones)가 백엔드에서 완전히 제거됐고, 도면관리 화면은 더 이상
@@ -36,9 +38,52 @@ const ReadinessChecklist = ({
   onConnectEdges,
 }: ReadinessChecklistProps) => {
   // 시작/탈출구가 모두 준비돼야 엣지 연결 버튼을 누를 수 있음 — 그 전엔 항목은 보이되
-  // 버튼을 비활성화함. 안내 문구는 "탈출 경로" 라벨과 한 줄에 나란히 있어 길면 라벨 쪽이
-  // 깨져 보이므로 짧게 고정된 문구만 씀(뭐가 부족한지는 위 두 항목에서 이미 보임)
+  // 버튼을 비활성화함(안내 문구는 짧게 고정 — 뭐가 부족한지는 위 두 항목에서 이미 보임)
   const canConnectRoute = hasStartNode && hasFinalExit;
+
+  const steps: ProgressStep[] = [
+    {
+      label: '시작 노드',
+      status: hasStartNode ? 'done' : 'current',
+      action: hasStartNode ? (
+        <span className={styles.readinessDoneText}>완료</span>
+      ) : (
+        <button type="button" className={styles.readinessActionBtn} onClick={onAddStartNode}>
+          지정하기
+        </button>
+      ),
+    },
+    {
+      label: '최종 탈출구',
+      status: hasFinalExit ? 'done' : 'current',
+      action: hasFinalExit ? (
+        <span className={styles.readinessDoneText}>완료</span>
+      ) : !hasStair ? (
+        <button type="button" className={styles.readinessActionBtn} onClick={onAddStair}>
+          계단 추가하기
+        </button>
+      ) : (
+        <button type="button" className={styles.readinessActionBtn} onClick={onFocusDeviceCards}>
+          카드에서 지정
+        </button>
+      ),
+    },
+    {
+      label: '탈출 경로',
+      status: hasRouteToExit ? 'done' : canConnectRoute ? 'current' : 'upcoming',
+      action: hasRouteToExit ? (
+        <span className={styles.readinessDoneText}>완료</span>
+      ) : canConnectRoute ? (
+        <button type="button" className={styles.readinessActionBtn} onClick={onConnectEdges}>
+          엣지 연결
+        </button>
+      ) : (
+        <button type="button" className={styles.readinessActionBtnDisabled} disabled>
+          엣지 추가하기
+        </button>
+      ),
+    },
+  ];
 
   return (
     <div className={styles.readinessCard}>
@@ -47,55 +92,7 @@ const ReadinessChecklist = ({
         시나리오를 재생하려면 이 층에 아래 항목이 필요해요
       </span>
 
-      <div className={styles.readinessItem}>
-        <div className={styles.readinessItemLabel}>
-          <span className={clsx(styles.readinessDot, hasStartNode && styles.readinessDotDone)} />
-          시작 노드
-        </div>
-        {hasStartNode ? (
-          <span className={styles.readinessDoneText}>완료</span>
-        ) : (
-          <button type="button" className={styles.readinessActionBtn} onClick={onAddStartNode}>
-            지정하기
-          </button>
-        )}
-      </div>
-
-      <div className={styles.readinessItem}>
-        <div className={styles.readinessItemLabel}>
-          <span className={clsx(styles.readinessDot, hasFinalExit && styles.readinessDotDone)} />
-          최종 탈출구
-        </div>
-        {hasFinalExit ? (
-          <span className={styles.readinessDoneText}>완료</span>
-        ) : !hasStair ? (
-          <button type="button" className={styles.readinessActionBtn} onClick={onAddStair}>
-            계단 추가하기
-          </button>
-        ) : (
-          <button type="button" className={styles.readinessActionBtn} onClick={onFocusDeviceCards}>
-            카드에서 지정
-          </button>
-        )}
-      </div>
-
-      <div className={styles.readinessItem}>
-        <div className={styles.readinessItemLabel}>
-          <span className={clsx(styles.readinessDot, hasRouteToExit && styles.readinessDotDone)} />
-          탈출 경로
-        </div>
-        {hasRouteToExit ? (
-          <span className={styles.readinessDoneText}>완료</span>
-        ) : canConnectRoute ? (
-          <button type="button" className={styles.readinessActionBtn} onClick={onConnectEdges}>
-            엣지 연결
-          </button>
-        ) : (
-          <button type="button" className={styles.readinessActionBtnDisabled} disabled>
-            엣지 추가하기
-          </button>
-        )}
-      </div>
+      <StepProgress steps={steps} />
     </div>
   );
 };

--- a/src/pages/floorPlans/components/ReadinessChecklist.tsx
+++ b/src/pages/floorPlans/components/ReadinessChecklist.tsx
@@ -78,9 +78,19 @@ const ReadinessChecklist = ({
           엣지 연결
         </button>
       ) : (
-        <button type="button" className={styles.readinessActionBtnDisabled} disabled>
-          엣지 추가하기
-        </button>
+        <>
+          <button
+            type="button"
+            className={styles.readinessActionBtnDisabled}
+            disabled
+            aria-describedby="readiness-edge-disabled-hint"
+          >
+            엣지 추가하기
+          </button>
+          <span id="readiness-edge-disabled-hint" className={styles.readinessDisabledHint}>
+            시작 노드와 최종 탈출구를 먼저 지정해주세요
+          </span>
+        </>
       ),
     },
   ];

--- a/src/pages/floorPlans/components/ReadinessChecklist.tsx
+++ b/src/pages/floorPlans/components/ReadinessChecklist.tsx
@@ -12,8 +12,8 @@ import * as styles from './ReadinessChecklist.css';
 // 발화점을 다루지 않음.
 //
 // 경로(엣지) 항목: 시작 노드·최종 탈출구가 있어도 둘을 잇는 엣지가 없으면 경로 탐색기가
-// EVAC005("도달 가능한 EXIT 노드가 없습니다")로 실패함 — 시작/탈출구가 준비된 뒤에만
-// 의미가 있어 그 전에는 표시하지 않음.
+// EVAC005("도달 가능한 EXIT 노드가 없습니다")로 실패함 — 세 항목이 뭐가 필요한지 한눈에
+// 보이도록 앞 단계가 안 끝났어도 항목 자체는 항상 보여주고, 버튼만 비활성화해서 안내함
 interface ReadinessChecklistProps {
   hasStartNode: boolean;
   hasFinalExit: boolean;
@@ -35,8 +35,15 @@ const ReadinessChecklist = ({
   onFocusDeviceCards,
   onConnectEdges,
 }: ReadinessChecklistProps) => {
-  // 시작/탈출구가 모두 준비돼야 경로 연결을 물을 단계 — 그 전엔 위 두 항목부터 안내
-  const showRouteItem = hasStartNode && hasFinalExit;
+  // 시작/탈출구가 모두 준비돼야 엣지 연결 버튼을 누를 수 있음 — 그 전엔 항목은 보이되
+  // 버튼을 비활성화하고 뭘 먼저 해야 하는지 안내함
+  const canConnectRoute = hasStartNode && hasFinalExit;
+  const routeBlockedLabel =
+    !hasStartNode && !hasFinalExit
+      ? '시작 노드·최종 탈출구 먼저 설정'
+      : !hasStartNode
+        ? '시작 노드 먼저 설정'
+        : '최종 탈출구 먼저 설정';
 
   return (
     <div className={styles.readinessCard}>
@@ -77,23 +84,23 @@ const ReadinessChecklist = ({
         )}
       </div>
 
-      {showRouteItem && (
-        <div className={styles.readinessItem}>
-          <div className={styles.readinessItemLabel}>
-            <span
-              className={clsx(styles.readinessDot, hasRouteToExit && styles.readinessDotDone)}
-            />
-            시작 지점 → 탈출구 경로
-          </div>
-          {hasRouteToExit ? (
-            <span className={styles.readinessDoneText}>완료</span>
-          ) : (
-            <button type="button" className={styles.readinessActionBtn} onClick={onConnectEdges}>
-              엣지 연결
-            </button>
-          )}
+      <div className={styles.readinessItem}>
+        <div className={styles.readinessItemLabel}>
+          <span className={clsx(styles.readinessDot, hasRouteToExit && styles.readinessDotDone)} />
+          탈출 경로
         </div>
-      )}
+        {hasRouteToExit ? (
+          <span className={styles.readinessDoneText}>완료</span>
+        ) : canConnectRoute ? (
+          <button type="button" className={styles.readinessActionBtn} onClick={onConnectEdges}>
+            엣지 연결
+          </button>
+        ) : (
+          <button type="button" className={styles.readinessActionBtnDisabled} disabled>
+            {routeBlockedLabel}
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/floorPlans/constants/deviceColors.ts
+++ b/src/pages/floorPlans/constants/deviceColors.ts
@@ -1,0 +1,13 @@
+// 노드/장비 종류별 대표 색상 — TSX(SVG fill·DEVICE_PLACE_CONFIG)와 CSS(vanilla-extract 점 색상)
+// 양쪽에서 같은 값을 써야 범례 점과 실제 도면 마커 색이 어긋나지 않음. SVG의 fill 속성은
+// vanilla-extract 클래스를 쓸 수 없어 클래스가 아닌 상수로 공유함(코드래빗 리뷰 반영)
+export const DEVICE_COLOR = {
+  cctv: '#8b5cf6',
+  // 계단(stair, #f97316)과 같은 주황 계열이라 구분이 안 된다는 피드백 — 노란색으로 분리
+  light: '#eab308',
+  door: '#2563eb',
+  stair: '#f97316',
+  hallway: '#0891b2',
+  // "시작 노드"가 아니라 "시작 후보"로 부름 — 실제 훈련 시작점 확정은 시나리오설정에서 함
+  start: '#db2777',
+} as const;

--- a/src/pages/floorPlans/modals/FloorUploadModal.tsx
+++ b/src/pages/floorPlans/modals/FloorUploadModal.tsx
@@ -7,6 +7,8 @@ import UploadIcon from '@assets/icons/ic-upload.svg?react';
 import { Button } from '@components/Button';
 import Modal from '@components/modal';
 
+import { formatFloor } from '@utils/floor';
+
 import * as styles from './FloorUploadModal.css';
 
 interface FloorUploadModalProps {
@@ -21,12 +23,6 @@ const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png'] as const;
 
 const isAcceptedImageType = (type: string): boolean =>
   (ACCEPTED_IMAGE_TYPES as readonly string[]).includes(type);
-
-const formatFloor = (floorNum: number) => {
-  if (floorNum > 0) return `${floorNum}층`;
-  if (floorNum < 0) return `B${Math.abs(floorNum)}층`;
-  return '1층';
-};
 
 const FloorUploadModal = ({
   open,

--- a/src/pages/floorPlans/types/floorPlans.ts
+++ b/src/pages/floorPlans/types/floorPlans.ts
@@ -3,12 +3,6 @@ export type SegmentationStatus = 'PENDING' | 'PROCESSING' | 'DONE' | 'FAILED';
 
 export type DeviceType = 'cctv' | 'iot' | 'fire';
 
-export type PoiType = 'exit' | 'stair' | 'fire_zone';
-
-export type EditMode = 'view' | 'poi' | 'simulation';
-
-export type AiLayer = 'wall' | 'corridor' | 'stairwell' | 'exit' | 'room';
-
 export interface DeviceMarker {
   id: string;
   type: DeviceType;
@@ -21,14 +15,6 @@ export interface DeviceMarker {
   zone: string;
 }
 
-export interface PoiMarker {
-  id: string;
-  type: PoiType;
-  label: string;
-  x: number;
-  y: number;
-}
-
 export interface Floor {
   id: string;
   buildingId: string;
@@ -37,7 +23,6 @@ export interface Floor {
   segmentationStatus: SegmentationStatus;
   processedAt: string | null;
   devices: DeviceMarker[];
-  pois: PoiMarker[];
 }
 
 export interface FloorBuilding {

--- a/src/pages/trainingAnalysis/TrainingCameraFramesPage.css.ts
+++ b/src/pages/trainingAnalysis/TrainingCameraFramesPage.css.ts
@@ -334,10 +334,15 @@ export const emptyEvents = style({
   ...vars.typography.body14,
 });
 
+// 이벤트가 쌓일수록 패널이 끝없이 길어져 페이지 전체가 늘어지던 문제 — 높이를 고정하고
+// 목록 안에서만 스크롤되게 함
 export const timelineList = style({
   display: 'flex',
   flexDirection: 'column',
   gap: vars.space.s3,
+  paddingRight: vars.space.s2,
+  maxHeight: '28rem',
+  overflowY: 'auto',
 });
 
 export const timelineItem = style({

--- a/src/shared/apis/floors/floorGridApi.ts
+++ b/src/shared/apis/floors/floorGridApi.ts
@@ -41,21 +41,28 @@ export const toFloorGridCell = (response: FloorGridCellResponse): FloorGridCell 
 
 const GRID_CELLS_PAGE_SIZE = 2000;
 
-export const getFloorGridCells = async (floorId: string, signal?: AbortSignal) => {
-  const cells: FloorGridCell[] = [];
-  let page = 0;
-  let isLastPage = false;
+const requestGridCellsPage = (floorId: string, page: number, signal?: AbortSignal) =>
+  request<FloorGridCellPageResponse>({
+    method: HTTP_METHOD.GET,
+    url: API_ENDPOINTS.FLOOR_GRID.CELLS(floorId),
+    query: { page, size: GRID_CELLS_PAGE_SIZE },
+    signal,
+  });
 
-  while (!isLastPage) {
-    const response = await request<FloorGridCellPageResponse>({
-      method: HTTP_METHOD.GET,
-      url: API_ENDPOINTS.FLOOR_GRID.CELLS(floorId),
-      query: { page, size: GRID_CELLS_PAGE_SIZE },
-      signal,
-    });
+export const getFloorGridCells = async (floorId: string, signal?: AbortSignal) => {
+  const first = await requestGridCellsPage(floorId, 0, signal);
+  const cells: FloorGridCell[] = (first.content ?? []).map(toFloorGridCell);
+  if (first.last ?? true) return cells;
+
+  // 이전엔 페이지를 하나씩 순서대로 기다려서, 그리드 배율을 작게 잡아 셀이 많아진 층은
+  // 페이지 수만큼 왕복이 쌓여 "요청이 끝없이 올라오고" 로딩이 멈춘 것처럼 보였음 — 첫 페이지
+  // 응답의 totalElements로 남은 페이지 수를 미리 알 수 있으니, 나머지는 한 번에 병렬로 요청함
+  const totalPages = Math.max(1, Math.ceil((first.totalElements ?? 0) / GRID_CELLS_PAGE_SIZE));
+  const remainingPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) => requestGridCellsPage(floorId, i + 1, signal)),
+  );
+  for (const response of remainingPages) {
     cells.push(...(response.content ?? []).map(toFloorGridCell));
-    isLastPage = response.last ?? true;
-    page += 1;
   }
 
   return cells;

--- a/src/shared/apis/floors/floorGridApi.ts
+++ b/src/shared/apis/floors/floorGridApi.ts
@@ -40,6 +40,9 @@ export const toFloorGridCell = (response: FloorGridCellResponse): FloorGridCell 
 };
 
 const GRID_CELLS_PAGE_SIZE = 2000;
+// 배율을 작게 잡아 셀이 아주 많은 층(수십 페이지)에서 남은 페이지를 전부 한 번에 쏘면 브라우저·
+// 서버 동시 요청이 과도해질 수 있어(코드래빗 리뷰 반영), 이 개수만큼씩 나눠서 순차 처리함
+const MAX_CONCURRENT_PAGE_REQUESTS = 4;
 
 const requestGridCellsPage = (floorId: string, page: number, signal?: AbortSignal) =>
   request<FloorGridCellPageResponse>({
@@ -56,13 +59,19 @@ export const getFloorGridCells = async (floorId: string, signal?: AbortSignal) =
 
   // 이전엔 페이지를 하나씩 순서대로 기다려서, 그리드 배율을 작게 잡아 셀이 많아진 층은
   // 페이지 수만큼 왕복이 쌓여 "요청이 끝없이 올라오고" 로딩이 멈춘 것처럼 보였음 — 첫 페이지
-  // 응답의 totalElements로 남은 페이지 수를 미리 알 수 있으니, 나머지는 한 번에 병렬로 요청함
+  // 응답의 totalElements로 남은 페이지 수를 미리 알 수 있으니, 나머지를 MAX_CONCURRENT_PAGE_REQUESTS개씩
+  // 묶어 병렬로 요청함(전부 한꺼번에 쏘지는 않음)
   const totalPages = Math.max(1, Math.ceil((first.totalElements ?? 0) / GRID_CELLS_PAGE_SIZE));
-  const remainingPages = await Promise.all(
-    Array.from({ length: totalPages - 1 }, (_, i) => requestGridCellsPage(floorId, i + 1, signal)),
-  );
-  for (const response of remainingPages) {
-    cells.push(...(response.content ?? []).map(toFloorGridCell));
+  const remainingPageNumbers = Array.from({ length: totalPages - 1 }, (_, i) => i + 1);
+
+  for (let i = 0; i < remainingPageNumbers.length; i += MAX_CONCURRENT_PAGE_REQUESTS) {
+    const batch = remainingPageNumbers.slice(i, i + MAX_CONCURRENT_PAGE_REQUESTS);
+    const responses = await Promise.all(
+      batch.map((page) => requestGridCellsPage(floorId, page, signal)),
+    );
+    for (const response of responses) {
+      cells.push(...(response.content ?? []).map(toFloorGridCell));
+    }
   }
 
   return cells;

--- a/src/shared/assets/icons/ic-info.svg
+++ b/src/shared/assets/icons/ic-info.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 19.25C15.5563 19.25 19.25 15.5563 19.25 11C19.25 6.44365 15.5563 2.75 11 2.75C6.44365 2.75 2.75 6.44365 2.75 11C2.75 15.5563 6.44365 19.25 11 19.25Z" stroke="currentColor" stroke-width="1.55833" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 9.90002V15.1834" stroke="currentColor" stroke-width="1.55833" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 7.3335V7.79183" stroke="currentColor" stroke-width="1.55833" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/components/dropdown/Dropdown.css.ts
+++ b/src/shared/components/dropdown/Dropdown.css.ts
@@ -68,8 +68,11 @@ export const chevron = style({
 });
 
 export const panel = style({
-  // document.body에 포탈로 렌더링되고 top/left/width는 인라인 스타일(뷰포트 좌표)로 정해짐 —
-  // 모달 등 overflow: hidden 조상 안에서 열려도 잘리지 않게 함
+  // document.body에 포탈로 렌더링되고 top/left/width(+maxHeight)는 인라인 스타일(뷰포트 좌표)로
+  // 정해짐 — 모달 등 overflow: hidden 조상 안에서 열려도 잘리지 않게 함.
+  // maxHeight 없이 overflow: hidden만 있으면 옵션이 많을 때 화면 아래로 넘친 항목이 스크롤도
+  // 안 되고 그냥 안 보여서 "목록에 없다"고 오해하기 쉬웠음(코드래빗 아님, 실사용 버그 리포트) —
+  // 세로 공간이 부족하면 트리거 위로 뒤집어 열리도록 이제 JS에서 maxHeight를 계산해 내려줌
   position: 'fixed',
   zIndex: 200,
   borderRadius: vars.radius.lg,
@@ -77,7 +80,7 @@ export const panel = style({
   backgroundColor: vars.color.white,
   padding: 0,
   minWidth: '18rem',
-  overflow: 'hidden',
+  overflowY: 'auto',
 });
 
 export const option = style({

--- a/src/shared/components/dropdown/Dropdown.tsx
+++ b/src/shared/components/dropdown/Dropdown.tsx
@@ -12,7 +12,15 @@ interface PanelRect {
   top: number;
   left: number;
   width: number;
+  maxHeight: number;
 }
+
+const PANEL_GAP = 4;
+// 옵션이 많을 때 패널이 화면 아래로 무한정 늘어나지 않도록 잡아두는 상한 — 트리거 위/아래
+// 여유 공간이 이보다 넓으면 이 값을, 좁으면 실제 여유 공간을 그대로 씀(아래 계산 참고)
+const PANEL_MAX_HEIGHT_CAP = 280;
+// 트리거 아래 공간이 이보다 좁으면 위로 뒤집어 여는 편이 나음
+const PANEL_FLIP_THRESHOLD = 160;
 
 export interface DropdownOption<T extends string = string> {
   label: string;
@@ -66,7 +74,17 @@ const Dropdown = <T extends string = string>({
     const updatePanelRect = () => {
       const rect = containerRef.current?.getBoundingClientRect();
       if (!rect) return;
-      setPanelRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+      const spaceBelow = window.innerHeight - rect.bottom - PANEL_GAP;
+      const spaceAbove = rect.top - PANEL_GAP;
+      const openUpward = spaceBelow < PANEL_FLIP_THRESHOLD && spaceAbove > spaceBelow;
+      const availableSpace = openUpward ? spaceAbove : spaceBelow;
+      const maxHeight = Math.max(120, Math.min(PANEL_MAX_HEIGHT_CAP, availableSpace));
+      setPanelRect({
+        top: openUpward ? rect.top - PANEL_GAP - maxHeight : rect.bottom + PANEL_GAP,
+        left: rect.left,
+        width: rect.width,
+        maxHeight,
+      });
     };
     updatePanelRect();
 
@@ -185,7 +203,12 @@ const Dropdown = <T extends string = string>({
             aria-label={ariaLabel ?? '선택 옵션'}
             aria-activedescendant={`${listboxId}-option-${activeIndex}`}
             onKeyDown={handleListKeyDown}
-            style={{ top: panelRect.top, left: panelRect.left, width: panelRect.width }}
+            style={{
+              top: panelRect.top,
+              left: panelRect.left,
+              width: panelRect.width,
+              maxHeight: panelRect.maxHeight,
+            }}
           >
             {options.map((option, index) => (
               <li

--- a/src/shared/components/progress/SegmentedProgressBar.css.ts
+++ b/src/shared/components/progress/SegmentedProgressBar.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '@styles/global.css';
+
+export const track = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
+  width: '100%',
+});
+
+export const segment = style({
+  flex: 1,
+  borderRadius: vars.radius.pill,
+  backgroundColor: vars.color.gray200,
+  height: '0.5rem',
+});
+
+export const segmentFilled = recipe({
+  base: {
+    backgroundColor: vars.color.primary,
+  },
+  variants: {
+    tone: {
+      neutral: { backgroundColor: vars.color.gray300 },
+      progress: { backgroundColor: vars.color.warning },
+      done: { backgroundColor: vars.color.success },
+    },
+  },
+  defaultVariants: {
+    tone: 'progress',
+  },
+});

--- a/src/shared/components/progress/SegmentedProgressBar.tsx
+++ b/src/shared/components/progress/SegmentedProgressBar.tsx
@@ -1,0 +1,51 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import clsx from 'clsx';
+
+import * as styles from './SegmentedProgressBar.css';
+
+export type SegmentedProgressBarTone = 'neutral' | 'progress' | 'done';
+
+export type SegmentedProgressBarProps = {
+  /** 전체 단계 수 */
+  total: number;
+  /** 완료된 단계 수 (앞에서부터 채움) */
+  completed: number;
+  /** 채워진 구간 색 — 다 됐으면 done, 일부만 됐으면 progress, 하나도 안 됐으면 neutral */
+  tone?: SegmentedProgressBarTone;
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children'>;
+
+// 카드처럼 좁은 자리에서 "N개 중 M개 완료"를 한눈에 보여주기 위한 구간형 진행바.
+// 연속된 퍼센트가 아니라 완료 여부가 뚜렷이 나뉘는 항목(체크리스트류)에 적합함
+const SegmentedProgressBar = ({
+  total,
+  completed,
+  tone = 'progress',
+  className,
+  ...props
+}: SegmentedProgressBarProps) => {
+  const clampedCompleted = Math.max(0, Math.min(completed, total));
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={clampedCompleted}
+      className={clsx(styles.track, className)}
+      {...props}
+    >
+      {Array.from({ length: total }, (_, index) => (
+        <span
+          key={index}
+          className={clsx(
+            styles.segment,
+            index < clampedCompleted && styles.segmentFilled({ tone }),
+          )}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SegmentedProgressBar;

--- a/src/shared/components/progress/StepProgress.css.ts
+++ b/src/shared/components/progress/StepProgress.css.ts
@@ -1,0 +1,158 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '@styles/global.css';
+
+export const list = recipe({
+  base: {
+    display: 'flex',
+  },
+  variants: {
+    orientation: {
+      vertical: { flexDirection: 'column' },
+      horizontal: { flexDirection: 'row', alignItems: 'flex-start' },
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+export const stepRow = recipe({
+  base: {
+    display: 'flex',
+  },
+  variants: {
+    orientation: {
+      // 세로: 마커 열(원 + 아래 연결선)과 라벨/액션이 나란히, 마지막 단계가 아니면 다음
+      // 단계와 이어지도록 연결선이 이 행의 남은 높이만큼 늘어남(마커 열이 stretch되고
+      // 그 안의 connector가 flex:1)
+      vertical: { flexDirection: 'row', alignItems: 'stretch', gap: vars.space.s3 },
+      // 가로: 마커 행(원 + 오른쪽 연결선)이 위, 라벨/액션이 아래 — 마지막 단계는 flex:0으로
+      // 남는 연결선이 안 늘어나게 함(list 컨테이너에서 처리)
+      horizontal: { flex: 1, flexDirection: 'column', alignItems: 'center', gap: vars.space.s1 },
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+export const markerColumn = recipe({
+  base: {
+    display: 'flex',
+    flexShrink: 0,
+    alignItems: 'center',
+  },
+  variants: {
+    orientation: {
+      vertical: { flexDirection: 'column' },
+      horizontal: { flexDirection: 'row', width: '100%' },
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+export const marker = recipe({
+  base: {
+    display: 'flex',
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    width: '2rem',
+    height: '2rem',
+    ...vars.typography.captionBold,
+  },
+  variants: {
+    status: {
+      done: {
+        border: 'none',
+        backgroundColor: vars.color.success,
+        color: vars.color.white,
+      },
+      current: {
+        border: `2px solid ${vars.color.primary}`,
+        backgroundColor: vars.color.primaryLight2,
+        color: vars.color.primary,
+      },
+      upcoming: {
+        border: `2px solid ${vars.color.gray200}`,
+        backgroundColor: vars.color.white,
+        color: vars.color.textLow,
+      },
+    },
+  },
+  defaultVariants: {
+    status: 'upcoming',
+  },
+});
+
+export const connector = recipe({
+  base: {
+    flexShrink: 0,
+  },
+  variants: {
+    orientation: {
+      vertical: { flex: 1, width: '2px', minHeight: vars.space.s3 },
+      horizontal: { flex: 1, marginTop: '1rem', minWidth: vars.space.s3, height: '2px' },
+    },
+    filled: {
+      true: { backgroundColor: vars.color.success },
+      false: { backgroundColor: vars.color.gray200 },
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+    filled: false,
+  },
+});
+
+export const stepContent = recipe({
+  base: {
+    display: 'flex',
+    flex: 1,
+    minWidth: 0,
+  },
+  variants: {
+    orientation: {
+      vertical: {
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: vars.space.s2,
+        paddingBottom: vars.space.s4,
+      },
+      horizontal: {
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: vars.space.s1,
+        textAlign: 'center',
+      },
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+export const stepLabel = recipe({
+  base: {
+    ...vars.typography.body14,
+  },
+  variants: {
+    status: {
+      done: { color: vars.color.textHigh },
+      current: { color: vars.color.textHigh },
+      upcoming: { color: vars.color.textLow },
+    },
+  },
+  defaultVariants: {
+    status: 'upcoming',
+  },
+});
+
+export const stepAction = style({
+  flexShrink: 0,
+});

--- a/src/shared/components/progress/StepProgress.tsx
+++ b/src/shared/components/progress/StepProgress.tsx
@@ -19,20 +19,26 @@ export interface ProgressStep {
 export type StepProgressProps = {
   steps: ProgressStep[];
   orientation?: 'horizontal' | 'vertical';
-} & Omit<ComponentPropsWithoutRef<'div'>, 'children'>;
+} & Omit<ComponentPropsWithoutRef<'ol'>, 'children'>;
 
 // 순서가 있는 준비 단계(체크리스트·온보딩 등)를 원형 마커 + 연결선으로 보여주는 스테퍼.
 // done은 체크 아이콘, current는 채워진 원(지금 진행 가능), upcoming은 빈 원(아직 못함)으로 구분.
-// 각 단계 라벨 옆에 action을 끼워둘 수 있어 "지정하기" 같은 버튼을 그대로 붙일 수 있음
+// 각 단계 라벨 옆에 action을 끼워둘 수 있어 "지정하기" 같은 버튼을 그대로 붙일 수 있음.
+// div 중첩 대신 ol/li로 둬서 스크린리더가 "총 N단계 중 몇 번째"를 자동으로 읽어주게 하고,
+// 지금 단계에는 aria-current="step"을 붙여 위치를 함께 알려줌(코드래빗 리뷰 반영)
 const StepProgress = ({
   steps,
   orientation = 'vertical',
   className,
   ...props
 }: StepProgressProps) => (
-  <div className={clsx(styles.list({ orientation }), className)} {...props}>
+  <ol className={clsx(styles.list({ orientation }), className)} {...props}>
     {steps.map((step, index) => (
-      <div key={index} className={styles.stepRow({ orientation })}>
+      <li
+        key={index}
+        className={styles.stepRow({ orientation })}
+        aria-current={step.status === 'current' ? 'step' : undefined}
+      >
         <div className={styles.markerColumn({ orientation })}>
           <span className={styles.marker({ status: step.status })}>
             {step.status === 'done' ? (
@@ -54,9 +60,9 @@ const StepProgress = ({
           <span className={styles.stepLabel({ status: step.status })}>{step.label}</span>
           {step.action && <div className={styles.stepAction}>{step.action}</div>}
         </div>
-      </div>
+      </li>
     ))}
-  </div>
+  </ol>
 );
 
 export default StepProgress;

--- a/src/shared/components/progress/StepProgress.tsx
+++ b/src/shared/components/progress/StepProgress.tsx
@@ -1,0 +1,62 @@
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import CheckIcon from '@assets/icons/ic-check.svg?react';
+
+import * as styles from './StepProgress.css';
+
+export type StepStatus = 'done' | 'current' | 'upcoming';
+
+export interface ProgressStep {
+  /** 단계 이름 */
+  label: string;
+  status: StepStatus;
+  /** 라벨 오른쪽에 보여줄 내용 — 버튼, "완료" 텍스트, 안내 문구 등 */
+  action?: ReactNode;
+}
+
+export type StepProgressProps = {
+  steps: ProgressStep[];
+  orientation?: 'horizontal' | 'vertical';
+} & Omit<ComponentPropsWithoutRef<'div'>, 'children'>;
+
+// 순서가 있는 준비 단계(체크리스트·온보딩 등)를 원형 마커 + 연결선으로 보여주는 스테퍼.
+// done은 체크 아이콘, current는 채워진 원(지금 진행 가능), upcoming은 빈 원(아직 못함)으로 구분.
+// 각 단계 라벨 옆에 action을 끼워둘 수 있어 "지정하기" 같은 버튼을 그대로 붙일 수 있음
+const StepProgress = ({
+  steps,
+  orientation = 'vertical',
+  className,
+  ...props
+}: StepProgressProps) => (
+  <div className={clsx(styles.list({ orientation }), className)} {...props}>
+    {steps.map((step, index) => (
+      <div key={index} className={styles.stepRow({ orientation })}>
+        <div className={styles.markerColumn({ orientation })}>
+          <span className={styles.marker({ status: step.status })}>
+            {step.status === 'done' ? (
+              <CheckIcon width={12} height={12} />
+            ) : (
+              <span>{index + 1}</span>
+            )}
+          </span>
+          {index < steps.length - 1 && (
+            <span
+              className={styles.connector({
+                orientation,
+                filled: step.status === 'done',
+              })}
+            />
+          )}
+        </div>
+        <div className={styles.stepContent({ orientation })}>
+          <span className={styles.stepLabel({ status: step.status })}>{step.label}</span>
+          {step.action && <div className={styles.stepAction}>{step.action}</div>}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+export default StepProgress;

--- a/src/shared/components/skeleton/Skeleton.css.ts
+++ b/src/shared/components/skeleton/Skeleton.css.ts
@@ -1,0 +1,21 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+import { vars } from '@styles/global.css';
+
+const pulse = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '50%': { opacity: 0.5 },
+});
+
+export const skeleton = style({
+  display: 'inline-block',
+  flexShrink: 0,
+  borderRadius: vars.radius.sm,
+  backgroundColor: vars.color.gray100,
+  animation: `${pulse} 1.4s ease-in-out infinite`,
+  '@media': {
+    '(prefers-reduced-motion: reduce)': {
+      animation: 'none',
+    },
+  },
+});

--- a/src/shared/components/skeleton/Skeleton.tsx
+++ b/src/shared/components/skeleton/Skeleton.tsx
@@ -1,0 +1,32 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+import clsx from 'clsx';
+
+import * as styles from './Skeleton.css';
+
+export type SkeletonProps = {
+  /** 너비 — rem 문자열(예: '4rem') */
+  width?: string;
+  /** 높이 — rem 문자열 */
+  height?: string;
+} & Omit<ComponentPropsWithoutRef<'span'>, 'children'>;
+
+// 카드마다 값이 서로 다른 시점에 도착해 들쭉날쭉 팝업되면(특히 목록 페이지처럼 카드 수만큼
+// 조회가 따로 도는 화면) 완성도가 떨어져 보인다는 피드백으로 만듦 — 값이 도착하기 전엔
+// 빈 자리 대신 로딩 중임을 알리는 자리표시자를 보여줌
+const Skeleton = ({
+  width = '100%',
+  height = '1.4rem',
+  className,
+  style,
+  ...props
+}: SkeletonProps) => (
+  <span
+    aria-hidden="true"
+    className={clsx(styles.skeleton, className)}
+    style={{ width, height, ...style }}
+    {...props}
+  />
+);
+
+export default Skeleton;

--- a/src/shared/constants/gnbConfig.ts
+++ b/src/shared/constants/gnbConfig.ts
@@ -68,27 +68,27 @@ const GNB_CONFIGS = [
     // 보일 로딩/빈 상태는 카메라 목록(진짜 홈)과 같은 톤으로 맞춰둠
     path: ROUTES.TRAINING_ANALYSIS,
     config: {
-      // 더 상위 단계가 없는 화면이라 빈 배열로 둠 — GNB가 이 경우 "훈련 분석"(title)
-      // 하나만 브레드크럼으로 보여주고, "훈련 분석 › 훈련 분석"처럼 중복되지 않게 함
+      // 더 상위 단계가 없는 화면이라 빈 배열로 둠 — GNB가 이 경우 "훈련 모니터링"(title)
+      // 하나만 브레드크럼으로 보여주고, "훈련 모니터링 › 훈련 모니터링"처럼 중복되지 않게 함
       breadcrumbs: [],
-      title: '훈련 분석',
+      title: '훈련 모니터링',
       description: '진행 중인 훈련의 CCTV 프레임을 실시간으로 확인합니다',
     },
   },
   {
-    // 훈련분석의 실질적인 첫 화면(더 이상 목록 페이지가 없음) — 위와 같은 이유로 빈 배열
+    // 훈련모니터링의 실질적인 첫 화면(더 이상 목록 페이지가 없음) — 위와 같은 이유로 빈 배열
     path: ROUTES.TRAINING_CAMERAS,
     config: {
       breadcrumbs: [],
-      title: '훈련 분석',
+      title: '훈련 모니터링',
       description: '선택한 훈련에서 카메라별로 수집된 프레임을 확인합니다',
     },
   },
   {
-    // 카메라 목록에서 한 단계 더 들어간 화면이라 "훈련 분석" 브레드크럼 아래 별도 타이틀을 둠
+    // 카메라 목록에서 한 단계 더 들어간 화면이라 "훈련 모니터링" 브레드크럼 아래 별도 타이틀을 둠
     path: ROUTES.TRAINING_CAMERA_FRAMES,
     config: {
-      breadcrumbs: [{ label: '훈련 분석' }],
+      breadcrumbs: [{ label: '훈련 모니터링' }],
       title: '영상 상세',
       description: '선택한 카메라의 CCTV 프레임을 확인합니다',
     },

--- a/src/shared/constants/sidebar.ts
+++ b/src/shared/constants/sidebar.ts
@@ -18,5 +18,5 @@ export const sidebarItems = [
       { label: '도면 관리', icon: MapIcon, path: ROUTES.FLOOR_PLANS },
     ],
   },
-  { label: '훈련 분석', icon: VideoIcon, path: ROUTES.TRAINING_ANALYSIS },
+  { label: '훈련 모니터링', icon: VideoIcon, path: ROUTES.TRAINING_ANALYSIS },
 ];


### PR DESCRIPTION
## 📌 Summary

도면관리(`FloorPlansPage`/`FloorPlansDetailPage`)·건물관리(`BuildingsPage`) 두 화면을 중심으로, QA 리스트에서 나온 항목들과 완성도 개선을 반영했습니다. UI/UX 개선, 버그 수정, 재사용 가능한 공용 컴포넌트 추가, 미사용 코드·중복 로직 정리까지 포함하였습니다.

## 🔗 관련 이슈

closes #91

## 📋 작업 내용

### 1. QA에서 언급된 사항

| # | 페이지 | 문제사항 | 해결방법 | 상태 |
|---|---|---|---|---|
| 1 | 도면관리 상세 | 엣지 거리 입력 시 소수점 입력이 안 됨 | input을 `type="text"`+정규식으로 바꿔 타이핑 중간 상태(끝에 점만 있는 경우 등)까지 허용 | ✅ 완료 |
| 2 | 도면관리 상세 | 기본값이 소수점일 때 백스페이스로 안 지워짐 | 위와 동일한 수정으로 함께 해결 | ✅ 완료 |
| 3 | 도면관리 상세 | 거리 1 이하 입력 불가 | cm 단위 정수 입력으로 바꿔 해결(예: 50cm=0.5m) | ✅ 완료 |
| 4 | 도면관리 상세 | 거리 단위를 cm로 조절 요청 | m → cm 입력, 저장 시 m로 환산 | ✅ 완료 |
| 5 | 도면관리 상세 | 엣지가 너무 가까우면 연결이 안 됨 | FE는 서버 에러 메시지를 그대로 노출할 뿐, 클라이언트 측 최소거리 제한 코드 없음 | ⚠️ 서버 검증 로직으로 추정 — 백엔드 확인 필요 |
| 6 | 도면관리 상세 | 화면을 키우면 좌우 패널도 커져서 도면 영역이 좁아짐 | 상세 페이지 레이아웃에 폭 상한 적용 | ✅ 완료 |
| 7 | 도면관리 상세 | 노드/구역 종류 안내 섹션이 화면 커질 때 방해됨 | 상시 노출 범례 → (i) 아이콘 클릭 시 여는 팝오버 방식으로 전환 | ✅ 완료 |
| 8 | 도면관리 상세 | 추가 버튼 아래 뜨는 입력창이 도면 우상단을 가림 | 캔버스 오버레이 → 좌측 사이드바 카드 형태로 이동 | ✅ 완료 |
| 9 | 훈련 모니터링 | 타이틀을 "훈련 분석"에서 "훈련 모니터링"으로 | 사이드바/페이지 타이틀 변경 | ✅ 완료 |
| 10 | 훈련 모니터링 | 이벤트 타임라인이 실시간으로 안 뜨고 갑자기 나타남 | 웹소켓 구독 로직 자체는 있으나(`useTrainingMonitoringSocket`), invalidateQueries로 다음 리페치를 트리거하는 구조라 지연이 있을 수 있음 | ❓ 라이브 확인 필요 |
| 11 | 도면관리 상세 | 그리드 배율 1m 이하로 업로드 시 그리드가 안 불러와짐 | 업로드 모달은 0.1m까지 선택 가능하고 그대로 서버에 전달함 — FE 제한 없음 | ⚠️ 서버가 작은 배율에서 그리드 생성 실패로 추정 — 백엔드 확인 필요 |
| 12 | 도면관리 상세 | 장비 카드 "설치 위치"가 뭘 바꿔도 새로고침하면 되돌아감 | 저장 API에 없는 값임을 확인 → 편집 불가한 읽기 전용으로 변경 | ✅ 완료 |
| 13 | 도면관리 상세 | 마이페이지처럼 변경 있을 때만 버튼 활성화 되면 좋겠음 | 장비 카드 "완료" 버튼에 `disabled={!hasChanges}` 적용 | ✅ 완료 |
| 14 | 훈련 모니터링 | 이벤트 타임라인 박스 높이 고정 + 스크롤 필요 | `maxHeight` + `overflowY: auto` 적용 | ✅ 완료 |
| 15 | 도면관리 상세 | 그리드 셀 불러오는 API 요청이 끝도 없이 올라옴 | 원인 3가지 진단 완료(불필요한 전체 건물 조회·canvasH 의존 재조회·StrictMode 중복호출) — 그리드 셀 페이지 조회는 순차→병렬로 우선 개선 | ⚠️ 부분 완료, 근본 해결은 react-query 전환 브랜치에서 예정 |

### 2. 페이지별 개선사항 (QA 목록 외 추가 작업)

#### 🗺️ 도면관리 — 목록 (`FloorPlansPage`)

| 유형 | 문제사항 | 해결방법 |
|---|---|---|
| 기능 | 층별 등록 요건(시작노드/최종탈출구/탈출경로) 현황이 안 보임 | 공용 `SegmentedProgressBar`로 카드에 진행 현황 표시  |
| UI | 카드마다 데이터 도착 시점이 달라 진행바가 하나씩 팝업되며 완성도 떨어져 보임 | 로딩 중 스켈레톤(펄스 애니메이션) 표시로 개선 |

#### 🗺️ 도면관리 — 상세 (`FloorPlansDetailPage`)

| 유형 | 문제사항 | 해결방법 |
|---|---|---|
| 버그 | 유도등 추가 시 담당CCTV·경로(구 가이던스) 값을 등록 단계에서 못 채움 → "활성 IoT 유도등" 집계에 안 잡힘 | 추가 팝업에도 동일 필드 노출, 등록 성공 시 경로·CCTV API 체이닝 호출 |
| 버그 | 구역 드래그 중 마커·격자 위를 지나가면 커서가 crosshair가 아닌 개별 커서로 바뀜 | 드래그 중 해당 레이어 pointer-events 임시 해제 |
| 버그 | 엣지 노드 재클릭 시 선택이 안 풀리고, 버튼 줄바꿈이 깨짐 | 선택 토글 로직·버튼 스타일 수정 |
| 버그 | 수정 모드 진입 시·마커 드래그 시 마커가 캔버스 위쪽/맨 위로 튐 | 중심 정렬 기준 및 좌표 계산 컨테이너 수정 |
| 버그 | "설치 위치"가 저장 API에 안 실려서 새로고침하면 사라지고 고정 문구로 바뀜 | 실제 좌표(X/Y %)를 표시하도록 변경 |
| 버그 | CCTV 카드를 클릭(조회)하기만 해도 도면의 배경 격자선이 사라짐 | 조회 모드에서도 격자선이 그려지도록 조건 수정 |
| 버그 | "+ 추가" 버튼이 캔버스 확대 후 스크롤하면 같이 밀려서 화면 밖으로 사라짐 | 버튼을 스크롤 컨테이너 바깥으로 분리해 항상 같은 위치에 고정 |
| 서버오류 | 최종 탈출구 지정 시 특정 층(차미리사관 2층)에서 500 에러 | FE 요청은 정상, `COMMON500` 응답 확인 → 백엔드팀에 재현 방법·요청/응답 로그 전달함 |
| UI | 유도등 마커 색이 계단과 비슷해 구분 안 됨, 범례 팝오버 위치가 다른 버튼과 겹침 | 색상 주황→노랑 변경, 팝오버를 줌 컨트롤 위로 재배치 |
| UI | 엣지 연결 취소/완료 버튼 구분 안 됨, 연결 개수 안 보임 | 버튼 분리, 연결 개수 뱃지 추가 |
| UI | 수정 카드의 방향 전환(왼쪽/오른쪽/끄기) 버튼이 불필요하고, 삭제 버튼이 다른 액션과 헷갈림 | 방향 전환 버튼 제거, 삭제는 이름 필드 옆 아이콘으로 이동(하단은 취소·완료만) |
| UI/UX | 엣지를 선택한 채로 다른 노드·구역·장비를 선택해도 엣지 강조가 그대로 남아있음 | 노드·구역·장비·빈 캔버스 중 하나를 선택하면 이전 엣지 선택이 자동으로 해제되도록 수정 |
| 기능/UX | 드롭다운으로 갈림길 위치·통로를 고르면 같은 종류 노드가 많아 구분 안 되고, 선택 취소·엣지 미연결 안내도 없음 | 캔버스 클릭 방식으로 전면 개편, "×" 취소 버튼 추가, 엣지 없을 때 안내 문구 표시 |




#### 🏢 건물관리 (`BuildingsPage`)

| 유형 | 문제사항 | 해결방법 |
|---|---|---|
| 버그 | 건물 추가 모달에서 필수값 없어도 "추가 완료" 버튼이 눌림 | 건물명·주소·지상층수 검증 후에만 활성화, 버튼 텍스트 "추가"로 변경 |
| 버그 | 건물 수정 모달에서 변경사항 없어도 버튼 눌림 | `isDirty` 체크 후 활성화, 버튼 텍스트 "수정"으로 변경 |
| UI | CCTV/IoT 유도등 등록 대수 0건일 때 "0/0"이 오류처럼 보임 | "-"로 표시 |
| UI | 카드마다 통계 로딩 시점이 달라 팝업되며 지저분해 보임 | 로딩 중 스켈레톤 표시 |

#### 🧹 공용 컴포넌트 / 코드 정리

| 유형 | 문제사항 | 해결방법 |
|---|---|---|
| 신규 컴포넌트 | 진행 현황 표시 UI가 페이지마다 제각각 만들어질 위험 | `SegmentedProgressBar`, `StepProgress`, `Skeleton` 공용 컴포넌트화 |
| 리팩토링 | 서버 에러 추출 로직이 `FloorPlansDetailPage`/`BuildingsPage`에 각각 중복 구현됨 | 기존 공용 헬퍼 `extractApiError`로 통합(13곳) |
| 리팩토링 | `formatFloor`가 `FloorUploadModal`에 로컬로 중복 구현 | 공용 `@utils/floor` 버전으로 교체 |
| 정리 | 안 쓰이는 타입/필드 존재 | `EditMode`, `AiLayer`, `PoiType`, `PoiMarker`, `Floor.pois`, 미사용 `FloorImageUrl` 재수출 제거 |

## 🔍 To Reviewer

- 알려진 미해결 이슈(이번 PR 범위 밖, 별도 트래킹): 도면 상세 페이지 로딩 성능(React Query 전환과 함께 별도 브랜치에서 처리 예정), 최종 탈출구 지정 500 에러 등 일부 항목은 백엔드 확인이 필요해 디스코드에 질문 올린 상태입니다.

## 📸 스크린샷

[도면관리 목록]
<img width="1904" height="916" alt="image" src="https://github.com/user-attachments/assets/ae59267a-4a16-4690-ac55-18dfb6eed917" />
- 등록 요건 진행바 + 로딩 스켈레톤

[도면관리 상세]

https://github.com/user-attachments/assets/8706ef8c-776b-447d-8d09-c2cf20c865d2


- 범례 (i) 아이콘 팝오버 닫힘/열림 상태
- 기존 팝업으로 관리되던 노드/구역/엣지 추가 창을  좌측 사이드바에 위치
- 훈련 준비 체크리스트(`StepProgress`) — 완료/진행중 상태
- 엣지 연결 리뷰 화면(cm 단위 거리 입력창)


## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료