### PR TITLE
[refactor] 도면관리 상세 페이지 데이터 조회 React Query 전환

### DIFF
--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -5,8 +5,9 @@ import { isAxiosError } from 'axios';
 import clsx from 'clsx';
 import { useNavigate, useParams } from 'react-router';
 
+import { useGetBuildingsQuery } from '@apis/buildings/useBuildingsQuery';
 import { extractApiError } from '@apis/errors/apiError';
-import { floorQueryKeys } from '@apis/floors/floorQueries';
+import { floorQueryKeys, useBuildingFloorsQuery } from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
 import CheckIcon from '@assets/icons/ic-check.svg?react';
@@ -46,9 +47,9 @@ import {
 import { getFloorGridCells, setFloorGrid } from './api/floorGridApi';
 import {
   analyzeFloor,
-  getFloorBuildings,
   getFloorDetail,
   getFloorImageUrl,
+  toFloor,
   uploadFloor,
 } from './api/floorPlansApi';
 import {
@@ -2535,7 +2536,6 @@ const FloorPlansDetailPage = () => {
   const { buildingId, floorId } = useParams<{ buildingId: string; floorId: string }>();
   const { show } = useToast();
 
-  const [floorBuildings, setFloorBuildings] = useState<FloorBuilding[]>([]);
   const [floor, setFloor] = useState<Floor | null>(null);
   const [loadingFloor, setLoadingFloor] = useState(false);
   const [resolvedMapImageUrl, setResolvedMapImageUrl] = useState<string | null>(null);
@@ -2566,13 +2566,6 @@ const FloorPlansDetailPage = () => {
   const isAnalysisSettled =
     floor?.segmentationStatus === 'DONE' || floor?.segmentationStatus === 'FAILED';
   const isAnalyzing = Boolean(floor?.mapImageUrl) && !isAnalysisSettled;
-
-  // 빌딩 목록 (사이드바 셀렉터용)
-  useEffect(() => {
-    getFloorBuildings()
-      .then(setFloorBuildings)
-      .catch(() => {});
-  }, []);
 
   // CCTV 등록 시 그리드 배율이 서버에서 사라져있어(CCTV006) 재적용 후 재시도할 때, 방금 사용자가
   // 드래그한 영역을 다시 그리게 하지 않고 같은 영역으로 셀을 재계산하기 위해 rect를 별도로 들고
@@ -2881,6 +2874,12 @@ const FloorPlansDetailPage = () => {
   }, [floorId]);
 
   const [selectedBuildingId] = useState(buildingId ?? '');
+  // 이 화면엔 건물 하나(이름)와 그 건물의 층 목록만 필요한데, 예전엔 getFloorBuildings()가
+  // 전체 건물 목록 + 건물마다 층 목록을 다 조회했음(건물 N개면 요청 N+1개, 건물이 늘수록
+  // 이 화면이 계속 느려지는 구조였음) — 건물 이름은 이미 캐시돼 있을 가능성이 높은 건물
+  // 목록 조회 1번, 층 목록은 이 건물 것만 조회 1번으로 나눔
+  const { data: buildingsForName } = useGetBuildingsQuery();
+  const { data: buildingFloors } = useBuildingFloorsQuery(selectedBuildingId);
   const [selectedFloorId, setSelectedFloorId] = useState(floorId ?? '');
   const [zoom, setZoom] = useState(100);
   const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
@@ -3122,7 +3121,18 @@ const FloorPlansDetailPage = () => {
     }
   }, [zoneAddOpen]);
 
-  const currentBuilding = floorBuildings.find((b) => b.id === selectedBuildingId) ?? null;
+  const currentBuildingName =
+    buildingsForName?.find((b) => b.id === selectedBuildingId)?.name ?? '';
+  // buildingFloors는 공용 훅(useBuildingFloorsQuery)이 내려주는 얕은 응답 형태(mapImageKey 등)라,
+  // 이 페이지가 기대하는 Floor 형태(mapImageUrl·devices 포함)로 그대로 쓰면 hasFloorPlan 판정이
+  // 항상 false가 돼(필드 이름이 달라 늘 "미등록"으로 보임) 이 파일의 toFloor로 다시 변환해줘야 함
+  const currentBuilding: FloorBuilding | null = selectedBuildingId
+    ? {
+        id: selectedBuildingId,
+        name: currentBuildingName,
+        floors: (buildingFloors ?? []).map((f) => toFloor(f, selectedBuildingId)),
+      }
+    : null;
   const currentFloor = currentBuilding?.floors.find((f) => f.id === selectedFloorId) ?? null;
 
   const handleFloorChange = (newId: string) => {
@@ -3175,13 +3185,12 @@ const FloorPlansDetailPage = () => {
             variant: 'warning',
           });
         }
-        setFloorBuildings((prev) =>
-          prev.map((b) =>
-            b.id !== selectedBuildingId
-              ? b
-              : { ...b, floors: b.floors.map((f) => (f.id !== currentFloor.id ? f : newFloor)) },
-          ),
-        );
+        // newFloor는 이 파일 기준 Floor 형태(mapImageUrl)라, 공용 훅의 캐시(BuildingFloor 형태,
+        // mapImageKey)에 그대로 patch하면 다른 화면(시나리오설정 등)이 같은 캐시를 읽을 때 모양이
+        // 깨짐 — 직접 patch하지 않고 무효화해서 서버에서 올바른 모양으로 다시 받아오게 함
+        void queryClient.invalidateQueries({
+          queryKey: floorQueryKeys.list(selectedBuildingId),
+        });
         setFloor(newFloor);
         URL.revokeObjectURL(previewUrl);
         setPendingUpload(null);

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -7,7 +7,11 @@ import { useNavigate, useParams } from 'react-router';
 
 import { useGetBuildingsQuery } from '@apis/buildings/useBuildingsQuery';
 import { extractApiError } from '@apis/errors/apiError';
-import { floorQueryKeys, useBuildingFloorsQuery } from '@apis/floors/floorQueries';
+import {
+  floorQueryKeys,
+  useBuildingFloorsQuery,
+  useFloorCctvsQuery,
+} from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
 import CheckIcon from '@assets/icons/ic-check.svg?react';
@@ -41,7 +45,6 @@ import {
   deleteCctv,
   disableCctv,
   enableCctv,
-  getFloorCctvs,
   updateCctv,
 } from './api/cctvApi';
 import { getFloorGridCells, setFloorGrid } from './api/floorGridApi';
@@ -332,6 +335,10 @@ type ZoneRefSelection = { kind: 'node'; id: string } | { kind: 'zone'; id: strin
 // 그리드 좌표계 기준값·순수 계산 함수는 shared/utils/floorCanvas에서 관리한다.
 // 시나리오 설정 캔버스도 같은 계산을 사용해 셀 경계가 어긋나지 않게 한다.
 const DEFAULT_CANVAS_H = 420;
+
+// react-query data가 아직 없을 때(로딩 중) 쓰는 안정적인 빈 배열 — `data ?? []`처럼 매 렌더
+// 새 배열을 만들면 그 값을 의존성으로 쓰는 effect가 로딩 중에 계속 재실행돼버림
+const EMPTY_CCTVS: Cctv[] = [];
 
 // AI 분석이 DONE으로 바뀐 직후엔 노드가 아직 생성 중일 수 있어 그래프가 비어 올 수 있음 — 재조회 설정
 const GRAPH_RETRY_LIMIT = 5;
@@ -2586,7 +2593,6 @@ const FloorPlansDetailPage = () => {
     setGraphNodes([]);
     setGraphEdges([]);
     setAddedDevices([]);
-    setRealCctvs([]);
     setIotLights([]);
     // 드래그로 옮긴 위치를 담아두는 오버레이 — 층을 바꿔도 안 비우면 다른 층에서 우연히
     // id가 겹칠 때 엉뚱한 위치가 그대로 보일 수 있음
@@ -2827,35 +2833,27 @@ const FloorPlansDetailPage = () => {
     };
   }, [floorId]);
 
-  // CCTV 조회 — 실제 등록된 CCTV를 장비 마커 목록에 채워 넣음
+  const { data: realCctvs = EMPTY_CCTVS } = useFloorCctvsQuery(floorId);
+
+  // CCTV는 useFloorCctvsQuery가 조회를 맡고(바로 위), 실제 등록된 CCTV가 바뀔 때마다(조회·생성·
+  // 수정·삭제 등 무엇으로 바뀌었든) 장비 마커 목록에 그대로 반영되게 동기화만 함
   useEffect(() => {
-    if (!floorId) return;
-    let cancelled = false;
-    getFloorCctvs(floorId)
-      .then((cctvs) => {
-        if (cancelled) return;
-        setRealCctvs(cctvs);
-        setAddedDevices((prev) => [
-          ...prev.filter((d) => d.type !== 'cctv'),
-          ...cctvs.map(
-            (cctv): AddedDevice => ({
-              id: cctv.id,
-              type: 'cctv',
-              placeType: 'cctv',
-              label: cctv.name,
-              x: cctv.x * 100,
-              y: cctv.y * 100,
-              status: 'online',
-              zone: formatMonitoredZone(cctv),
-            }),
-          ),
-        ]);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [floorId]);
+    setAddedDevices((prev) => [
+      ...prev.filter((d) => d.type !== 'cctv'),
+      ...realCctvs.map(
+        (cctv): AddedDevice => ({
+          id: cctv.id,
+          type: 'cctv',
+          placeType: 'cctv',
+          label: cctv.name,
+          x: cctv.x * 100,
+          y: cctv.y * 100,
+          status: 'online',
+          zone: formatMonitoredZone(cctv),
+        }),
+      ),
+    ]);
+  }, [realCctvs]);
 
   // 사용자 지정 영역 조회 — 목록 API는 이름만 내려줘서, 화면에 그리려면 구역마다 셀 상세를 따로 조회
   useEffect(() => {
@@ -3003,7 +3001,6 @@ const FloorPlansDetailPage = () => {
   const [gridSetupPromptOpen, setGridSetupPromptOpen] = useState(false);
   const [gridSetupIntent, setGridSetupIntent] = useState<'cctv' | 'zone' | null>(null);
   const [gridSizeMeterInput, setGridSizeMeterInput] = useState('1');
-  const [realCctvs, setRealCctvs] = useState<Cctv[]>([]);
   const [cctvDraftCellIds, setCctvDraftCellIds] = useState<string[]>([]);
   const [zoneDraftCellIds, setZoneDraftCellIds] = useState<string[]>([]);
   const [zoneDeleteTarget, setZoneDeleteTarget] = useState<ZoneEntry | null>(null);
@@ -3022,6 +3019,14 @@ const FloorPlansDetailPage = () => {
     setDevicePositions((prev) => ({ ...prev, [id]: { x, y } }));
   };
 
+  // realCctvs는 useFloorCctvsQuery 캐시라, 서버 응답으로 갱신하려면 로컬 setState가 아니라
+  // 이 캐시를 직접 patch해야 함(여러 핸들러가 반복해서 쓰는 패턴이라 하나로 모음)
+  const patchCctvCache = (updated: Cctv) => {
+    queryClient.setQueryData<Cctv[]>(floorQueryKeys.cctv(floorId), (prev) =>
+      prev?.map((c) => (c.id === updated.id ? updated : c)),
+    );
+  };
+
   // CCTV/유도등 카드의 활성화 스위치 — 둘 다 enabled 필드와 활성화/비활성화 PATCH API 모양이
   // 같아서 한 핸들러에서 타입만 보고 갈라 처리함
   const handleToggleEnabled = (item: PanelItem) => {
@@ -3032,7 +3037,7 @@ const FloorPlansDetailPage = () => {
       const request = enabled ? enableCctv : disableCctv;
       request(cctv.id)
         .then((updated) => {
-          setRealCctvs((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+          patchCctvCache(updated);
           show({
             title: enabled ? 'CCTV를 활성화했습니다.' : 'CCTV를 비활성화했습니다.',
             variant: 'success',
@@ -3081,17 +3086,8 @@ const FloorPlansDetailPage = () => {
     if (!editingCctvId || cctvDraftCellIds.length === 0) return;
     configureCctvGridCells(editingCctvId, cctvDraftCellIds)
       .then((updated) => {
-        setRealCctvs((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
-        setAddedDevices((prev) =>
-          prev.map((d) =>
-            d.id === updated.id
-              ? {
-                  ...d,
-                  zone: formatMonitoredZone(updated),
-                }
-              : d,
-          ),
-        );
+        // addedDevices의 zone(감시 영역 문구)은 realCctvs 동기화 effect가 알아서 다시 채움
+        patchCctvCache(updated);
         setEditingCctvId(null);
         setCctvDraftCellIds([]);
       })
@@ -3534,19 +3530,10 @@ const FloorPlansDetailPage = () => {
 
     // 최초 시도·재시도 둘 다 여기로 옴 — 성공 처리를 한 곳에 모아 둠
     const handleCreated = (newCctv: Cctv) => {
-      setRealCctvs((prev) => [...prev, newCctv]);
-      setAddedDevices((prev) => [
-        ...prev,
-        {
-          id: newCctv.id,
-          type: 'cctv',
-          placeType: 'cctv',
-          label: newCctv.name,
-          x: nodeStagedPosition.x,
-          y: nodeStagedPosition.y,
-          status: 'online',
-          zone: formatMonitoredZone(newCctv),
-        },
+      // addedDevices에 새 마커를 추가하는 것도 realCctvs 동기화 effect가 알아서 처리함
+      queryClient.setQueryData<Cctv[]>(floorQueryKeys.cctv(floorId), (prev) => [
+        ...(prev ?? []),
+        newCctv,
       ]);
       lastCctvDraftRectRef.current = null;
       setNodeAddStage('entry');
@@ -4655,9 +4642,7 @@ const FloorPlansDetailPage = () => {
         }
       } else if (item.type === 'cctv' && prevDevice) {
         updateCctv(item.id, { name: newLabel, x: finalX / 100, y: finalY / 100 })
-          .then((updated) => {
-            setRealCctvs((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
-          })
+          .then(patchCctvCache)
           .catch(() => {
             rollback();
             show({ title: 'CCTV 정보 수정에 실패했습니다.', variant: 'error' });
@@ -4717,7 +4702,9 @@ const FloorPlansDetailPage = () => {
         deleteCctv(item.id)
           .then(() => {
             handleAddedDeviceDelete(item.id);
-            setRealCctvs((prev) => prev.filter((cctv) => cctv.id !== item.id));
+            queryClient.setQueryData<Cctv[]>(floorQueryKeys.cctv(floorId), (prev) =>
+              prev?.filter((cctv) => cctv.id !== item.id),
+            );
             setSelectedItem((prev) =>
               prev?.kind === 'device' && prev.data.id === item.id ? null : prev,
             );

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -93,7 +93,7 @@ import {
 import type { Cctv } from './api/cctvApi';
 import type { FloorGridCell } from './api/floorGridApi';
 import type { IoTLight } from './api/iotLightsApi';
-import type { MapEdge, MapNode, MapNodeType } from './api/mapGraphApi';
+import type { FloorGraph, MapEdge, MapNode, MapNodeType } from './api/mapGraphApi';
 import type { DeviceMarker, DeviceType, Floor, FloorBuilding } from './types/floorPlans';
 
 type SelectedItem = { kind: 'device'; data: DeviceMarker };
@@ -2579,6 +2579,9 @@ const FloorPlansDetailPage = () => {
   // 화면에 남지 않도록 층 단위 상태를 한 번에 비움 (각 조회 effect가 새 데이터로 다시 채움)
   const resetFloorScopedState = useCallback(() => {
     lastCctvDraftRectRef.current = null;
+    // 층을 바꿨는데 이전 층의 원본 그래프가 남아있으면, 새 층 그래프가 도착하기 전에 canvasH가
+    // 바뀔 때 이전 층 데이터로 구조 노드를 잘못 재계산할 수 있어 같이 비움
+    lastGraphRef.current = null;
     setStructureNodes([]);
     setGraphNodes([]);
     setGraphEdges([]);
@@ -2724,6 +2727,32 @@ const FloorPlansDetailPage = () => {
     };
   }, [floorId, isFloorReady, show]);
 
+  // canvasH(그리드/이미지 로드가 끝나야 확정)는 구조 노드의 비율 좌표를 픽셀로 바꾸는 데만
+  // 쓰이고 그래프 데이터 자체와는 무관한데, 예전엔 이 값이 fetch effect의 의존성에 들어있어서
+  // canvasH가 바뀔 때마다(그리드가 늦게 로드되는 등) 서버에서 노드·엣지를 통째로 다시 조회했음
+  // (실측 확인된 중복 요청의 주 원인). 원본(비율 좌표) 그래프를 ref에 남겨두고, canvasH가
+  // 나중에 바뀌면 재조회 없이 이 ref로 구조 노드 픽셀 좌표만 다시 계산함
+  const lastGraphRef = useRef<FloorGraph | null>(null);
+
+  const applyStructureNodes = (graph: FloorGraph, h: number) => {
+    const structureFromGraph: StructureNode[] = graph.nodes.flatMap((n) => {
+      const structureType = API_TYPE_TO_STRUCTURE[n.type];
+      if (!structureType) return [];
+      return [
+        {
+          id: n.id,
+          type: structureType,
+          x: n.x * CANVAS_W,
+          y: n.y * h,
+          // 경로 탐색기가 인정하는 최종 탈출구는 type === 'EXIT'뿐 — 예전 코드로 isExitTarget만
+          // 붙은 계단은 '탈출구로 지정'을 다시 눌러 EXIT로 승격해야 함(배지 아직 안 붙음)
+          isFinalExit: n.type === 'EXIT',
+        },
+      ];
+    });
+    setStructureNodes(structureFromGraph);
+  };
+
   // 맵그래프(노드/엣지) 조회 — 문/계단은 기존 구조 노드 편집 상태로, 나머지는 조회 전용으로 보관.
   // 세그멘테이션 상태가 DONE으로 바뀌어도 서버가 노드를 다 만들기 전이라 빈 그래프가 올 수 있어서,
   // 비어 있으면 짧은 간격으로 몇 번 더 조회한다. (예전에는 이 자리에서 페이지를 통째로
@@ -2738,22 +2767,8 @@ const FloorPlansDetailPage = () => {
       getFloorGraph(floorId)
         .then((graph) => {
           if (cancelled) return;
-          const structureFromGraph: StructureNode[] = graph.nodes.flatMap((n) => {
-            const structureType = API_TYPE_TO_STRUCTURE[n.type];
-            if (!structureType) return [];
-            return [
-              {
-                id: n.id,
-                type: structureType,
-                x: n.x * CANVAS_W,
-                y: n.y * canvasH,
-                // 경로 탐색기가 인정하는 최종 탈출구는 type === 'EXIT'뿐 — 예전 코드로 isExitTarget만
-                // 붙은 계단은 '탈출구로 지정'을 다시 눌러 EXIT로 승격해야 함(배지 아직 안 붙음)
-                isFinalExit: n.type === 'EXIT',
-              },
-            ];
-          });
-          setStructureNodes(structureFromGraph);
+          lastGraphRef.current = graph;
+          applyStructureNodes(graph, canvasH);
           setGraphNodes(graph.nodes.filter((n) => !API_TYPE_TO_STRUCTURE[n.type]));
           setGraphEdges(graph.edges);
 
@@ -2771,8 +2786,16 @@ const FloorPlansDetailPage = () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
     };
-    // canvasH가 확정되면(그리드/이미지 로드) 구조 노드 px 좌표를 그 기준으로 다시 계산해야 함
-  }, [floorId, isFloorReady, canvasH]);
+    // canvasH는 의도적으로 뺌 — 바뀔 때마다 재조회하던 걸 없애는 게 이 effect 분리의 목적이라,
+    // 픽셀 재계산은 아래 별도 effect가 맡음(applyStructureNodes 안에서만 canvasH를 씀)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [floorId, isFloorReady]);
+
+  // canvasH가 나중에 확정되거나 바뀌면(그리드 로드 등), 서버 재조회 없이 이미 받아둔 원본
+  // 그래프로 구조 노드 픽셀 좌표만 다시 계산함
+  useEffect(() => {
+    if (lastGraphRef.current) applyStructureNodes(lastGraphRef.current, canvasH);
+  }, [canvasH]);
 
   // IoT 유도등 조회 — 기존 장비 마커 목록(addedDevices)에 실제 데이터로 채워 넣음
   useEffect(() => {

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   floorQueryKeys,
   useBuildingFloorsQuery,
   useFloorCctvsQuery,
+  useFloorLightsQuery,
 } from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
@@ -62,7 +63,6 @@ import {
   deleteIoTLight,
   disableIoTLight,
   enableIoTLight,
-  getFloorLights,
   updateIoTLight,
 } from './api/iotLightsApi';
 import {
@@ -339,6 +339,7 @@ const DEFAULT_CANVAS_H = 420;
 // react-query data가 아직 없을 때(로딩 중) 쓰는 안정적인 빈 배열 — `data ?? []`처럼 매 렌더
 // 새 배열을 만들면 그 값을 의존성으로 쓰는 effect가 로딩 중에 계속 재실행돼버림
 const EMPTY_CCTVS: Cctv[] = [];
+const EMPTY_LIGHTS: IoTLight[] = [];
 
 // AI 분석이 DONE으로 바뀐 직후엔 노드가 아직 생성 중일 수 있어 그래프가 비어 올 수 있음 — 재조회 설정
 const GRAPH_RETRY_LIMIT = 5;
@@ -2593,7 +2594,6 @@ const FloorPlansDetailPage = () => {
     setGraphNodes([]);
     setGraphEdges([]);
     setAddedDevices([]);
-    setIotLights([]);
     // 드래그로 옮긴 위치를 담아두는 오버레이 — 층을 바꿔도 안 비우면 다른 층에서 우연히
     // id가 겹칠 때 엉뚱한 위치가 그대로 보일 수 있음
     setDevicePositions({});
@@ -2803,35 +2803,27 @@ const FloorPlansDetailPage = () => {
     if (lastGraphRef.current) applyStructureNodes(lastGraphRef.current, canvasH);
   }, [canvasH]);
 
-  // IoT 유도등 조회 — 기존 장비 마커 목록(addedDevices)에 실제 데이터로 채워 넣음
+  const { data: iotLights = EMPTY_LIGHTS } = useFloorLightsQuery(floorId);
+
+  // 유도등은 useFloorLightsQuery가 조회를 맡고(바로 위), 실제 등록된 유도등이 바뀔 때마다(조회·
+  // 생성·수정·삭제 등 무엇으로 바뀌었든) 장비 마커 목록에 그대로 반영되게 동기화만 함
   useEffect(() => {
-    if (!floorId) return;
-    let cancelled = false;
-    getFloorLights(floorId)
-      .then((lights) => {
-        if (cancelled) return;
-        setIotLights(lights);
-        setAddedDevices((prev) => [
-          ...prev.filter((d) => d.placeType !== 'light'),
-          ...lights.map(
-            (light): AddedDevice => ({
-              id: light.id,
-              type: 'iot',
-              placeType: 'light',
-              label: light.name,
-              x: light.x * 100,
-              y: light.y * 100,
-              status: 'online',
-              zone: '사용자 등록',
-            }),
-          ),
-        ]);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [floorId]);
+    setAddedDevices((prev) => [
+      ...prev.filter((d) => d.placeType !== 'light'),
+      ...iotLights.map(
+        (light): AddedDevice => ({
+          id: light.id,
+          type: 'iot',
+          placeType: 'light',
+          label: light.name,
+          x: light.x * 100,
+          y: light.y * 100,
+          status: 'online',
+          zone: '사용자 등록',
+        }),
+      ),
+    ]);
+  }, [iotLights]);
 
   const { data: realCctvs = EMPTY_CCTVS } = useFloorCctvsQuery(floorId);
 
@@ -2990,7 +2982,6 @@ const FloorPlansDetailPage = () => {
 
   const [graphNodes, setGraphNodes] = useState<MapNode[]>([]);
   const [graphEdges, setGraphEdges] = useState<MapEdge[]>([]);
-  const [iotLights, setIotLights] = useState<IoTLight[]>([]);
   const [editingCctvId, setEditingCctvId] = useState<string | null>(null);
   const [editingStructureId, setEditingStructureId] = useState<string | null>(null);
   const [editingZoneId, setEditingZoneId] = useState<string | null>(null);
@@ -3027,6 +3018,13 @@ const FloorPlansDetailPage = () => {
     );
   };
 
+  // iotLights도 useFloorLightsQuery 캐시라 같은 방식으로 patch함
+  const patchLightCache = (updated: IoTLight) => {
+    queryClient.setQueryData<IoTLight[]>(floorQueryKeys.light(floorId), (prev) =>
+      prev?.map((l) => (l.id === updated.id ? updated : l)),
+    );
+  };
+
   // CCTV/유도등 카드의 활성화 스위치 — 둘 다 enabled 필드와 활성화/비활성화 PATCH API 모양이
   // 같아서 한 핸들러에서 타입만 보고 갈라 처리함
   const handleToggleEnabled = (item: PanelItem) => {
@@ -3055,7 +3053,7 @@ const FloorPlansDetailPage = () => {
       const request = enabled ? enableIoTLight : disableIoTLight;
       request(light.id)
         .then((updated) => {
-          setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l)));
+          patchLightCache(updated);
           show({
             title: enabled ? '유도등을 활성화했습니다.' : '유도등을 비활성화했습니다.',
             variant: 'success',
@@ -3300,22 +3298,10 @@ const FloorPlansDetailPage = () => {
           y: position.y / 100,
         })
           .then((newLight) => {
-            // 설정 모달·활성화 표시가 iotLights를 참조하므로 여기에도 반영해야 함
-            setIotLights((prev) => [...prev, newLight]);
-            setAddedDevices((prev) => [
-              ...prev,
-              {
-                id: newLight.id,
-                type: 'iot',
-                placeType: 'light',
-                label: newLight.name,
-                x: position.x,
-                y: position.y,
-                status: 'online',
-                // 유도등의 "설치 위치"는 실제 좌표(x/y)로 표시하므로(formatInstallLocation) 여기
-                // 값은 안 쓰임 — AddedDevice.zone 타입을 맞추기 위한 자리만 채움
-                zone: '',
-              },
+            // addedDevices에 새 마커를 추가하는 것도 iotLights 동기화 effect가 알아서 처리함
+            queryClient.setQueryData<IoTLight[]>(floorQueryKeys.light(floorId), (prev) => [
+              ...(prev ?? []),
+              newLight,
             ]);
 
             // 담당 CCTV·가이던스는 handleSaveEdit(카드 수정)과 같은 방식으로, 값이 채워졌을
@@ -3324,9 +3310,7 @@ const FloorPlansDetailPage = () => {
             const { decisionNodeId, leftEdgeId, rightEdgeId, cctvId } = lightFields;
             if (decisionNodeId && leftEdgeId && rightEdgeId) {
               configureLightGuidance(newLight.id, { decisionNodeId, leftEdgeId, rightEdgeId })
-                .then((updated) =>
-                  setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
-                )
+                .then(patchLightCache)
                 .catch((error: unknown) => {
                   const { message } = extractApiError(error);
                   show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
@@ -3334,9 +3318,7 @@ const FloorPlansDetailPage = () => {
             }
             if (cctvId) {
               assignLightCctv(newLight.id, cctvId)
-                .then((updated) =>
-                  setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
-                )
+                .then(patchLightCache)
                 .catch((error: unknown) => {
                   const { message } = extractApiError(error);
                   show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
@@ -4621,9 +4603,7 @@ const FloorPlansDetailPage = () => {
           rightEdgeId !== (prevLight?.rightEdgeId ?? '');
         if (decisionNodeId && leftEdgeId && rightEdgeId && guidanceChanged) {
           configureLightGuidance(item.id, { decisionNodeId, leftEdgeId, rightEdgeId })
-            .then((updated) =>
-              setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
-            )
+            .then(patchLightCache)
             .catch((error: unknown) => {
               const { message } = extractApiError(error);
               show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
@@ -4632,9 +4612,7 @@ const FloorPlansDetailPage = () => {
 
         if (editForm.cctvId && editForm.cctvId !== (prevLight?.cctvId ?? '')) {
           assignLightCctv(item.id, editForm.cctvId)
-            .then((updated) =>
-              setIotLights((prev) => prev.map((l) => (l.id === updated.id ? updated : l))),
-            )
+            .then(patchLightCache)
             .catch((error: unknown) => {
               const { message } = extractApiError(error);
               show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
@@ -4725,7 +4703,9 @@ const FloorPlansDetailPage = () => {
         deleteIoTLight(item.id)
           .then(() => {
             handleAddedDeviceDelete(item.id);
-            setIotLights((prev) => prev.filter((l) => l.id !== item.id));
+            queryClient.setQueryData<IoTLight[]>(floorQueryKeys.light(floorId), (prev) =>
+              prev?.filter((l) => l.id !== item.id),
+            );
             setDeleteConfirmTarget(null);
           })
           .catch((error: unknown) => {

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -13,7 +13,9 @@ import {
   useFloorCctvsQuery,
   useFloorGridCellsQuery,
   useFloorLightsQuery,
+  useFloorUserZonesQuery,
 } from '@apis/floors/floorQueries';
+import type { UserZoneWithCells } from '@apis/floors/floorQueries';
 
 import CameraIcon from '@assets/icons/ic-camera.svg?react';
 import CheckIcon from '@assets/icons/ic-check.svg?react';
@@ -74,12 +76,7 @@ import {
   getFloorGraph,
   updateMapNodePosition,
 } from './api/mapGraphApi';
-import {
-  createUserZone,
-  deleteUserZone,
-  getFloorUserZones,
-  getUserZoneDetail,
-} from './api/userZoneApi';
+import { createUserZone, deleteUserZone } from './api/userZoneApi';
 import ReadinessChecklist from './components/ReadinessChecklist';
 import { DEVICE_COLOR } from './constants/deviceColors';
 import * as styles from './FloorPlansDetailPage.css';
@@ -342,6 +339,7 @@ const DEFAULT_CANVAS_H = 420;
 const EMPTY_CCTVS: Cctv[] = [];
 const EMPTY_LIGHTS: IoTLight[] = [];
 const EMPTY_GRID_CELLS: FloorGridCell[] = [];
+const EMPTY_USER_ZONES: UserZoneWithCells[] = [];
 
 // AI 분석이 DONE으로 바뀐 직후엔 노드가 아직 생성 중일 수 있어 그래프가 비어 올 수 있음 — 재조회 설정
 const GRAPH_RETRY_LIMIT = 5;
@@ -2599,7 +2597,6 @@ const FloorPlansDetailPage = () => {
     // 드래그로 옮긴 위치를 담아두는 오버레이 — 층을 바꿔도 안 비우면 다른 층에서 우연히
     // id가 겹칠 때 엉뚱한 위치가 그대로 보일 수 있음
     setDevicePositions({});
-    setZones([]);
     setSelectedItem(null);
     setSelectedZoneRef(null);
     setSelectedEdgeId(null);
@@ -2838,28 +2835,13 @@ const FloorPlansDetailPage = () => {
     ]);
   }, [realCctvs]);
 
-  // 사용자 지정 영역 조회 — 목록 API는 이름만 내려줘서, 화면에 그리려면 구역마다 셀 상세를 따로 조회
-  useEffect(() => {
-    if (!floorId) return;
-    let cancelled = false;
-    getFloorUserZones(floorId)
-      .then((zoneList) => Promise.all(zoneList.map((zone) => getUserZoneDetail(floorId, zone.id))))
-      .then((details) => {
-        if (cancelled) return;
-        setZones(
-          details.map((d) => ({
-            id: d.id,
-            type: 'general',
-            label: d.name,
-            cellIds: d.cells.map((c) => c.cellId),
-          })),
-        );
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [floorId]);
+  // 사용자 지정 영역 조회 — 목록 API는 이름만 내려줘서, 화면에 그리려면 구역마다 셀 상세를 따로
+  // 조회해야 함(useFloorUserZonesQuery 내부에서 합쳐서 내려줌)
+  const { data: userZones = EMPTY_USER_ZONES } = useFloorUserZonesQuery(floorId);
+  const zones: ZoneEntry[] = useMemo(
+    () => userZones.map((z) => ({ id: z.id, type: 'general', label: z.name, cellIds: z.cellIds })),
+    [userZones],
+  );
 
   const [selectedBuildingId] = useState(buildingId ?? '');
   // 이 화면엔 건물 하나(이름)와 그 건물의 층 목록만 필요한데, 예전엔 getFloorBuildings()가
@@ -2894,7 +2876,6 @@ const FloorPlansDetailPage = () => {
   const [edgeChainNodeIds, setEdgeChainNodeIds] = useState<string[]>([]);
   const [edgeChainReviewOpen, setEdgeChainReviewOpen] = useState(false);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
-  const [zones, setZones] = useState<ZoneEntry[]>([]);
   // 구역 재설정(재드래그) 중인 기존 구역 id — null이면 zoneAddOpen은 "새 구역 추가" 흐름.
   // 구역은 PATCH가 없어 새로 만들고 기존 걸 지우는 방식으로만 "수정"할 수 있음(스웨거 확인)
   const [zoneResetTargetId, setZoneResetTargetId] = useState<string | null>(null);
@@ -2997,6 +2978,14 @@ const FloorPlansDetailPage = () => {
   const patchLightCache = (updated: IoTLight) => {
     queryClient.setQueryData<IoTLight[]>(floorQueryKeys.light(floorId), (prev) =>
       prev?.map((l) => (l.id === updated.id ? updated : l)),
+    );
+  };
+
+  // zones(위 useMemo)도 useFloorUserZonesQuery 캐시에서 파생된 값이라 로컬 setState 대신
+  // 이 캐시를 직접 갱신해야 반영됨
+  const updateZonesCache = (updater: (prev: UserZoneWithCells[]) => UserZoneWithCells[]) => {
+    queryClient.setQueryData<UserZoneWithCells[]>(floorQueryKeys.zone(floorId), (prev) =>
+      updater(prev ?? []),
     );
   };
 
@@ -3893,7 +3882,7 @@ const FloorPlansDetailPage = () => {
       return;
     }
     if (trimmed) {
-      setZones((prev) => prev.map((z) => (z.id === id ? { ...z, label: trimmed } : z)));
+      updateZonesCache((prev) => prev.map((z) => (z.id === id ? { ...z, name: trimmed } : z)));
     }
     setEditingZoneId(null);
   };
@@ -3902,9 +3891,9 @@ const FloorPlansDetailPage = () => {
     if (!currentFloor || zoneDraftCellIds.length === 0) return;
     createUserZone(currentFloor.id, { name: label, cellIds: zoneDraftCellIds })
       .then((zone) => {
-        setZones((prev) => [
+        updateZonesCache((prev) => [
           ...prev,
-          { id: zone.id, type: 'general', label: zone.name, cellIds: zoneDraftCellIds },
+          { id: zone.id, name: zone.name, floorNum: zone.floorNum, cellIds: zoneDraftCellIds },
         ]);
         setZoneAddOpen(false);
         setZoneDraftCellIds([]);
@@ -3938,9 +3927,9 @@ const FloorPlansDetailPage = () => {
         return createUserZone(floorId, { name: label, cellIds: nextCellIds });
       })
       .then((zone) => {
-        setZones((prev) => [
+        updateZonesCache((prev) => [
           ...prev.filter((z) => z.id !== targetId),
-          { id: zone.id, type: 'general', label: zone.name, cellIds: nextCellIds },
+          { id: zone.id, name: zone.name, floorNum: zone.floorNum, cellIds: nextCellIds },
         ]);
         if (selectedZoneRef?.kind === 'zone' && selectedZoneRef.id === targetId) {
           setSelectedZoneRef(null);
@@ -3958,7 +3947,7 @@ const FloorPlansDetailPage = () => {
         }
         if (!original) {
           // 원본 정보가 없으면(이론상 거의 없음) 복구를 시도할 수 없음 — 기존 안내로 대체
-          setZones((prev) => prev.filter((z) => z.id !== targetId));
+          updateZonesCache((prev) => prev.filter((z) => z.id !== targetId));
           show({
             title:
               message || '기존 구역은 삭제됐지만 새 구역 생성에 실패했습니다. 다시 만들어주세요.',
@@ -3971,12 +3960,12 @@ const FloorPlansDetailPage = () => {
         // 실패 범위를 줄임(이름만 바꾸는 흔한 경우 특히 유효)
         createUserZone(floorId, { name: original.label, cellIds: original.cellIds })
           .then((restored) => {
-            setZones((prev) => [
+            updateZonesCache((prev) => [
               ...prev.filter((z) => z.id !== targetId),
               {
                 id: restored.id,
-                type: 'general',
-                label: original.label,
+                name: original.label,
+                floorNum: restored.floorNum,
                 cellIds: original.cellIds,
               },
             ]);
@@ -3988,7 +3977,7 @@ const FloorPlansDetailPage = () => {
           })
           .catch(() => {
             // 복구 재시도까지 실패한 경우에만 진짜로 사라짐 — 목록에서 지우고 명확히 알림
-            setZones((prev) => prev.filter((z) => z.id !== targetId));
+            updateZonesCache((prev) => prev.filter((z) => z.id !== targetId));
             show({
               title: '기존 구역이 삭제됐고 복구에도 실패했습니다. 구역을 다시 만들어주세요.',
               variant: 'error',
@@ -4122,7 +4111,7 @@ const FloorPlansDetailPage = () => {
     setIsDeletingZone(true);
     deleteUserZone(currentFloor.id, id)
       .then(() => {
-        setZones((prev) => prev.filter((z) => z.id !== id));
+        updateZonesCache((prev) => prev.filter((z) => z.id !== id));
         if (selectedZoneRef?.kind === 'zone' && selectedZoneRef.id === id) {
           setSelectedZoneRef(null);
         }

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import clsx from 'clsx';
 import { useNavigate, useParams } from 'react-router';
@@ -12,6 +12,7 @@ import {
   useBuildingFloorsQuery,
   useFloorCctvsQuery,
   useFloorGridCellsQuery,
+  useFloorImageUrlQuery,
   useFloorLightsQuery,
   useFloorUserZonesQuery,
 } from '@apis/floors/floorQueries';
@@ -52,13 +53,7 @@ import {
   updateCctv,
 } from './api/cctvApi';
 import { getFloorGridCells, setFloorGrid } from './api/floorGridApi';
-import {
-  analyzeFloor,
-  getFloorDetail,
-  getFloorImageUrl,
-  toFloor,
-  uploadFloor,
-} from './api/floorPlansApi';
+import { analyzeFloor, getFloorDetail, toFloor, uploadFloor } from './api/floorPlansApi';
 import {
   assignLightCctv,
   configureLightGuidance,
@@ -2544,10 +2539,28 @@ const FloorPlansDetailPage = () => {
   const { buildingId, floorId } = useParams<{ buildingId: string; floorId: string }>();
   const { show } = useToast();
 
-  const [floor, setFloor] = useState<Floor | null>(null);
-  const [loadingFloor, setLoadingFloor] = useState(false);
-  const [resolvedMapImageUrl, setResolvedMapImageUrl] = useState<string | null>(null);
   const { data: floorGridCells = EMPTY_GRID_CELLS } = useFloorGridCellsQuery(floorId);
+
+  // 현재 층 상세 — 세그멘테이션이 끝날 때까지(isAnalyzing) 짧은 간격으로 다시 조회해 상태 전환을
+  // 감지해야 해서, 폴링 여부를 방금 받은 데이터 기준으로 매번 다시 판단하는 refetchInterval에 맡김
+  const floorDetailQuery = useQuery({
+    queryKey: floorQueryKeys.detail(buildingId, floorId),
+    queryFn: ({ signal }) => {
+      if (!buildingId || !floorId) throw new Error('층 상세 조회 조건이 필요합니다.');
+      return getFloorDetail(buildingId, floorId, signal);
+    },
+    enabled: Boolean(buildingId && floorId),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return false;
+      const settled = data.segmentationStatus === 'DONE' || data.segmentationStatus === 'FAILED';
+      const analyzing = Boolean(data.mapImageUrl) && !settled;
+      return analyzing ? 4000 : false;
+    },
+  });
+  const floor = floorDetailQuery.data ?? null;
+  const loadingFloor = floorDetailQuery.isLoading;
+
   // 도면 이미지의 원본 가로/세로 비율 — viewBox 높이(canvasH)를 여기에 맞춰 이미지 왜곡을 없앰
   const [imageAspect, setImageAspect] = useState<number | null>(null);
 
@@ -2567,13 +2580,7 @@ const FloorPlansDetailPage = () => {
     return DEFAULT_CANVAS_H;
   }, [imageAspect, floorGridCells]);
 
-  // 업로드 직후엔 AI 세그멘테이션이 아직 진행 중(PENDING/PROCESSING)이라 노드/도면이 안 뜸.
-  // 이미지가 올라온 층에서 DONE/FAILED가 아니면 "분석 중"으로 보고(업로드 전 층은 제외),
-  // 완료로 바뀌는 순간 화면을 자동 새로고침함
   const isFloorReady = floor?.segmentationStatus === 'DONE';
-  const isAnalysisSettled =
-    floor?.segmentationStatus === 'DONE' || floor?.segmentationStatus === 'FAILED';
-  const isAnalyzing = Boolean(floor?.mapImageUrl) && !isAnalysisSettled;
 
   // CCTV 등록 시 그리드 배율이 서버에서 사라져있어(CCTV006) 재적용 후 재시도할 때, 방금 사용자가
   // 드래그한 영역을 다시 그리게 하지 않고 같은 영역으로 셀을 재계산하기 위해 rect를 별도로 들고
@@ -2613,62 +2620,22 @@ const FloorPlansDetailPage = () => {
     setNodeStagedPosition(null);
   }, []);
 
-  // 현재 층 상세 — 층 전환 시 이전 층 데이터가 남아있지 않도록 즉시 초기화
+  // 층이 바뀌면(라우트 전환) 이전 층 기준으로 만들어진 노드·장비·구역이 화면에 남지 않도록 즉시 비움
+  // (각 조회는 floorDetailQuery 등 react-query 훅들이 쿼리 키 변경으로 알아서 새로 받아옴)
   useEffect(() => {
-    if (!buildingId || !floorId) return;
-    let cancelled = false;
-    setFloor(null);
     resetFloorScopedState();
-    setLoadingFloor(true);
-    getFloorDetail(buildingId, floorId)
-      .then((data) => {
-        if (!cancelled) setFloor(data);
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setLoadingFloor(false);
-      });
-    return () => {
-      cancelled = true;
-    };
   }, [buildingId, floorId, resetFloorScopedState]);
-
-  // 세그멘테이션이 끝날 때까지 층 상세를 주기적으로 다시 조회해서 상태 전환을 감지
-  useEffect(() => {
-    if (!buildingId || !floorId || !isAnalyzing) return;
-    let cancelled = false;
-    const timer = setInterval(() => {
-      getFloorDetail(buildingId, floorId)
-        .then((data) => {
-          // clearInterval은 다음 틱만 막아서, 층 전환 중 이미 보낸 요청이 늦게 응답하면
-          // 새 층 데이터를 이전 층 데이터로 덮어쓸 수 있음 — cancelled로 막음
-          if (!cancelled) setFloor(data);
-        })
-        .catch(() => {});
-    }, 4000);
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [buildingId, floorId, isAnalyzing]);
 
   // 분석이 끝나면(DONE) 노드·엣지는 아래 맵그래프 effect가 isFloorReady 전환으로 자동 재조회하고,
   // 그리드 셀은 배율 재적용 effect가 다시 받아온다 — 별도의 페이지 새로고침은 필요 없음
 
   // 캔버스에 실제로 그릴 도면 이미지의 presigned URL — 도면이 있는 층일 때만, 그 층 하나에 대해서만 조회
-  useEffect(() => {
-    setResolvedMapImageUrl(null);
-    if (!buildingId || !floorId || !floor?.mapImageUrl) return;
-    let cancelled = false;
-    getFloorImageUrl(buildingId, floorId)
-      .then(({ imageUrl }) => {
-        if (!cancelled) setResolvedMapImageUrl(imageUrl);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [buildingId, floorId, floor?.mapImageUrl]);
+  const { data: floorImageData } = useFloorImageUrlQuery(
+    buildingId,
+    floorId,
+    Boolean(floor?.mapImageUrl),
+  );
+  const resolvedMapImageUrl = floorImageData?.imageUrl ?? null;
 
   // 도면 이미지 원본 비율 측정 — 그리드가 없을 때 canvasH 계산의 기준으로 씀
   useEffect(() => {
@@ -2989,6 +2956,14 @@ const FloorPlansDetailPage = () => {
     );
   };
 
+  // floor(위 floorDetailQuery)도 쿼리 캐시에서 파생된 값이라 로컬 setState 대신 이 캐시를 직접
+  // 갱신해야 반영됨
+  const updateFloorCache = (updater: (prev: Floor | null) => Floor | null) => {
+    queryClient.setQueryData<Floor | null>(floorQueryKeys.detail(buildingId, floorId), (prev) =>
+      updater(prev ?? null),
+    );
+  };
+
   // CCTV/유도등 카드의 활성화 스위치 — 둘 다 enabled 필드와 활성화/비활성화 PATCH API 모양이
   // 같아서 한 핸들러에서 타입만 보고 갈라 처리함
   const handleToggleEnabled = (item: PanelItem) => {
@@ -3175,7 +3150,7 @@ const FloorPlansDetailPage = () => {
         void queryClient.invalidateQueries({
           queryKey: floorQueryKeys.list(selectedBuildingId),
         });
-        setFloor(newFloor);
+        queryClient.setQueryData(floorQueryKeys.detail(buildingId, floorId), newFloor);
         URL.revokeObjectURL(previewUrl);
         setPendingUpload(null);
         setIsReuploading(false);
@@ -4524,7 +4499,7 @@ const FloorPlansDetailPage = () => {
     if (editingCctvId === item.id) handleCancelEditCctvCells();
     const newLabel = editForm.label;
     if (item.source === 'floor') {
-      setFloor((prev) =>
+      updateFloorCache((prev) =>
         prev
           ? {
               ...prev,
@@ -4688,7 +4663,7 @@ const FloorPlansDetailPage = () => {
       setDeleteConfirmTarget(null);
       return;
     }
-    setFloor((prev) =>
+    updateFloorCache((prev) =>
       prev ? { ...prev, devices: prev.devices.filter((d) => d.id !== item.id) } : prev,
     );
     if (selectedItem?.kind === 'device' && selectedItem.data.id === item.id) {

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from 'react-router';
 import { useGetBuildingsQuery } from '@apis/buildings/useBuildingsQuery';
 import { extractApiError } from '@apis/errors/apiError';
 import {
+  floorGraphQueryOptions,
   floorQueryKeys,
   useBuildingFloorsQuery,
   useFloorCctvsQuery,
@@ -68,7 +69,6 @@ import {
   createMapNode,
   deleteMapEdge,
   deleteMapNode,
-  getFloorGraph,
   updateMapNodePosition,
 } from './api/mapGraphApi';
 import { createUserZone, deleteUserZone } from './api/userZoneApi';
@@ -335,6 +335,7 @@ const EMPTY_CCTVS: Cctv[] = [];
 const EMPTY_LIGHTS: IoTLight[] = [];
 const EMPTY_GRID_CELLS: FloorGridCell[] = [];
 const EMPTY_USER_ZONES: UserZoneWithCells[] = [];
+const EMPTY_GRAPH: FloorGraph = { nodes: [], edges: [] };
 
 // AI 분석이 DONE으로 바뀐 직후엔 노드가 아직 생성 중일 수 있어 그래프가 비어 올 수 있음 — 재조회 설정
 const GRAPH_RETRY_LIMIT = 5;
@@ -2594,12 +2595,6 @@ const FloorPlansDetailPage = () => {
   // 화면에 남지 않도록 층 단위 상태를 한 번에 비움 (각 조회 effect가 새 데이터로 다시 채움)
   const resetFloorScopedState = useCallback(() => {
     lastCctvDraftRectRef.current = null;
-    // 층을 바꿨는데 이전 층의 원본 그래프가 남아있으면, 새 층 그래프가 도착하기 전에 canvasH가
-    // 바뀔 때 이전 층 데이터로 구조 노드를 잘못 재계산할 수 있어 같이 비움
-    lastGraphRef.current = null;
-    setStructureNodes([]);
-    setGraphNodes([]);
-    setGraphEdges([]);
     setAddedDevices([]);
     // 드래그로 옮긴 위치를 담아두는 오버레이 — 층을 바꿔도 안 비우면 다른 층에서 우연히
     // id가 겹칠 때 엉뚱한 위치가 그대로 보일 수 있음
@@ -2688,15 +2683,35 @@ const FloorPlansDetailPage = () => {
     };
   }, [floorId, isFloorReady, show, queryClient]);
 
-  // canvasH(그리드/이미지 로드가 끝나야 확정)는 구조 노드의 비율 좌표를 픽셀로 바꾸는 데만
-  // 쓰이고 그래프 데이터 자체와는 무관한데, 예전엔 이 값이 fetch effect의 의존성에 들어있어서
-  // canvasH가 바뀔 때마다(그리드가 늦게 로드되는 등) 서버에서 노드·엣지를 통째로 다시 조회했음
-  // (실측 확인된 중복 요청의 주 원인). 원본(비율 좌표) 그래프를 ref에 남겨두고, canvasH가
-  // 나중에 바뀌면 재조회 없이 이 ref로 구조 노드 픽셀 좌표만 다시 계산함
-  const lastGraphRef = useRef<FloorGraph | null>(null);
+  // 맵그래프(노드/엣지) 조회 — 세그멘테이션 상태가 DONE으로 바뀌어도 서버가 노드를 다 만들기
+  // 전이라 빈 그래프가 올 수 있어서, 비어 있으면 짧은 간격으로 몇 번 더 조회한다(최대
+  // GRAPH_RETRY_LIMIT회 — dataUpdateCount로 세서 floorId가 바뀌면 자동으로 초기화됨)
+  const graphQuery = useQuery({
+    ...floorGraphQueryOptions(floorId),
+    enabled: Boolean(floorId) && isFloorReady,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (!data) return false;
+      return data.nodes.length === 0 && query.state.dataUpdateCount <= GRAPH_RETRY_LIMIT
+        ? GRAPH_RETRY_INTERVAL_MS
+        : false;
+    },
+  });
+  const graphData = graphQuery.data ?? EMPTY_GRAPH;
 
-  const applyStructureNodes = (graph: FloorGraph, h: number) => {
-    const structureFromGraph: StructureNode[] = graph.nodes.flatMap((n) => {
+  const updateGraphCache = (updater: (prev: FloorGraph) => FloorGraph) => {
+    queryClient.setQueryData<FloorGraph>(floorQueryKeys.graph(floorId), (prev) =>
+      updater(prev ?? EMPTY_GRAPH),
+    );
+  };
+
+  // 문/계단/복도/시작 후보는 구조 노드 편집 상태(비율 좌표 → 픽셀)로 별도로 들고, 나머지는
+  // graphNodes로 조회 전용 보관 — canvasH(그리드/이미지 로드가 끝나야 확정)가 나중에 바뀌어도
+  // 서버 재조회 없이 이 조회 결과(graphData)로 픽셀 좌표만 다시 계산함(예전엔 canvasH가 fetch
+  // effect의 의존성에 들어있어서 canvasH가 바뀔 때마다 노드·엣지를 통째로 다시 조회했었음 —
+  // 실측 확인된 중복 요청의 주 원인)
+  useEffect(() => {
+    const structureFromGraph: StructureNode[] = graphData.nodes.flatMap((n) => {
       const structureType = API_TYPE_TO_STRUCTURE[n.type];
       if (!structureType) return [];
       return [
@@ -2704,7 +2719,7 @@ const FloorPlansDetailPage = () => {
           id: n.id,
           type: structureType,
           x: n.x * CANVAS_W,
-          y: n.y * h,
+          y: n.y * canvasH,
           // 경로 탐색기가 인정하는 최종 탈출구는 type === 'EXIT'뿐 — 예전 코드로 isExitTarget만
           // 붙은 계단은 '탈출구로 지정'을 다시 눌러 EXIT로 승격해야 함(배지 아직 안 붙음)
           isFinalExit: n.type === 'EXIT',
@@ -2712,51 +2727,7 @@ const FloorPlansDetailPage = () => {
       ];
     });
     setStructureNodes(structureFromGraph);
-  };
-
-  // 맵그래프(노드/엣지) 조회 — 문/계단은 기존 구조 노드 편집 상태로, 나머지는 조회 전용으로 보관.
-  // 세그멘테이션 상태가 DONE으로 바뀌어도 서버가 노드를 다 만들기 전이라 빈 그래프가 올 수 있어서,
-  // 비어 있으면 짧은 간격으로 몇 번 더 조회한다. (예전에는 이 자리에서 페이지를 통째로
-  // 새로고침했는데, 편집 중이던 상태가 날아가고 깜빡임이 커서 재조회 방식으로 바꿈)
-  useEffect(() => {
-    if (!floorId || !isFloorReady) return;
-    let cancelled = false;
-    let attempts = 0;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    const load = () => {
-      getFloorGraph(floorId)
-        .then((graph) => {
-          if (cancelled) return;
-          lastGraphRef.current = graph;
-          applyStructureNodes(graph, canvasH);
-          setGraphNodes(graph.nodes.filter((n) => !API_TYPE_TO_STRUCTURE[n.type]));
-          setGraphEdges(graph.edges);
-
-          // 분석 직후 아직 노드가 안 만들어졌으면 잠시 뒤 다시 시도(최대 GRAPH_RETRY_LIMIT회)
-          if (graph.nodes.length === 0 && attempts < GRAPH_RETRY_LIMIT) {
-            attempts += 1;
-            timer = setTimeout(load, GRAPH_RETRY_INTERVAL_MS);
-          }
-        })
-        .catch(() => {});
-    };
-
-    load();
-    return () => {
-      cancelled = true;
-      if (timer) clearTimeout(timer);
-    };
-    // canvasH는 의도적으로 뺌 — 바뀔 때마다 재조회하던 걸 없애는 게 이 effect 분리의 목적이라,
-    // 픽셀 재계산은 아래 별도 effect가 맡음(applyStructureNodes 안에서만 canvasH를 씀)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [floorId, isFloorReady]);
-
-  // canvasH가 나중에 확정되거나 바뀌면(그리드 로드 등), 서버 재조회 없이 이미 받아둔 원본
-  // 그래프로 구조 노드 픽셀 좌표만 다시 계산함
-  useEffect(() => {
-    if (lastGraphRef.current) applyStructureNodes(lastGraphRef.current, canvasH);
-  }, [canvasH]);
+  }, [graphData, canvasH]);
 
   const { data: iotLights = EMPTY_LIGHTS } = useFloorLightsQuery(floorId);
 
@@ -2903,8 +2874,12 @@ const FloorPlansDetailPage = () => {
     });
   }, [floorId, structureNodes, show]);
 
-  const [graphNodes, setGraphNodes] = useState<MapNode[]>([]);
-  const [graphEdges, setGraphEdges] = useState<MapEdge[]>([]);
+  // 문/계단 등 구조 노드가 아닌 나머지 그래프 노드 — graphData(위 graphQuery)에서 조회 전용으로만 씀
+  const graphNodes = useMemo(
+    () => graphData.nodes.filter((n) => !API_TYPE_TO_STRUCTURE[n.type]),
+    [graphData],
+  );
+  const graphEdges = graphData.edges;
   const [editingCctvId, setEditingCctvId] = useState<string | null>(null);
   const [editingStructureId, setEditingStructureId] = useState<string | null>(null);
   const [editingZoneId, setEditingZoneId] = useState<string | null>(null);
@@ -3196,8 +3171,6 @@ const FloorPlansDetailPage = () => {
       // 클릭해 지정한 위치 그대로 저장 (격자 스냅 없음). position은 0~100(%) 기준
       const ratioX = position.x / 100;
       const ratioY = position.y / 100;
-      const x = ratioX * CANVAS_W;
-      const y = ratioY * canvasH;
       if (currentFloor) {
         const apiType = STRUCTURE_NODE_API_TYPE[type];
         const count = structureNodes.filter((n) => n.type === type).length + 1;
@@ -3210,10 +3183,7 @@ const FloorPlansDetailPage = () => {
           isExitTarget: false,
         })
           .then((newNode) => {
-            setStructureNodes((prev) => [
-              ...prev,
-              { id: newNode.id, type, x, y, isFinalExit: false },
-            ]);
+            updateGraphCache((prev) => ({ ...prev, nodes: [...prev.nodes, newNode] }));
           })
           .catch((error: unknown) => {
             // 지금까지 문/계단/복도가 실패한 적이 없어서 안 드러났을 뿐, 실패해도 조용히
@@ -3575,18 +3545,24 @@ const FloorPlansDetailPage = () => {
     const node = structureNodes.find((n) => n.id === id);
     if (!node) return;
     const nextIsFinalExit = !node.isFinalExit;
-    setStructureNodes((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, isFinalExit: nextIsFinalExit } : n)),
-    );
+    const originalType: MapNodeType = node.isFinalExit
+      ? 'EXIT'
+      : STRUCTURE_NODE_API_TYPE[node.type];
+    const nextType: MapNodeType = nextIsFinalExit ? 'EXIT' : STRUCTURE_NODE_API_TYPE[node.type];
+    updateGraphCache((prev) => ({
+      ...prev,
+      nodes: prev.nodes.map((n) => (n.id === id ? { ...n, type: nextType } : n)),
+    }));
     updateMapNodePosition(id, {
       x: node.x / CANVAS_W,
       y: node.y / canvasH,
-      type: nextIsFinalExit ? 'EXIT' : STRUCTURE_NODE_API_TYPE[node.type],
+      type: nextType,
       isExitTarget: nextIsFinalExit,
     }).catch((error: unknown) => {
-      setStructureNodes((prev) =>
-        prev.map((n) => (n.id === id ? { ...n, isFinalExit: !nextIsFinalExit } : n)),
-      );
+      updateGraphCache((prev) => ({
+        ...prev,
+        nodes: prev.nodes.map((n) => (n.id === id ? { ...n, type: originalType } : n)),
+      }));
       // 마지막 남은 탈출구는 해제할 수 없는 등 서버가 이유를 message로 내려주므로 그대로 보여줌
       const { message: serverMessage } = extractApiError(error);
       show({
@@ -3625,9 +3601,14 @@ const FloorPlansDetailPage = () => {
     );
   };
 
-  // 드래그 중 미리보기용 — API 호출은 드래그가 끝났을 때(handleStructureNodeMoveEnd)만
+  // 드래그 중 미리보기용 — API 호출은 드래그가 끝났을 때(handleStructureNodeMoveEnd)만.
+  // 픽셀 좌표를 그래프 캐시의 비율 좌표로 바로 바꿔 써서, structureNodes 동기화 effect가
+  // canvasH로 다시 픽셀 변환해 그대로 반영함
   const handleStructureNodeMove = (id: string, x: number, y: number) => {
-    setStructureNodes((prev) => prev.map((n) => (n.id === id ? { ...n, x, y } : n)));
+    updateGraphCache((prev) => ({
+      ...prev,
+      nodes: prev.nodes.map((n) => (n.id === id ? { ...n, x: x / CANVAS_W, y: y / canvasH } : n)),
+    }));
   };
 
   const handleStructureNodeMoveEnd = (id: string, x: number, y: number) => {
@@ -3640,11 +3621,11 @@ const FloorPlansDetailPage = () => {
   const handleStructureNodeDelete = (id: string) => {
     deleteMapNode(id)
       .then(() => {
-        setStructureNodes((prev) => prev.filter((n) => n.id !== id));
-        // 서버는 이 노드에 붙은 엣지까지 cascade 삭제하므로 로컬 엣지도 같이 정리
-        setGraphEdges((prev) =>
-          prev.filter((edge) => edge.fromNodeId !== id && edge.toNodeId !== id),
-        );
+        // 서버는 이 노드에 붙은 엣지까지 cascade 삭제하므로 로컬 캐시의 엣지도 같이 정리
+        updateGraphCache((prev) => ({
+          nodes: prev.nodes.filter((n) => n.id !== id),
+          edges: prev.edges.filter((edge) => edge.fromNodeId !== id && edge.toNodeId !== id),
+        }));
         setEditingStructureId((prev) => (prev === id ? null : prev));
       })
       .catch((error: unknown) => {
@@ -3780,7 +3761,7 @@ const FloorPlansDetailPage = () => {
         }
       });
       if (succeeded.length > 0) {
-        setGraphEdges((prev) => [...prev, ...succeeded]);
+        updateGraphCache((prev) => ({ ...prev, edges: [...prev.edges, ...succeeded] }));
         show({ title: `${succeeded.length}개 구간이 연결되었습니다.`, variant: 'success' });
       }
       if (failedLabels.length > 0) {
@@ -3804,7 +3785,7 @@ const FloorPlansDetailPage = () => {
   const handleEdgeDelete = (edgeId: string) => {
     deleteMapEdge(edgeId)
       .then(() => {
-        setGraphEdges((prev) => prev.filter((e) => e.id !== edgeId));
+        updateGraphCache((prev) => ({ ...prev, edges: prev.edges.filter((e) => e.id !== edgeId) }));
         setSelectedEdgeId((prev) => (prev === edgeId ? null : prev));
       })
       .catch(() => {});

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   floorQueryKeys,
   useBuildingFloorsQuery,
   useFloorCctvsQuery,
+  useFloorGridCellsQuery,
   useFloorLightsQuery,
 } from '@apis/floors/floorQueries';
 
@@ -340,6 +341,7 @@ const DEFAULT_CANVAS_H = 420;
 // 새 배열을 만들면 그 값을 의존성으로 쓰는 effect가 로딩 중에 계속 재실행돼버림
 const EMPTY_CCTVS: Cctv[] = [];
 const EMPTY_LIGHTS: IoTLight[] = [];
+const EMPTY_GRID_CELLS: FloorGridCell[] = [];
 
 // AI 분석이 DONE으로 바뀐 직후엔 노드가 아직 생성 중일 수 있어 그래프가 비어 올 수 있음 — 재조회 설정
 const GRAPH_RETRY_LIMIT = 5;
@@ -2547,7 +2549,7 @@ const FloorPlansDetailPage = () => {
   const [floor, setFloor] = useState<Floor | null>(null);
   const [loadingFloor, setLoadingFloor] = useState(false);
   const [resolvedMapImageUrl, setResolvedMapImageUrl] = useState<string | null>(null);
-  const [floorGridCells, setFloorGridCells] = useState<FloorGridCell[]>([]);
+  const { data: floorGridCells = EMPTY_GRID_CELLS } = useFloorGridCellsQuery(floorId);
   // 도면 이미지의 원본 가로/세로 비율 — viewBox 높이(canvasH)를 여기에 맞춰 이미지 왜곡을 없앰
   const [imageAspect, setImageAspect] = useState<number | null>(null);
 
@@ -2598,7 +2600,6 @@ const FloorPlansDetailPage = () => {
     // id가 겹칠 때 엉뚱한 위치가 그대로 보일 수 있음
     setDevicePositions({});
     setZones([]);
-    setFloorGridCells([]);
     setSelectedItem(null);
     setSelectedZoneRef(null);
     setSelectedEdgeId(null);
@@ -2689,16 +2690,6 @@ const FloorPlansDetailPage = () => {
     };
   }, [resolvedMapImageUrl]);
 
-  // 그리드는 더 이상 토글로 켜야만 보이는 게 아니라 항상 표시함 — 층이 준비되면 바로
-  // 조회해둠(floorGridCells가 비어있을 때만 실제로 요청함, ensureFloorGridCells 내부 참고)
-  useEffect(() => {
-    if (!isFloorReady) return;
-    void ensureFloorGridCells();
-    // ensureFloorGridCells는 매 렌더 새로 만들어지는 함수라 의존성에 넣으면 무한 재실행됨.
-    // floorId/isFloorReady가 바뀔 때만 재조회하면 됨
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [floorId, isFloorReady]);
-
   // 업로드 시 정한 그리드 배율이 AI 분석 과정에서 사라질 수 있어, 분석 완료(DONE) 후
   // sessionStorage에 남겨둔 값으로 PUT /grid를 한 번 더 호출해 배율을 확정함
   useEffect(() => {
@@ -2710,7 +2701,7 @@ const FloorPlansDetailPage = () => {
       .then(() => getFloorGridCells(floorId))
       .then((cells) => {
         if (cancelled) return;
-        setFloorGridCells(cells);
+        queryClient.setQueryData(floorQueryKeys.grid(floorId), cells);
         rememberGridSize(floorId, cellSizeMeter);
         show({
           title: `그리드 배율(${cellSizeMeter}m)이 자동 적용되었습니다.`,
@@ -2731,7 +2722,7 @@ const FloorPlansDetailPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [floorId, isFloorReady, show]);
+  }, [floorId, isFloorReady, show, queryClient]);
 
   // canvasH(그리드/이미지 로드가 끝나야 확정)는 구조 노드의 비율 좌표를 픽셀로 바꾸는 데만
   // 쓰이고 그래프 데이터 자체와는 무관한데, 예전엔 이 값이 fetch effect의 의존성에 들어있어서
@@ -2867,22 +2858,6 @@ const FloorPlansDetailPage = () => {
       .catch(() => {});
     return () => {
       cancelled = true;
-    };
-  }, [floorId]);
-
-  // 층 그리드 셀 조회 — CCTV 시야구역 선택에 사용.
-  // 층을 빠르게 옮기거나 화면을 벗어나면(언마운트) 응답을 무시하는 것뿐 아니라 실제로 요청도
-  // 중단해야, 배율이 작아 페이지가 많은 층에서 안 쓸 응답까지 끝까지 받아오는 낭비가 없음
-  useEffect(() => {
-    if (!floorId) return;
-    const controller = new AbortController();
-    getFloorGridCells(floorId, controller.signal)
-      .then((cells) => {
-        setFloorGridCells(cells);
-      })
-      .catch(() => {});
-    return () => {
-      controller.abort();
     };
   }, [floorId]);
 
@@ -3195,7 +3170,10 @@ const FloorPlansDetailPage = () => {
         rememberPendingGridSize(newFloor.id, params.cellSizeMeter);
         try {
           await setFloorGrid(newFloor.id, params.cellSizeMeter);
-          setFloorGridCells(await getFloorGridCells(newFloor.id));
+          queryClient.setQueryData(
+            floorQueryKeys.grid(newFloor.id),
+            await getFloorGridCells(newFloor.id),
+          );
         } catch {
           show({
             title: '그리드 설정에 실패했습니다. 분석 완료 후 자동으로 다시 시도합니다.',
@@ -3345,7 +3323,7 @@ const FloorPlansDetailPage = () => {
     if (!currentFloor) return Promise.resolve([]);
     return getFloorGridCells(currentFloor.id)
       .then((cells) => {
-        setFloorGridCells(cells);
+        queryClient.setQueryData(floorQueryKeys.grid(currentFloor.id), cells);
         return cells;
       })
       .catch(() => []);
@@ -3406,7 +3384,7 @@ const FloorPlansDetailPage = () => {
         setFloorGrid(floorIdForGrid, knownSize)
           .then(() => getFloorGridCells(floorIdForGrid))
           .then((refreshed) => {
-            setFloorGridCells(refreshed);
+            queryClient.setQueryData(floorQueryKeys.grid(floorIdForGrid), refreshed);
             rememberGridSize(floorIdForGrid, knownSize);
             setNodeAddStage('fov');
           })
@@ -3452,7 +3430,7 @@ const FloorPlansDetailPage = () => {
     setFloorGrid(floorIdForGrid, cellSizeMeter)
       .then(() => getFloorGridCells(floorIdForGrid))
       .then((cells) => {
-        setFloorGridCells(cells);
+        queryClient.setQueryData(floorQueryKeys.grid(floorIdForGrid), cells);
         rememberGridSize(floorIdForGrid, cellSizeMeter);
         setGridSetupPromptOpen(false);
         if (gridSetupIntent === 'cctv') {
@@ -3556,7 +3534,7 @@ const FloorPlansDetailPage = () => {
           setFloorGrid(currentFloor.id, knownSize)
             .then(() => getFloorGridCells(currentFloor.id))
             .then((refreshed) => {
-              setFloorGridCells(refreshed);
+              queryClient.setQueryData(floorQueryKeys.grid(currentFloor.id), refreshed);
               // gridCellPxSize는 재적용 전 floorGridCells 기준으로 계산된 memo라 그대로 쓰면
               // 안 됨 — 재생성된 그리드는 행·열 수가 달라질 수 있어(코드래빗 리뷰로 발견),
               // 새로 조회한 refreshed 기준으로 다시 계산해서 넘김

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2781,14 +2781,17 @@ const FloorPlansDetailPage = () => {
     [userZones],
   );
 
-  const [selectedBuildingId] = useState(buildingId ?? '');
+  // 라우트 파라미터를 그대로 씀 — useState로 복제해두면 뒤로가기/외부 링크처럼 handleFloorChange를
+  // 거치지 않고 URL만 바뀌는 경우 값이 낡아, 실제 조회(floorId 기반 쿼리)와 currentFloor 메타데이터가
+  // 서로 다른 층을 가리키게 됨
+  const selectedBuildingId = buildingId ?? '';
+  const selectedFloorId = floorId ?? '';
   // 이 화면엔 건물 하나(이름)와 그 건물의 층 목록만 필요한데, 예전엔 getFloorBuildings()가
   // 전체 건물 목록 + 건물마다 층 목록을 다 조회했음(건물 N개면 요청 N+1개, 건물이 늘수록
   // 이 화면이 계속 느려지는 구조였음) — 건물 이름은 이미 캐시돼 있을 가능성이 높은 건물
   // 목록 조회 1번, 층 목록은 이 건물 것만 조회 1번으로 나눔
   const { data: buildingsForName } = useGetBuildingsQuery();
   const { data: buildingFloors } = useBuildingFloorsQuery(selectedBuildingId);
-  const [selectedFloorId, setSelectedFloorId] = useState(floorId ?? '');
   const [zoom, setZoom] = useState(100);
   const [selectedItem, setSelectedItem] = useState<SelectedItem | null>(null);
   const [selectedZoneRef, setSelectedZoneRef] = useState<ZoneRefSelection | null>(null);
@@ -2921,6 +2924,39 @@ const FloorPlansDetailPage = () => {
     queryClient.setQueryData<IoTLight[]>(floorQueryKeys.light(floorId), (prev) =>
       prev?.map((l) => (l.id === updated.id ? updated : l)),
     );
+  };
+
+  // configureLightGuidance와 assignLightCctv는 같은 IoTLight를 건드리는데, 각자 응답으로
+  // patchLightCache를 부르면 나중에 도착한 응답이 다른 mutation의 변경분을 덮어쓸 수 있음
+  // (코드래빗 리뷰). 둘을 병렬로 보내되 에러만 각자 알리고, 모두 끝난 뒤 캐시를 한 번
+  // 무효화해서 서버 기준 최신 상태로 맞춤
+  const runLightFollowups = async (
+    lightId: string,
+    opts: {
+      guidance?: { decisionNodeId: string; leftEdgeId: string; rightEdgeId: string };
+      cctvId?: string;
+    },
+  ) => {
+    const tasks: Promise<unknown>[] = [];
+    if (opts.guidance) {
+      tasks.push(
+        configureLightGuidance(lightId, opts.guidance).catch((error: unknown) => {
+          const { message } = extractApiError(error);
+          show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
+        }),
+      );
+    }
+    if (opts.cctvId) {
+      tasks.push(
+        assignLightCctv(lightId, opts.cctvId).catch((error: unknown) => {
+          const { message } = extractApiError(error);
+          show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
+        }),
+      );
+    }
+    if (tasks.length === 0) return;
+    await Promise.allSettled(tasks);
+    void queryClient.invalidateQueries({ queryKey: floorQueryKeys.light(floorId) });
   };
 
   // zones(위 useMemo)도 useFloorUserZonesQuery 캐시에서 파생된 값이라 로컬 setState 대신
@@ -3067,7 +3103,7 @@ const FloorPlansDetailPage = () => {
   const currentFloor = currentBuilding?.floors.find((f) => f.id === selectedFloorId) ?? null;
 
   const handleFloorChange = (newId: string) => {
-    setSelectedFloorId(newId);
+    // selectedFloorId는 아래 navigate로 URL이 바뀌면 useParams를 통해 자동으로 갱신됨
     setSelectedItem(null);
     setDeleteConfirmTarget(null);
     setNodeAddOpen(false);
@@ -3220,22 +3256,13 @@ const FloorPlansDetailPage = () => {
             // 때만 등록 직후 이어서 저장함 — 등록 시점에 판단 노드·엣지가 아직 없으면
             // 비워둔 채로 넘어가고 나중에 카드에서 채워도 됨
             const { decisionNodeId, leftEdgeId, rightEdgeId, cctvId } = lightFields;
-            if (decisionNodeId && leftEdgeId && rightEdgeId) {
-              configureLightGuidance(newLight.id, { decisionNodeId, leftEdgeId, rightEdgeId })
-                .then(patchLightCache)
-                .catch((error: unknown) => {
-                  const { message } = extractApiError(error);
-                  show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
-                });
-            }
-            if (cctvId) {
-              assignLightCctv(newLight.id, cctvId)
-                .then(patchLightCache)
-                .catch((error: unknown) => {
-                  const { message } = extractApiError(error);
-                  show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
-                });
-            }
+            void runLightFollowups(newLight.id, {
+              guidance:
+                decisionNodeId && leftEdgeId && rightEdgeId
+                  ? { decisionNodeId, leftEdgeId, rightEdgeId }
+                  : undefined,
+              cctvId: cctvId || undefined,
+            });
           })
           .catch(() => {
             show({ title: '유도등 등록에 실패했습니다. 다시 시도해주세요.', variant: 'error' });
@@ -3615,6 +3642,10 @@ const FloorPlansDetailPage = () => {
     updateMapNodePosition(id, { x: x / CANVAS_W, y: y / canvasH }).catch((error: unknown) => {
       const { message } = extractApiError(error);
       show({ title: message || '위치 저장에 실패했습니다.', variant: 'error' });
+      // 드래그 미리보기가 캐시에 이미 새 좌표를 써둔 상태 — 저장이 실패했는데 그래프가 비어있지
+      // 않으면 폴링도 멈춰서, 그대로 두면 저장 안 된 좌표가 화면·엣지 거리 계산에 계속 쓰임.
+      // 서버 기준으로 다시 받아와 되돌림
+      void queryClient.invalidateQueries({ queryKey: floorQueryKeys.graph(floorId) });
     });
   };
 
@@ -4524,23 +4555,14 @@ const FloorPlansDetailPage = () => {
           decisionNodeId !== (prevLight?.decisionNodeId ?? '') ||
           leftEdgeId !== (prevLight?.leftEdgeId ?? '') ||
           rightEdgeId !== (prevLight?.rightEdgeId ?? '');
-        if (decisionNodeId && leftEdgeId && rightEdgeId && guidanceChanged) {
-          configureLightGuidance(item.id, { decisionNodeId, leftEdgeId, rightEdgeId })
-            .then(patchLightCache)
-            .catch((error: unknown) => {
-              const { message } = extractApiError(error);
-              show({ title: message || '경로 저장에 실패했습니다.', variant: 'error' });
-            });
-        }
-
-        if (editForm.cctvId && editForm.cctvId !== (prevLight?.cctvId ?? '')) {
-          assignLightCctv(item.id, editForm.cctvId)
-            .then(patchLightCache)
-            .catch((error: unknown) => {
-              const { message } = extractApiError(error);
-              show({ title: message || '담당 CCTV 배정에 실패했습니다.', variant: 'error' });
-            });
-        }
+        const cctvChanged = !!editForm.cctvId && editForm.cctvId !== (prevLight?.cctvId ?? '');
+        void runLightFollowups(item.id, {
+          guidance:
+            decisionNodeId && leftEdgeId && rightEdgeId && guidanceChanged
+              ? { decisionNodeId, leftEdgeId, rightEdgeId }
+              : undefined,
+          cctvId: cctvChanged ? editForm.cctvId : undefined,
+        });
       } else if (item.type === 'cctv' && prevDevice) {
         updateCctv(item.id, { name: newLabel, x: finalX / 100, y: finalY / 100 })
           .then(patchCctvCache)

--- a/src/pages/floorPlans/api/floorPlansApi.ts
+++ b/src/pages/floorPlans/api/floorPlansApi.ts
@@ -2,10 +2,7 @@ import type { FloorResponse } from '@apis/__generated__/data-contracts';
 import { getBuildings } from '@apis/buildings/buildingsApi';
 import { request as apiRequest, HTTP_METHOD } from '@apis/config/request';
 import { API_ENDPOINTS } from '@apis/constants/endpoints';
-import {
-  getBuildingFloors as getSharedBuildingFloors,
-  getFloorImageUrl,
-} from '@apis/floors/floorsApi';
+import { getBuildingFloors as getSharedBuildingFloors } from '@apis/floors/floorsApi';
 
 import type { Floor, FloorBuilding } from '../types/floorPlans';
 
@@ -42,10 +39,15 @@ export async function getBuildingFloors(buildingId: string): Promise<Floor[]> {
   return floors.map((f) => toFloor(f, buildingId));
 }
 
-export async function getFloorDetail(buildingId: string, floorId: string): Promise<Floor> {
+export async function getFloorDetail(
+  buildingId: string,
+  floorId: string,
+  signal?: AbortSignal,
+): Promise<Floor> {
   const floor = await apiRequest<FloorResponse>({
     method: HTTP_METHOD.GET,
     url: API_ENDPOINTS.FLOORS.DETAIL(buildingId, floorId),
+    signal,
   });
   return toFloor(floor, buildingId);
 }
@@ -112,5 +114,3 @@ export async function analyzeFloor(floorId: string): Promise<void> {
     timeout: ANALYZE_TIMEOUT_MS,
   });
 }
-
-export { getFloorImageUrl };

--- a/src/pages/floorPlans/api/userZoneApi.ts
+++ b/src/pages/floorPlans/api/userZoneApi.ts
@@ -1,68 +1,11 @@
-import type {
-  AllUserZoneResponse,
-  CellResponse,
-  UserZoneCellsResponse,
-  UserZoneCreateRequest,
-  UserZoneResponse,
-} from '@apis/__generated__/data-contracts';
+import type { UserZoneCreateRequest, UserZoneResponse } from '@apis/__generated__/data-contracts';
 import { request as apiRequest, HTTP_METHOD } from '@apis/config/request';
 import { API_ENDPOINTS } from '@apis/constants/endpoints';
+import { toUserZone } from '@apis/floors/userZoneApi';
+import type { UserZone } from '@apis/floors/userZoneApi';
 
-export interface UserZone {
-  id: string;
-  name: string;
-  floorNum: number;
-}
-
-export interface UserZoneCellRef {
-  cellId: string;
-  rowIndex: number;
-  columnIndex: number;
-}
-
-export interface UserZoneDetail extends UserZone {
-  cells: UserZoneCellRef[];
-}
-
-const toUserZone = (response: UserZoneResponse): UserZone => {
-  const { userZoneId, userZoneName, floorNum } = response;
-  if (!userZoneId || !userZoneName || floorNum === undefined) {
-    throw new Error('사용자 지정 영역 응답에 필수 필드가 누락되었습니다.');
-  }
-  return { id: userZoneId, name: userZoneName, floorNum };
-};
-
-const toUserZoneCellRef = (response: CellResponse): UserZoneCellRef => {
-  const { cellId, rowIndex, columnIndex } = response;
-  if (!cellId || rowIndex === undefined || columnIndex === undefined) {
-    throw new Error('사용자 지정 영역 셀 응답에 필수 필드가 누락되었습니다.');
-  }
-  return { cellId, rowIndex, columnIndex };
-};
-
-export async function getFloorUserZones(floorId: string): Promise<UserZone[]> {
-  const response = await apiRequest<AllUserZoneResponse>({
-    method: HTTP_METHOD.GET,
-    url: API_ENDPOINTS.USER_ZONES.ROOT(floorId),
-  });
-  return (response.userzones ?? []).map(toUserZone);
-}
-
-// 목록 조회(getFloorUserZones)는 이름만 내려주고 셀 정보가 없어서, 실제로 그려주려면 구역마다 상세를 따로 조회해야 함
-export async function getUserZoneDetail(
-  floorId: string,
-  userZoneId: string,
-): Promise<UserZoneDetail> {
-  const response = await apiRequest<UserZoneCellsResponse>({
-    method: HTTP_METHOD.GET,
-    url: API_ENDPOINTS.USER_ZONES.DETAIL(floorId, userZoneId),
-  });
-  if (!response.response) {
-    throw new Error('사용자 지정 영역 상세 응답에 필수 필드가 누락되었습니다.');
-  }
-  const zone = toUserZone(response.response);
-  return { ...zone, cells: (response.cells ?? []).map(toUserZoneCellRef) };
-}
+export { getFloorUserZones, getUserZoneDetail } from '@apis/floors/userZoneApi';
+export type { UserZone, UserZoneCellRef, UserZoneDetail } from '@apis/floors/userZoneApi';
 
 export async function createUserZone(
   floorId: string,

--- a/src/shared/apis/floors/floorQueries.ts
+++ b/src/shared/apis/floors/floorQueries.ts
@@ -13,6 +13,9 @@ export const floorQueryKeys = {
   all: ['floors'] as const,
   lists: () => [...floorQueryKeys.all, 'list'] as const,
   list: (buildingId?: string) => [...floorQueryKeys.lists(), buildingId] as const,
+  details: () => [...floorQueryKeys.all, 'detail'] as const,
+  detail: (buildingId?: string, floorId?: string) =>
+    [...floorQueryKeys.details(), buildingId, floorId] as const,
   images: () => [...floorQueryKeys.all, 'image'] as const,
   image: (buildingId?: string, floorId?: string) =>
     [...floorQueryKeys.images(), buildingId, floorId] as const,

--- a/src/shared/apis/floors/floorQueries.ts
+++ b/src/shared/apis/floors/floorQueries.ts
@@ -5,6 +5,9 @@ import { getFloorGridCells } from './floorGridApi';
 import { getBuildingFloors, getFloorImageUrl } from './floorsApi';
 import { getFloorLights } from './iotLightsApi';
 import { getFloorGraph } from './mapGraphApi';
+import { getFloorUserZones, getUserZoneDetail } from './userZoneApi';
+
+import type { UserZone } from './userZoneApi';
 
 export const floorQueryKeys = {
   all: ['floors'] as const,
@@ -21,7 +24,14 @@ export const floorQueryKeys = {
   cctv: (floorId?: string) => [...floorQueryKeys.cctvs(), floorId] as const,
   lights: () => [...floorQueryKeys.all, 'light'] as const,
   light: (floorId?: string) => [...floorQueryKeys.lights(), floorId] as const,
+  zones: () => [...floorQueryKeys.all, 'zone'] as const,
+  zone: (floorId?: string) => [...floorQueryKeys.zones(), floorId] as const,
 };
+
+// 목록 API가 이름만 내려줘서, 화면에 그리려면 구역마다 셀 상세를 따로 조회해 합쳐야 함
+export interface UserZoneWithCells extends UserZone {
+  cellIds: string[];
+}
 
 export const buildingFloorsQueryOptions = (buildingId?: string) =>
   queryOptions({
@@ -83,6 +93,24 @@ export const floorLightsQueryOptions = (floorId?: string) =>
     },
   });
 
+export const floorUserZonesQueryOptions = (floorId?: string) =>
+  queryOptions({
+    queryKey: floorQueryKeys.zone(floorId),
+    queryFn: async ({ signal }): Promise<UserZoneWithCells[]> => {
+      if (!floorId) throw new Error('사용자 지정 영역 조회 조건이 필요합니다.');
+      const zoneList = await getFloorUserZones(floorId, signal);
+      const details = await Promise.all(
+        zoneList.map((zone) => getUserZoneDetail(floorId, zone.id, signal)),
+      );
+      return details.map((d) => ({
+        id: d.id,
+        name: d.name,
+        floorNum: d.floorNum,
+        cellIds: d.cells.map((c) => c.cellId),
+      }));
+    },
+  });
+
 export const useFloorGraphQuery = (floorId?: string, enabled = true) =>
   useQuery({
     ...floorGraphQueryOptions(floorId),
@@ -110,5 +138,11 @@ export const useFloorCctvsQuery = (floorId?: string, enabled = true) =>
 export const useFloorLightsQuery = (floorId?: string, enabled = true) =>
   useQuery({
     ...floorLightsQueryOptions(floorId),
+    enabled: enabled && Boolean(floorId),
+  });
+
+export const useFloorUserZonesQuery = (floorId?: string, enabled = true) =>
+  useQuery({
+    ...floorUserZonesQueryOptions(floorId),
     enabled: enabled && Boolean(floorId),
   });

--- a/src/shared/apis/floors/userZoneApi.ts
+++ b/src/shared/apis/floors/userZoneApi.ts
@@ -1,0 +1,70 @@
+import type {
+  AllUserZoneResponse,
+  CellResponse,
+  UserZoneCellsResponse,
+  UserZoneResponse,
+} from '@apis/__generated__/data-contracts';
+import { HTTP_METHOD, request } from '@apis/config/request';
+import { API_ENDPOINTS } from '@apis/constants/endpoints';
+
+export interface UserZone {
+  id: string;
+  name: string;
+  floorNum: number;
+}
+
+export interface UserZoneCellRef {
+  cellId: string;
+  rowIndex: number;
+  columnIndex: number;
+}
+
+export interface UserZoneDetail extends UserZone {
+  cells: UserZoneCellRef[];
+}
+
+export const toUserZone = (response: UserZoneResponse): UserZone => {
+  const { userZoneId, userZoneName, floorNum } = response;
+  if (!userZoneId || !userZoneName || floorNum === undefined) {
+    throw new Error('사용자 지정 영역 응답에 필수 필드가 누락되었습니다.');
+  }
+  return { id: userZoneId, name: userZoneName, floorNum };
+};
+
+const toUserZoneCellRef = (response: CellResponse): UserZoneCellRef => {
+  const { cellId, rowIndex, columnIndex } = response;
+  if (!cellId || rowIndex === undefined || columnIndex === undefined) {
+    throw new Error('사용자 지정 영역 셀 응답에 필수 필드가 누락되었습니다.');
+  }
+  return { cellId, rowIndex, columnIndex };
+};
+
+export const getFloorUserZones = async (
+  floorId: string,
+  signal?: AbortSignal,
+): Promise<UserZone[]> => {
+  const response = await request<AllUserZoneResponse>({
+    method: HTTP_METHOD.GET,
+    url: API_ENDPOINTS.USER_ZONES.ROOT(floorId),
+    signal,
+  });
+  return (response.userzones ?? []).map(toUserZone);
+};
+
+// 목록 조회(getFloorUserZones)는 이름만 내려주고 셀 정보가 없어서, 실제로 그려주려면 구역마다 상세를 따로 조회해야 함
+export const getUserZoneDetail = async (
+  floorId: string,
+  userZoneId: string,
+  signal?: AbortSignal,
+): Promise<UserZoneDetail> => {
+  const response = await request<UserZoneCellsResponse>({
+    method: HTTP_METHOD.GET,
+    url: API_ENDPOINTS.USER_ZONES.DETAIL(floorId, userZoneId),
+    signal,
+  });
+  if (!response.response) {
+    throw new Error('사용자 지정 영역 상세 응답에 필수 필드가 누락되었습니다.');
+  }
+  const zone = toUserZone(response.response);
+  return { ...zone, cells: (response.cells ?? []).map(toUserZoneCellRef) };
+};


### PR DESCRIPTION
## 📌 Summary

도면 관리 상세 페이지(`FloorPlansDetailPage`)의 데이터 조회를 순수 `useEffect` 기반에서 react-query 기반으로 전환. 무거운 층에서 로딩이 매우 느려지던 문제의 근본 원인(과다 조회 + 중복 조회)을 제거함.

## 🔗 관련 이슈

closes #94

## 📋 작업 내용

### 🔴 뭐가 문제였는지

1. **층 목록 사이드바가 항상 전체 건물을 과다 조회함** — 현재 건물 하나만 필요한데 `getFloorBuildings()`가 전체 건물 목록 + 건물마다 층 목록을 다 가져옴. 건물이 늘수록 이 페이지가 계속 느려지는 구조였음.
2. **맵그래프 재조회 버그** — 노드/엣지 조회 `useEffect`가 `canvasH`(그리드 로딩이 끝나야 확정되는 값)에 의존하고 있어서, 그리드가 로드되며 값이 바뀔 때마다 서버에서 노드·엣지를 통째로 재조회함(좌표를 픽셀로 바꾸는 데만 필요한 값인데 그래프 데이터 자체와는 무관).
3. **StrictMode(dev) 이중 호출이 그대로 노출됨** — 그래프/그리드셀/CCTV/유도등/사용자 지정 영역/층 상세/이미지 URL, 총 7개 리소스가 react-query 없이 순수 `useEffect` + 직접 API 호출로 짜여 있어서, 캐시가 없어 React StrictMode의 의도적 이중 실행이 그대로 네트워크 요청 두 배로 이어짐.
4. **무거운 층에서 위 문제가 겹쳐 유독 심함** — 그리드 셀이 6,000개 이상(페이지네이션 2~3페이지)인 층은 위 중복 조회가 겹쳐 로딩이 매우 오래 걸렸고, 최대 12,000개 셀을 반복 렌더링하며 메인 스레드를 점유해 다른 클릭이 안 먹히는 것처럼 보이는 증상까지 있었음.

### 🟢 얼마만큼 개선됐는지

| 리소스 | 이전 | 이후 |
|---|---|---|
| 건물/층 목록 | 건물 N개 기준 요청 N+1개 (예: 6개 → 7개) | 항상 2개 (건물 이름 1 + 이 건물 층 목록 1) — **6개 건물 기준 약 71% 감소** |
| 맵그래프(`/graph`) | `canvasH` 확정 전후로 최대 3회 추가 재조회 | 0회 (캐시된 원본으로 픽셀만 재계산) |
| 그리드 셀 / CCTV / 유도등 / 사용자 지정 영역 / 층 상세 / 이미지 URL / 맵그래프 | 리소스당 페이지 로드마다 2회(StrictMode 이중 호출) | 리소스당 정확히 **1회**  |

→ 그리드 6,000셀 이상인 무거운 층 기준으로 최초 로드 시 API 요청 수가 이전 대비 절반 이하로 줄었고, 그만큼 중복 응답을 처리·렌더링하던 메인 스레드 점유도 같이 줄어듦.


### 장점
- react-query 캐시가 StrictMode 이중 호출을 자동으로 dedupe해서, 리소스마다 직접 짜던 `AbortController` + `cancelled` 플래그 보일러플레이트가 전부 제거됨 → 앞으로 이 페이지에 리소스를 추가해도 같은 버그가 구조적으로 재발하지 않음
- 낙관적 업데이트가 `queryClient.setQueryData` 기반으로 8개 리소스에 걸쳐 통일된 패턴이 됨(patchCctvCache, updateZonesCache, updateFloorCache, updateGraphCache)
- 층 분석 상태 폴링·그래프 재시도 폴링이 `refetchInterval`로 표준화돼 수동 `setInterval`/`setTimeout` 관리 코드가 사라짐
- 층 전환 시 로컬 state를 일일이 비우던 `resetFloorScopedState`가 훨씬 단순해짐(쿼리 키가 리소스별 캐시를 알아서 분리)


### 🎯 영향 범위

- **`FloorPlansDetailPage.tsx` 내부 구현만 변경** — 공용 훅 레이어(`floorQueries.ts`)는 기존 훅 시그니처를 그대로 두고 새 훅(`useFloorUserZonesQuery`, `floorQueryKeys.detail`)만 추가함
- 같은 공용 훅(`useFloorGraphQuery` 등)을 이미 쓰고 있는 다른 화면 — 시나리오 설정(`useScenarioFloorView.ts`), 도면관리 목록의 `useFloorReadinessQuery` — 에는 **영향 없음**(사용 중인 훅 자체를 안 건드림)
- `api/floorPlansApi.ts`, `api/userZoneApi.ts`의 일부 export가 바뀜(`getFloorImageUrl` 제거, `getFloorDetail`에 `signal` 파라미터 추가) — grep으로 확인한 결과 이 두 파일을 이 페이지 밖에서 쓰는 곳은 도면관리 목록 페이지(`FloorPlansPage.tsx`)뿐이고, 거기서 쓰는 함수(`analyzeFloor`, `getFloorBuildings`, `uploadFloor`)는 이번에 손대지 않아 영향 없음

## 🔍 To Reviewer


## 📸 스크린샷

UI 변경 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
