### PR TITLE
[fix] 보고서 가중치 및 필드 이름 변경

### DIFF
--- a/src/pages/reports/utils/report.ts
+++ b/src/pages/reports/utils/report.ts
@@ -52,8 +52,8 @@ export const toReportSummary = (report: ReportResponse): ReportSummary => ({
 
 export const toReportScores = (report: ReportResponse): ReportScoreItem[] =>
   [
-    toScoreItem('대피 완료율', '30%', report.survivalRate, 'success'),
-    toScoreItem('평균 대피 시간', '25%', report.evacuationScore, 'primary'),
+    toScoreItem('생존율', '30%', report.survivalRate, 'success'),
+    toScoreItem('평균 대피 시간', '35%', report.evacuationScore, 'primary'),
     toScoreItem('병목 회피율', '20%', report.bottleneckScore, 'primary'),
     toScoreItem('경로 이탈률', '15%', report.deviationScore, 'primary'),
   ].filter(isNotNull);


### PR DESCRIPTION
## 📌 Summary
보고서 페이지의 평가 항목별 점수의 가중치와 항목 이름 변경합니다.

## 🔗 관련 이슈

closes #101

## 📋 작업 내용

- 대피 완료율 → 생존율
  - 가중치 30으로 변경

- 평균 대피 시간 가중치 35로 변경

## 🔍 To Reviewer

<!-- 리뷰어에게 요청하는 내용 -->

## 📸 스크린샷

<!-- UI 변경 시 첨부 -->

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
