### PR TITLE
[fix] 훈련 경과 시간 타이머가 백그라운드 탭에서 멈춰 보이는 이슈 수정

### DIFF
--- a/src/shared/hooks/useElapsedTrainingTime.ts
+++ b/src/shared/hooks/useElapsedTrainingTime.ts
@@ -15,9 +15,19 @@ const useElapsedTrainingTime = (startedAt?: number | null, stoppedAt?: number | 
       return;
     }
 
-    const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
+    const tick = () => setNow(Date.now());
+    const intervalId = window.setInterval(tick, 1000);
+    // 탭이 백그라운드로 가면 브라우저가 setInterval을 수십 초~분 단위로 늦춰서, 실제로는
+    // 시간이 흐르는데도 화면엔 멈춰있는 것처럼 보임(다른 탭에서 도면관리 등을 보다가 돌아오면
+    // 특히 두드러짐) — 탭이 다시 보이거나 포커스가 돌아오는 순간 즉시 한 번 더 갱신해서 따라잡음
+    document.addEventListener('visibilitychange', tick);
+    window.addEventListener('focus', tick);
 
-    return () => window.clearInterval(intervalId);
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', tick);
+      window.removeEventListener('focus', tick);
+    };
   }, [startedAt, stoppedAt]);
 
   if (startedAt === null || startedAt === undefined) return '-';


### PR DESCRIPTION
## 📌 Summary
훈련 모니터링 화면의 "훈련 진행 시간" 타이머가 다른 탭을 보는 동안 멈춰 보이다가 돌아오면 급증하는 이슈 수정

## 🔗 관련 이슈
closes #95

## 📋 작업 내용
- 브라우저가 백그라운드 탭의 `setInterval`을 수십 초~분 단위로 늦추는 특성 때문에, 실제 경과 시간은 정확한데 화면 갱신만 지연되어 멈춘 것처럼 보이던 문제
- `useElapsedTrainingTime`에 `visibilitychange`/`focus` 리스너를 추가해, 탭이 다시 보이거나 포커스가 돌아오는 즉시 한 번 더 갱신하도록 수정(같은 코드베이스의 `useScenarioTraining`에 이미 있던 동일 패턴 적용)
- 공용 훅이라 시나리오설정 훈련 모니터링뿐 아니라 훈련분석(카메라 프레임), 홈의 예정된 훈련 섹션도 함께 수정됨

## ✅ 체크리스트
- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료