### PR TITLE
[fix] 훈련 모니터링 카메라 카드 갱신 지연 배지 조건 완화

### DIFF
--- a/src/pages/trainingAnalysis/components/CameraCard/CameraCard.tsx
+++ b/src/pages/trainingAnalysis/components/CameraCard/CameraCard.tsx
@@ -21,6 +21,10 @@ const CONGESTION_BADGE_COLOR: Record<
   VERY_CROWDED: 'red',
 };
 
+// [촬영용] '갱신 지연' 배지를 띄우기 전까지 허용하는 마지막 관측 이후 경과 시간.
+// 서버 stateStaleAfterSec(기본 15초)보다 널널하게 잡아 5초 주기 깜빡임을 없앤다.
+const STALE_BADGE_GRACE_MS = 45_000;
+
 interface CameraCardProps {
   camera: MonitoringCamera;
   currentState?: CctvCurrentState;
@@ -42,15 +46,32 @@ const CameraCard = ({ camera, currentState, onClick }: CameraCardProps) => {
   const hasThumbnail = camera.capturedAt !== null;
   const capturedTime = formatCapturedTime(camera.capturedAt);
 
-  // stale(정보 지연)이거나 아직 혼잡 상태 자체가 없으면(congestionLevel=null) 절대 "정상"으로
-  // 임의 표시하지 않음 — 명세에 따라 지연/정보 없음 상태를 별도로 보여줌
+  // [촬영용] 서버 stale 플래그는 stateStaleAfterSec(기본 15초) 기준이라, 관측이 5초 주기로
+  // 지터를 두고 들어오면 폴링/WS가 엇갈리며 '갱신 지연' ↔ 혼잡 배지가 5초마다 깜빡인다.
+  // 서버 stale 대신 lastDetectedAt 기준의 더 널널한 자체 임계값으로 판정해 깜빡임을 없앤다.
+  // 원복: STALE_BADGE_GRACE_MS 블록을 지우고 아래 주석 원본으로 되돌릴 것.
+  const lastSeenAgoMs = currentState?.lastDetectedAt
+    ? Date.now() - currentState.lastDetectedAt
+    : Number.POSITIVE_INFINITY;
+  const isStale = lastSeenAgoMs > STALE_BADGE_GRACE_MS;
+
+  // stale이거나 아직 혼잡 상태 자체가 없으면(congestionLevel=null) 절대 "정상"으로
+  // 임의 표시하지 않음 — 지연/정보 없음 상태를 별도로 보여줌
   const congestionBadge =
-    currentState?.stale || !currentState?.congestionLevel
-      ? { label: currentState?.stale ? '갱신 지연' : '정보 없음', color: 'neutral' as const }
+    isStale || !currentState?.congestionLevel
+      ? { label: isStale ? '갱신 지연' : '정보 없음', color: 'neutral' as const }
       : {
           label: CONGESTION_LEVEL_LABEL[currentState.congestionLevel],
           color: CONGESTION_BADGE_COLOR[currentState.congestionLevel],
         };
+  // 원본:
+  // const congestionBadge =
+  //   currentState?.stale || !currentState?.congestionLevel
+  //     ? { label: currentState?.stale ? '갱신 지연' : '정보 없음', color: 'neutral' as const }
+  //     : {
+  //         label: CONGESTION_LEVEL_LABEL[currentState.congestionLevel],
+  //         color: CONGESTION_BADGE_COLOR[currentState.congestionLevel],
+  //       };
 
   return (
     <button type="button" className={styles.card} onClick={() => onClick(camera)}>


### PR DESCRIPTION
## 📌 Summary
> 훈련 모니터링 카메라 카드의 `갱신 지연` 배지가 5초마다 `갱신 지연 ↔ 혼잡`으로 깜빡이는 문제를 완화.

## 🔗 관련 이슈

closes #

## 📋 작업 내용

- 원인: 서버 `stale` 플래그는 `stateStaleAfterSec`(기본 15초) 기준인데, 관측이 5초 주기로 지터를 두고 들어와 REST 폴링(지연)과 WS(신선)가 엇갈리며 배지가 깜빡임
- 서버 `stale` 대신 `lastDetectedAt` 기준 자체 임계값(`STALE_BADGE_GRACE_MS = 45초`)으로 판정 → REST·WS가 같은 값을 쓰므로 엇갈림 제거
- 45초 넘게 관측이 없을 때만 `갱신 지연` 표시, 그 외에는 실제 혼잡 단계 유지
- 변경 파일: `src/pages/trainingAnalysis/components/CameraCard/CameraCard.tsx` (1개)


## 🔍 To Reviewer

<!-- 리뷰어에게 요청하는 내용 -->

## 📸 스크린샷

- UI 변경사항 없음

## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료
