### PR TITLE
[fix] 도면 그리드 배율 단위를 cm로 변경 (재작성)

### DIFF
--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -2711,7 +2711,7 @@ const FloorPlansDetailPage = () => {
         if (cancelled) return;
         queryClient.setQueryData(floorQueryKeys.grid(floorId), await getFloorGridCells(floorId));
         rememberGridSize(floorId, pending);
-        show({ title: `그리드 배율(${pending}m)이 자동 적용되었습니다.`, variant: 'success' });
+        show({ title: `그리드 배율(${pending}cm)이 자동 적용되었습니다.`, variant: 'success' });
       } catch (error) {
         if (cancelled) return;
         if (import.meta.env.DEV) console.warn('[그리드 배율 자동 적용 건너뜀]', error);
@@ -2959,7 +2959,7 @@ const FloorPlansDetailPage = () => {
   // 확인 버튼을 눌렀을 때 어느 쪽으로 돌아가야 하는지 구분하기 위한 값
   const [gridSetupPromptOpen, setGridSetupPromptOpen] = useState(false);
   const [gridSetupIntent, setGridSetupIntent] = useState<'cctv' | 'zone' | null>(null);
-  const [gridSizeMeterInput, setGridSizeMeterInput] = useState('1');
+  const [gridSizeCmInput, setGridSizeCmInput] = useState('100');
   const [cctvDraftCellIds, setCctvDraftCellIds] = useState<string[]>([]);
   const [zoneDraftCellIds, setZoneDraftCellIds] = useState<string[]>([]);
   const [zoneDeleteTarget, setZoneDeleteTarget] = useState<ZoneEntry | null>(null);
@@ -3194,7 +3194,7 @@ const FloorPlansDetailPage = () => {
   const handleUploadDimensionsConfirm = (params: {
     realWidth: number;
     realHeight: number;
-    cellSizeMeter: number;
+    cellSizeCm: number;
   }) => {
     if (!currentFloor || !pendingUpload || isReuploading) return;
     const { file, previewUrl } = pendingUpload;
@@ -3211,9 +3211,9 @@ const FloorPlansDetailPage = () => {
         // 화면에서 먼저 비우고, AI 재분석이 끝나면 각 조회 effect가 새 데이터로 채운다
         resetFloorScopedState();
         // 초기 업로드 경로와 동일하게, AI 분석이 배율을 지우더라도 복원할 수 있도록 먼저 기록해둠
-        rememberPendingGridSize(newFloor.id, params.cellSizeMeter);
+        rememberPendingGridSize(newFloor.id, params.cellSizeCm);
         try {
-          await setFloorGrid(newFloor.id, params.cellSizeMeter);
+          await setFloorGrid(newFloor.id, params.cellSizeCm);
           queryClient.setQueryData(
             floorQueryKeys.grid(newFloor.id),
             await getFloorGridCells(newFloor.id),
@@ -3383,7 +3383,7 @@ const FloorPlansDetailPage = () => {
       ? (readStoredNumber(GRID_SIZE_KEY(currentFloor.id)) ??
         readStoredNumber(PENDING_GRID_SIZE_KEY(currentFloor.id)))
       : null;
-    setGridSizeMeterInput(String(remembered ?? 1));
+    setGridSizeCmInput(String(remembered ?? 100));
     setGridSetupPromptOpen(true);
   };
 
@@ -3471,14 +3471,14 @@ const FloorPlansDetailPage = () => {
 
   const handleGridSetupPromptConfirm = () => {
     if (!currentFloor) return;
-    const cellSizeMeter = Number(gridSizeMeterInput);
-    if (!(cellSizeMeter > 0)) return;
+    const cellSizeCm = Number(gridSizeCmInput);
+    if (!(cellSizeCm > 0 && cellSizeCm < 500)) return;
     const floorIdForGrid = currentFloor.id;
-    setFloorGrid(floorIdForGrid, cellSizeMeter)
+    setFloorGrid(floorIdForGrid, cellSizeCm)
       .then(() => getFloorGridCells(floorIdForGrid))
       .then((cells) => {
         queryClient.setQueryData(floorQueryKeys.grid(floorIdForGrid), cells);
-        rememberGridSize(floorIdForGrid, cellSizeMeter);
+        rememberGridSize(floorIdForGrid, cellSizeCm);
         setGridSetupPromptOpen(false);
         if (gridSetupIntent === 'cctv') {
           setNodeAddStage('fov');
@@ -3571,7 +3571,7 @@ const FloorPlansDetailPage = () => {
             openGridSetupPrompt('cctv');
             show({
               title:
-                '이 층의 그리드 배율(m)을 먼저 설정해야 합니다. 설정 후 감시 구역을 다시 드래그해주세요.',
+                '이 층의 그리드 배율(cm)을 먼저 설정해야 합니다. 설정 후 감시 구역을 다시 드래그해주세요.',
               variant: 'warning',
               duration: 7000,
             });
@@ -3596,7 +3596,7 @@ const FloorPlansDetailPage = () => {
               if (retryCellIds.length === 0) {
                 setCctvDraftCellIds([]);
                 show({
-                  title: `그리드 배율(${knownSize}m)을 다시 적용했습니다. 감시 구역을 다시 드래그해주세요.`,
+                  title: `그리드 배율(${knownSize}cm)을 다시 적용했습니다. 감시 구역을 다시 드래그해주세요.`,
                   variant: 'warning',
                   duration: 7000,
                 });
@@ -3613,7 +3613,7 @@ const FloorPlansDetailPage = () => {
                 .catch(() => {
                   setCctvDraftCellIds([]);
                   show({
-                    title: `그리드 배율(${knownSize}m)을 다시 적용했습니다. 감시 구역을 다시 드래그해주세요.`,
+                    title: `그리드 배율(${knownSize}cm)을 다시 적용했습니다. 감시 구역을 다시 드래그해주세요.`,
                     variant: 'warning',
                     duration: 7000,
                   });
@@ -3834,18 +3834,18 @@ const FloorPlansDetailPage = () => {
     setEdgeAddOpen(false);
   };
 
-  // 두 노드 사이 거리(m) 추정 — 정규화 좌표(0~1) 차이를 칸 수로 환산한 뒤 그리드 배율(m/칸)을
-  // 곱한다. 배율(GRID_SIZE_KEY→PENDING→등록된 CCTV 순으로 탐색)이나 그리드 정보가 없으면 null이라
+  // 두 노드 사이 거리(m) 추정 — 정규화 좌표(0~1) 차이를 칸 수로 환산한 뒤 그리드 배율(cm/칸)을
+  // 곱하고 m로 변환한다. 배율(GRID_SIZE_KEY→PENDING→등록된 CCTV 순으로 탐색)이나 그리드 정보가 없으면 null이라
   // 검토 화면에서 그 구간만 수동 입력으로 폴백한다.
   const estimateEdgeDistanceM = (fromId: string, toId: string): number | null => {
     if (!currentFloor) return null;
-    const cellSizeMeter =
+    const cellSizeCm =
       readStoredNumber(GRID_SIZE_KEY(currentFloor.id)) ??
       readStoredNumber(PENDING_GRID_SIZE_KEY(currentFloor.id)) ??
       realCctvs.find((c) => c.floorId === currentFloor.id && c.gridCellSizeMeter)
         ?.gridCellSizeMeter ??
       null;
-    if (!cellSizeMeter) return null;
+    if (!cellSizeCm) return null;
     const { cols, rows } = getGridDimensions(floorGridCells);
     if (!cols || !rows) return null;
     const normalizedPos = (id: string): { x: number; y: number } | null => {
@@ -3857,7 +3857,7 @@ const FloorPlansDetailPage = () => {
     const from = normalizedPos(fromId);
     const to = normalizedPos(toId);
     if (!from || !to) return null;
-    const meters = Math.hypot((from.x - to.x) * cols, (from.y - to.y) * rows) * cellSizeMeter;
+    const meters = (Math.hypot((from.x - to.x) * cols, (from.y - to.y) * rows) * cellSizeCm) / 100;
     return Math.max(0.1, Math.round(meters * 10) / 10);
   };
 
@@ -4897,18 +4897,16 @@ const FloorPlansDetailPage = () => {
                 <div className={styles.nodeAddField}>
                   <div className={styles.gridSizeLabelRow}>
                     <span className={styles.nodeAddLabel}>셀 크기</span>
-                    <span className={styles.gridSizeValue}>
-                      {Number(gridSizeMeterInput || 1).toFixed(1)}m
-                    </span>
+                    <span className={styles.gridSizeValue}>{Number(gridSizeCmInput || 1)}cm</span>
                   </div>
                   <input
                     type="range"
                     className={styles.gridSizeSlider}
-                    min={0.1}
-                    max={5}
-                    step={0.1}
-                    value={Number(gridSizeMeterInput || 1)}
-                    onChange={(e) => setGridSizeMeterInput(e.target.value)}
+                    min={1}
+                    max={499}
+                    step={1}
+                    value={Number(gridSizeCmInput || 1)}
+                    onChange={(e) => setGridSizeCmInput(e.target.value)}
                   />
                 </div>
                 <div className={styles.nodeAddActions}>
@@ -4922,7 +4920,7 @@ const FloorPlansDetailPage = () => {
                   <button
                     type="button"
                     className={styles.nodeAddSubmitBtn}
-                    disabled={!(Number(gridSizeMeterInput) > 0)}
+                    disabled={!(Number(gridSizeCmInput) > 0 && Number(gridSizeCmInput) < 500)}
                     onClick={handleGridSetupPromptConfirm}
                   >
                     설정

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -3192,8 +3192,8 @@ const FloorPlansDetailPage = () => {
   };
 
   const handleUploadDimensionsConfirm = (params: {
-    realWidth: number;
-    realHeight: number;
+    realWidthCm: number;
+    realHeightCm: number;
     cellSizeCm: number;
   }) => {
     if (!currentFloor || !pendingUpload || isReuploading) return;
@@ -3203,8 +3203,8 @@ const FloorPlansDetailPage = () => {
       selectedBuildingId,
       currentFloor.floorNum,
       file,
-      params.realWidth,
-      params.realHeight,
+      params.realWidthCm,
+      params.realHeightCm,
     )
       .then(async (newFloor) => {
         // 도면이 바뀌면 이전 도면 기준으로 만들어진 노드·엣지·장비·구역은 더 이상 유효하지 않으므로

--- a/src/pages/floorPlans/FloorPlansDetailPage.tsx
+++ b/src/pages/floorPlans/FloorPlansDetailPage.tsx
@@ -4902,6 +4902,7 @@ const FloorPlansDetailPage = () => {
                   <input
                     type="range"
                     className={styles.gridSizeSlider}
+                    aria-label="그리드 셀 크기(cm)"
                     min={1}
                     max={499}
                     step={1}

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -263,7 +263,7 @@ const FloorPlansPage = () => {
   const handleUploadDimensionsConfirm = (params: {
     realWidth: number;
     realHeight: number;
-    cellSizeMeter: number;
+    cellSizeCm: number;
   }) => {
     if (!pendingUpload || isUploading) return;
     const { buildingId, buildingName, floorNum, file, previewUrl } = pendingUpload;
@@ -274,10 +274,10 @@ const FloorPlansPage = () => {
         // cellSizeMeter가 사라지는 경우가 있음. 그래서 값을 남겨두고(새로고침에도 살아남음)
         // 상세 화면에서 분석 완료 후 한 번 더 PUT 하게 함 — pending으로 남기고 값 자체도
         // 기억해둬서 이후 CCTV 등록 때 사용자에게 다시 묻지 않게 함
-        rememberPendingGridSize(newFloor.id, params.cellSizeMeter);
+        rememberPendingGridSize(newFloor.id, params.cellSizeCm);
         // 상세 화면의 1회성 그리드 조회가 빈 결과를 캐싱하지 않도록, 이동 전에 한 번은 설정 시도
         try {
-          await setFloorGrid(newFloor.id, params.cellSizeMeter);
+          await setFloorGrid(newFloor.id, params.cellSizeCm);
         } catch {
           show({
             title: '그리드 설정에 실패했습니다. 분석 완료 후 자동으로 다시 시도합니다.',

--- a/src/pages/floorPlans/FloorPlansPage.tsx
+++ b/src/pages/floorPlans/FloorPlansPage.tsx
@@ -261,14 +261,14 @@ const FloorPlansPage = () => {
   };
 
   const handleUploadDimensionsConfirm = (params: {
-    realWidth: number;
-    realHeight: number;
+    realWidthCm: number;
+    realHeightCm: number;
     cellSizeCm: number;
   }) => {
     if (!pendingUpload || isUploading) return;
     const { buildingId, buildingName, floorNum, file, previewUrl } = pendingUpload;
     setIsUploading(true);
-    uploadFloor(buildingId, floorNum, file, params.realWidth, params.realHeight)
+    uploadFloor(buildingId, floorNum, file, params.realWidthCm, params.realHeightCm)
       .then(async (newFloor) => {
         // 그리드 배율을 지금 설정해도, 뒤이어 실행되는 AI 분석이 그리드 셀을 재생성하면서
         // cellSizeMeter가 사라지는 경우가 있음. 그래서 값을 남겨두고(새로고침에도 살아남음)

--- a/src/pages/floorPlans/api/floorGridApi.ts
+++ b/src/pages/floorPlans/api/floorGridApi.ts
@@ -16,7 +16,7 @@ export interface FloorGrid {
 export { getFloorGridCells } from '@apis/floors/floorGridApi';
 export type { FloorGridCell } from '@apis/floors/floorGridApi';
 
-// 서버에 저장된 현재 그리드 배율(m). 별도 GET /grid가 없어서, 셀 목록 응답에 함께 실려 오는
+// 서버에 저장된 현재 그리드 배율(cm). 별도 GET /grid가 없어서, 셀 목록 응답에 함께 실려 오는
 // cellSizeMeter를 최소 payload(size=1)로 읽어온다. 값이 없으면(미설정/분석이 지움) null.
 export async function getFloorGridScale(
   floorId: string,
@@ -34,18 +34,18 @@ export async function getFloorGridScale(
 // 그리드 배율 설정(생성/수정 겸용). 요청이 200으로 돌아왔다면 서버에는 이미 반영된 것이므로,
 // 응답 바디에 일부 필드가 없더라도 실패로 취급하지 않는다 — 예전에는 여기서 throw해서
 // 성공한 설정을 실패로 만들고 뒤따르는 셀 재조회까지 건너뛰는 문제가 있었음
-export async function setFloorGrid(floorId: string, cellSizeMeter: number): Promise<FloorGrid> {
+export async function setFloorGrid(floorId: string, cellSizeCm: number): Promise<FloorGrid> {
   const grid = await apiRequest<FloorGridResponse, CreateOrUpdateFloorGridRequest>({
     method: HTTP_METHOD.PUT,
     url: API_ENDPOINTS.FLOOR_GRID.ROOT(floorId),
-    body: { cellSizeMeter },
+    body: { cellSizeMeter: cellSizeCm },
   });
   if (import.meta.env.DEV) {
     console.warn('[그리드 배율 설정] 응답:', grid);
   }
   return {
     floorId: grid?.floorId ?? floorId,
-    cellSizeMeter: grid?.cellSizeMeter ?? cellSizeMeter,
+    cellSizeMeter: grid?.cellSizeMeter ?? cellSizeCm,
     rows: grid?.rows ?? 0,
     columns: grid?.columns ?? 0,
   };

--- a/src/pages/floorPlans/api/floorPlansApi.ts
+++ b/src/pages/floorPlans/api/floorPlansApi.ts
@@ -79,13 +79,13 @@ export async function uploadFloor(
   buildingId: string,
   floorNum: number,
   file: File,
-  realWidth: number,
-  realHeight: number,
+  realWidthCm: number,
+  realHeightCm: number,
 ): Promise<Floor> {
   const form = new FormData();
   form.append('floorNum', String(floorNum));
-  form.append('realWidth', String(realWidth));
-  form.append('realHeight', String(realHeight));
+  form.append('realWidth', String(realWidthCm));
+  form.append('realHeight', String(realHeightCm));
   form.append('file', file);
   const floor = await apiRequest<FloorResponse, FormData>({
     method: HTTP_METHOD.POST,

--- a/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
+++ b/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
@@ -26,6 +26,8 @@ const GridAreaSettingModal = ({
   const widthInputId = useId();
   const heightInputId = useId();
   const cellSizeInputId = useId();
+  const realWidthCmValue = Number(realWidthCm);
+  const realHeightCmValue = Number(realHeightCm);
 
   const makeDimensionChangeHandler =
     (setter: (v: string) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -42,14 +44,19 @@ const GridAreaSettingModal = ({
   };
 
   const isDimensionsValid =
-    Number(realWidthCm) > 0 && Number(realHeightCm) > 0 && cellSizeCm > 0 && cellSizeCm < 500;
+    Number.isFinite(realWidthCmValue) &&
+    realWidthCmValue > 0 &&
+    Number.isFinite(realHeightCmValue) &&
+    realHeightCmValue > 0 &&
+    cellSizeCm > 0 &&
+    cellSizeCm < 500;
 
   const handleSubmit = () => {
     if (!isDimensionsValid || isSubmitting) return;
     // 요청이 실패해도 모달이 닫히지 않을 수 있으므로(부모가 open을 유지) 값은 리셋하지 않고 재시도할 수 있게 둠
     onConfirm({
-      realWidthCm: Number(realWidthCm),
-      realHeightCm: Number(realHeightCm),
+      realWidthCm: realWidthCmValue,
+      realHeightCm: realHeightCmValue,
       cellSizeCm,
     });
   };

--- a/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
+++ b/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
@@ -9,7 +9,7 @@ interface GridAreaSettingModalProps {
   open: boolean;
   onClose: () => void;
   mapImageUrl: string | null;
-  onConfirm: (params: { realWidth: number; realHeight: number; cellSizeMeter: number }) => void;
+  onConfirm: (params: { realWidth: number; realHeight: number; cellSizeCm: number }) => void;
   isSubmitting?: boolean;
 }
 
@@ -50,7 +50,7 @@ const GridAreaSettingModal = ({
     onConfirm({
       realWidth: Number(realWidth),
       realHeight: Number(realHeight),
-      cellSizeMeter: cellSizeCm / 100,
+      cellSizeCm,
     });
   };
 

--- a/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
+++ b/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
@@ -22,7 +22,7 @@ const GridAreaSettingModal = ({
 }: GridAreaSettingModalProps) => {
   const [realWidth, setRealWidth] = useState('');
   const [realHeight, setRealHeight] = useState('');
-  const [cellSizeMeter, setCellSizeMeter] = useState(1);
+  const [cellSizeCm, setCellSizeCm] = useState(100);
   const widthInputId = useId();
   const heightInputId = useId();
   const cellSizeInputId = useId();
@@ -37,11 +37,12 @@ const GridAreaSettingModal = ({
   const handleClose = () => {
     setRealWidth('');
     setRealHeight('');
-    setCellSizeMeter(1);
+    setCellSizeCm(100);
     onClose();
   };
 
-  const isDimensionsValid = Number(realWidth) > 0 && Number(realHeight) > 0 && cellSizeMeter > 0;
+  const isDimensionsValid =
+    Number(realWidth) > 0 && Number(realHeight) > 0 && cellSizeCm > 0 && cellSizeCm < 500;
 
   const handleSubmit = () => {
     if (!isDimensionsValid || isSubmitting) return;
@@ -49,12 +50,12 @@ const GridAreaSettingModal = ({
     onConfirm({
       realWidth: Number(realWidth),
       realHeight: Number(realHeight),
-      cellSizeMeter,
+      cellSizeMeter: cellSizeCm / 100,
     });
   };
 
   // 실제 축척과 무관한 미리보기 전용 근사치 — 정확한 격자는 업로드 후 실제 캔버스에서 확인 가능
-  const cellSize = Math.max(6, Math.min(120, cellSizeMeter * 20));
+  const cellSize = Math.max(6, Math.min(120, cellSizeCm / 5));
 
   return (
     <Modal
@@ -148,17 +149,17 @@ const GridAreaSettingModal = ({
             <label className={styles.fieldLabel} htmlFor={cellSizeInputId}>
               그리드 셀 크기
             </label>
-            <span className={styles.scaleValue}>{cellSizeMeter.toFixed(1)}m</span>
+            <span className={styles.scaleValue}>{cellSizeCm}cm</span>
           </div>
           <input
             id={cellSizeInputId}
             type="range"
             className={styles.scaleSlider}
-            min={0.1}
-            max={5}
-            step={0.1}
-            value={cellSizeMeter}
-            onChange={(e) => setCellSizeMeter(Number(e.target.value))}
+            min={1}
+            max={499}
+            step={1}
+            value={cellSizeCm}
+            onChange={(e) => setCellSizeCm(Number(e.target.value))}
           />
         </div>
       </div>

--- a/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
+++ b/src/pages/floorPlans/modals/GridAreaSettingModal.tsx
@@ -9,7 +9,7 @@ interface GridAreaSettingModalProps {
   open: boolean;
   onClose: () => void;
   mapImageUrl: string | null;
-  onConfirm: (params: { realWidth: number; realHeight: number; cellSizeCm: number }) => void;
+  onConfirm: (params: { realWidthCm: number; realHeightCm: number; cellSizeCm: number }) => void;
   isSubmitting?: boolean;
 }
 
@@ -20,8 +20,8 @@ const GridAreaSettingModal = ({
   onConfirm,
   isSubmitting = false,
 }: GridAreaSettingModalProps) => {
-  const [realWidth, setRealWidth] = useState('');
-  const [realHeight, setRealHeight] = useState('');
+  const [realWidthCm, setRealWidthCm] = useState('');
+  const [realHeightCm, setRealHeightCm] = useState('');
   const [cellSizeCm, setCellSizeCm] = useState(100);
   const widthInputId = useId();
   const heightInputId = useId();
@@ -35,21 +35,21 @@ const GridAreaSettingModal = ({
     };
 
   const handleClose = () => {
-    setRealWidth('');
-    setRealHeight('');
+    setRealWidthCm('');
+    setRealHeightCm('');
     setCellSizeCm(100);
     onClose();
   };
 
   const isDimensionsValid =
-    Number(realWidth) > 0 && Number(realHeight) > 0 && cellSizeCm > 0 && cellSizeCm < 500;
+    Number(realWidthCm) > 0 && Number(realHeightCm) > 0 && cellSizeCm > 0 && cellSizeCm < 500;
 
   const handleSubmit = () => {
     if (!isDimensionsValid || isSubmitting) return;
     // 요청이 실패해도 모달이 닫히지 않을 수 있으므로(부모가 open을 유지) 값은 리셋하지 않고 재시도할 수 있게 둠
     onConfirm({
-      realWidth: Number(realWidth),
-      realHeight: Number(realHeight),
+      realWidthCm: Number(realWidthCm),
+      realHeightCm: Number(realHeightCm),
       cellSizeCm,
     });
   };
@@ -107,7 +107,7 @@ const GridAreaSettingModal = ({
         <div className={styles.dimensionFields}>
           <div className={styles.areaField}>
             <label className={styles.fieldLabel} htmlFor={widthInputId}>
-              가로 (m)
+              가로 (cm)
             </label>
             <div className={styles.areaInputShell}>
               <input
@@ -115,17 +115,17 @@ const GridAreaSettingModal = ({
                 className={styles.areaInput}
                 type="text"
                 inputMode="decimal"
-                placeholder="20"
-                value={realWidth}
-                onChange={makeDimensionChangeHandler(setRealWidth)}
+                placeholder="2000"
+                value={realWidthCm}
+                onChange={makeDimensionChangeHandler(setRealWidthCm)}
               />
-              <span className={styles.areaUnit}>m</span>
+              <span className={styles.areaUnit}>cm</span>
             </div>
           </div>
 
           <div className={styles.areaField}>
             <label className={styles.fieldLabel} htmlFor={heightInputId}>
-              세로 (m)
+              세로 (cm)
             </label>
             <div className={styles.areaInputShell}>
               <input
@@ -133,11 +133,11 @@ const GridAreaSettingModal = ({
                 className={styles.areaInput}
                 type="text"
                 inputMode="decimal"
-                placeholder="15"
-                value={realHeight}
-                onChange={makeDimensionChangeHandler(setRealHeight)}
+                placeholder="1500"
+                value={realHeightCm}
+                onChange={makeDimensionChangeHandler(setRealHeightCm)}
               />
-              <span className={styles.areaUnit}>m</span>
+              <span className={styles.areaUnit}>cm</span>
             </div>
           </div>
         </div>

--- a/src/pages/floorPlans/utils/gridStorage.ts
+++ b/src/pages/floorPlans/utils/gridStorage.ts
@@ -15,9 +15,9 @@ export const readStoredNumber = (key: string): number | null => {
 };
 
 // 확정된 배율을 기록하고, 더는 필요 없는 pending 값은 지움
-export const rememberGridSize = (floorId: string, cellSizeMeter: number) => {
+export const rememberGridSize = (floorId: string, cellSizeCm: number) => {
   try {
-    localStorage.setItem(GRID_SIZE_KEY(floorId), String(cellSizeMeter));
+    localStorage.setItem(GRID_SIZE_KEY(floorId), String(cellSizeCm));
     localStorage.removeItem(PENDING_GRID_SIZE_KEY(floorId));
     sessionStorage.removeItem(PENDING_GRID_SIZE_KEY(floorId));
   } catch {
@@ -26,10 +26,10 @@ export const rememberGridSize = (floorId: string, cellSizeMeter: number) => {
 };
 
 // 업로드 직후 — AI 분석이 배율을 지우더라도 복원할 수 있도록 먼저 pending과 확정 값을 함께 기록
-export const rememberPendingGridSize = (floorId: string, cellSizeMeter: number) => {
+export const rememberPendingGridSize = (floorId: string, cellSizeCm: number) => {
   try {
-    localStorage.setItem(PENDING_GRID_SIZE_KEY(floorId), String(cellSizeMeter));
-    localStorage.setItem(GRID_SIZE_KEY(floorId), String(cellSizeMeter));
+    localStorage.setItem(PENDING_GRID_SIZE_KEY(floorId), String(cellSizeCm));
+    localStorage.setItem(GRID_SIZE_KEY(floorId), String(cellSizeCm));
   } catch {
     /* 스토리지 사용 불가 환경 — 기록만 생략 */
   }

--- a/src/pages/floorPlans/utils/gridStorage.ts
+++ b/src/pages/floorPlans/utils/gridStorage.ts
@@ -1,9 +1,11 @@
 // 백엔드에 "이 층의 배율" 조회 API가 없다(PUT /grid만 있고 GET /grid 없음).
 // 그래서 배율을 브라우저에 기록해뒀다가 필요할 때 되찾아 쓴다 — 도면 업로드(FloorPlansPage)와
 // 상세 화면(FloorPlansDetailPage) 양쪽에서 같은 키를 읽고 쓰므로 한 곳에 모아 export함.
-export const GRID_SIZE_KEY = (floorId: string) => `saferoute:gridCellSize:${floorId}`;
+// 기존 키에는 m 단위 값이 저장돼 있으므로 cm 값을 같은 키에 덮어쓰지 않는다.
+// 단위가 명시된 새 키를 사용해 기존 값이 100분의 1 크기로 오해되는 것을 방지한다.
+export const GRID_SIZE_KEY = (floorId: string) => `saferoute:gridCellSizeCm:${floorId}`;
 export const PENDING_GRID_SIZE_KEY = (floorId: string) =>
-  `saferoute:pendingGridCellSize:${floorId}`;
+  `saferoute:pendingGridCellSizeCm:${floorId}`;
 
 export const readStoredNumber = (key: string): number | null => {
   try {

--- a/src/shared/apis/floors/cctvApi.ts
+++ b/src/shared/apis/floors/cctvApi.ts
@@ -19,7 +19,7 @@ export interface Cctv {
   x: number;
   y: number;
   enabled: boolean;
-  /** 이 CCTV가 등록될 때 층에 설정돼 있던 그리드 배율(m). 층 배율 조회 API가 없어서 이 값으로 역추적함 */
+  /** 이 CCTV가 등록될 때 층에 설정돼 있던 그리드 배율(cm). 층 배율 조회 API가 없어서 이 값으로 역추적함 */
   gridCellSizeMeter: number | null;
   monitoredGridCellCount: number;
   monitoredAreaM2: number;


### PR DESCRIPTION
## 📌 Summary

도면 업로드 후 그리드 배율 설정 시 셀 크기를 cm 단위로 입력할 수 있도록 변경했습니다.

## 🔗 관련 이슈

closes #109

## 📋 작업 내용

- 그리드 셀 크기 표시 단위를 `m`에서 `cm`로 변경
  - 슬라이더 범위를 `1~499cm`, 조절 단위를 `1cm`로 변경
  - 기본 셀 크기를 `100cm`로 변경
  - `0cm 초과, 500cm 미만` 유효성 검사 적용
- 도면 사이즈 (가로, 세로) 단위도 `m`에서 `cm`로 변경

## 🔍 To Reviewer
- API 타입은 그대로 `cellSizeMeter`지만, 서버로 보내야하는 값은 `cm`라고 해서 API 요청시에도 `cm`를 사용합니다.

## 📸 스크린샷
<img width="930" height="710" alt="image" src="https://github.com/user-attachments/assets/018def89-56f2-4be7-99c9-bba40e543e34" />


## ✅ 체크리스트

- [x] 셀프 코드리뷰 완료
- [x] 컨벤션 준수
- [x] `pnpm build` 정상 완료